### PR TITLE
feat: add Gemini OAuth support (registry-driven)

### DIFF
--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -54,8 +54,14 @@ export interface AgentRegistryEntry {
   /** Environment variable name for API key */
   apiKeyEnv: string;
 
-  /** Environment variable name for OAuth token (Claude only - Max subscription) */
+  /** Environment variable name for OAuth (file path or token depending on agent) */
   oauthEnv?: string;
+
+  /** OAuth credentials filename (e.g., "auth.json" for Codex, "oauth_creds.json" for Gemini) */
+  oauthFileName?: string;
+
+  /** Environment variable to set when OAuth is active (e.g., GOOGLE_GENAI_USE_GCA=true for Gemini) */
+  oauthActivationEnv?: { key: string; value: string };
 
   /** Environment variable name for base URL */
   baseUrlEnv: string;
@@ -136,6 +142,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     image: "evolve-all",
     apiKeyEnv: "OPENAI_API_KEY",
     oauthEnv: "CODEX_OAUTH_FILE_PATH",
+    oauthFileName: "auth.json",
     baseUrlEnv: "OPENAI_BASE_URL",
     defaultModel: "gpt-5.2",
     models: [
@@ -165,6 +172,9 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
   gemini: {
     image: "evolve-all",
     apiKeyEnv: "GEMINI_API_KEY",
+    oauthEnv: "GEMINI_OAUTH_FILE_PATH",
+    oauthFileName: "oauth_creds.json",
+    oauthActivationEnv: { key: "GOOGLE_GENAI_USE_GCA", value: "true" },
     baseUrlEnv: "GOOGLE_GEMINI_BASE_URL",
     defaultModel: "gemini-3-flash-preview",
     models: [

--- a/packages/sdk-ts/src/utils/config.ts
+++ b/packages/sdk-ts/src/utils/config.ts
@@ -77,12 +77,12 @@ export function resolveAgentConfig(config?: AgentConfig): ResolvedAgentConfig {
   if (registry.oauthEnv) {
     const oauthValue = process.env[registry.oauthEnv];
     if (oauthValue) {
-      if (type === "codex") {
-        // Codex: env var is file path, read content
+      if (registry.oauthFileName) {
+        // File-based OAuth (Codex, Gemini): env var is file path, read content
         const oauthFileContent = readOAuthFile(oauthValue);
         return { type, apiKey: "__oauth_file__", isDirectMode: true, isOAuth: true, oauthFileContent, model: config?.model, reasoningEffort: config?.reasoningEffort, betas: config?.betas };
       }
-      // Claude: env var is token itself
+      // Token-based OAuth (Claude): env var is token itself
       return { type, apiKey: oauthValue, isDirectMode: true, isOAuth: true, model: config?.model, reasoningEffort: config?.reasoningEffort, betas: config?.betas };
     }
   }
@@ -92,7 +92,7 @@ export function resolveAgentConfig(config?: AgentConfig): ResolvedAgentConfig {
   // ─────────────────────────────────────────────────────────────────────────
 
   const oauthHint = registry.oauthEnv
-    ? `, oauthToken (Claude Max), or ${registry.oauthEnv}`
+    ? (registry.oauthFileName ? `, or ${registry.oauthEnv}` : `, oauthToken, or ${registry.oauthEnv}`)
     : "";
   throw new Error(
     `No API key found for ${type}. Set apiKey (gateway), providerApiKey (direct)${oauthHint}, ` +

--- a/packages/sdk-ts/tests/integration/19-gemini-oauth.ts
+++ b/packages/sdk-ts/tests/integration/19-gemini-oauth.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env tsx
+/**
+ * Integration Test 19: Gemini OAuth Mode
+ *
+ * Tests file-based OAuth for Gemini using GEMINI_OAUTH_FILE_PATH.
+ * Gemini requires both the oauth_creds.json file AND GOOGLE_GENAI_USE_GCA=true.
+ *
+ * Required env vars (in .env):
+ *   GEMINI_OAUTH_FILE_PATH - Path to ~/.gemini/oauth_creds.json
+ *   E2B_API_KEY - For E2B sandbox
+ *
+ * Usage:
+ *   npx tsx tests/integration/19-gemini-oauth.ts
+ */
+
+import { Evolve } from "../../dist/index.js";
+import { getSandboxProvider } from "./test-config.js";
+import { config } from "dotenv";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, "../../../../.env") });
+
+async function main() {
+  const oauthPath = process.env.GEMINI_OAUTH_FILE_PATH;
+  if (!oauthPath) {
+    console.log("GEMINI_OAUTH_FILE_PATH not set - skipping");
+    process.exit(0);
+  }
+
+  console.log("=".repeat(60));
+  console.log("Gemini OAuth Integration Test");
+  console.log("=".repeat(60));
+  console.log(`GEMINI_OAUTH_FILE_PATH: ${oauthPath}`);
+
+  const evolve = new Evolve()
+    .withAgent({ type: "gemini" })
+    .withSandbox(getSandboxProvider())
+    .withSystemPrompt("Be concise. One sentence max.");
+
+  try {
+    console.log("\n[gemini] Running OAuth test...");
+    const result = await evolve.run({
+      prompt: "Say hello and confirm you are working.",
+      timeoutMs: 120000,
+    });
+
+    console.log(`[gemini] Exit code: ${result.exitCode}`);
+    console.log(`[gemini] Stdout:\n${result.stdout}`);
+
+    if (result.exitCode === 0) {
+      console.log("\n✓ PASS - Gemini OAuth works!");
+    } else {
+      console.log("\n✗ FAIL - Non-zero exit code");
+      console.log("stderr:", result.stderr.slice(0, 500));
+    }
+
+    console.log(`\nSandbox ID: ${result.sandboxId}`);
+    console.log("(sandbox kept alive)");
+    process.exit(result.exitCode === 0 ? 0 : 1);
+  } catch (err) {
+    console.error("\n✗ FAIL -", err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
- Add oauthFileName and oauthActivationEnv to registry interface
- Gemini: oauth_creds.json + GOOGLE_GENAI_USE_GCA=true
- Codex: auth.json (no activation env needed)
- Claude: token-based OAuth (no file)
- Fix error message to be agent-appropriate