### PR TITLE
feat: add proper Kimi CLI and OpenCode support

### DIFF
--- a/packages/sdk-ts/src/mcp/index.ts
+++ b/packages/sdk-ts/src/mcp/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentType, SandboxInstance, McpServerConfig } from "../types";
-import { writeClaudeMcpConfig, writeGeminiMcpConfig, writeQwenMcpConfig } from "./json";
+import { writeClaudeMcpConfig, writeGeminiMcpConfig, writeQwenMcpConfig, writeKimiMcpConfig, writeOpenCodeMcpConfig } from "./json";
 import { writeCodexMcpConfig } from "./toml";
 
 /**
@@ -17,6 +17,7 @@ import { writeCodexMcpConfig } from "./toml";
  * - Codex: TOML to ~/.codex/config.toml
  * - Gemini: JSON to ~/.gemini/settings.json
  * - Qwen: JSON to ~/.qwen/settings.json
+ * - OpenCode: JSON to ${workingDir}/opencode.json (mcp key)
  */
 export async function writeMcpConfig(
   agentType: AgentType,
@@ -45,11 +46,19 @@ export async function writeMcpConfig(
       await writeQwenMcpConfig(sandbox, servers);
       break;
 
+    case "kimi":
+      await writeKimiMcpConfig(sandbox, servers);
+      break;
+
+    case "opencode":
+      await writeOpenCodeMcpConfig(sandbox, workingDir, servers);
+      break;
+
     default:
       throw new Error(`Unknown agent type for MCP config: ${agentType}`);
   }
 }
 
 // Re-export individual writers for direct use if needed
-export { writeClaudeMcpConfig, writeGeminiMcpConfig, writeQwenMcpConfig } from "./json";
+export { writeClaudeMcpConfig, writeGeminiMcpConfig, writeQwenMcpConfig, writeKimiMcpConfig, writeOpenCodeMcpConfig } from "./json";
 export { writeCodexMcpConfig } from "./toml";

--- a/packages/sdk-ts/src/parsers/index.ts
+++ b/packages/sdk-ts/src/parsers/index.ts
@@ -10,6 +10,8 @@ import type { OutputEvent } from "./types";
 import { createClaudeParser } from "./claude";
 import { createCodexParser } from "./codex";
 import { createGeminiParser } from "./gemini";
+import { createKimiParser } from "./kimi";
+import { createOpenCodeParser } from "./opencode";
 import { createQwenParser } from "./qwen";
 
 // Re-export types for convenience
@@ -38,6 +40,12 @@ export function createAgentParser(agentType: AgentType): AgentParser {
 
     case "qwen":
       return createQwenParser();
+
+    case "kimi":
+      return createKimiParser();
+
+    case "opencode":
+      return createOpenCodeParser();
 
     default:
       return () => null;
@@ -98,4 +106,6 @@ export function parseNdjsonOutput(
 export { createClaudeParser } from "./claude";
 export { createCodexParser } from "./codex";
 export { createGeminiParser } from "./gemini";
+export { createKimiParser } from "./kimi";
+export { createOpenCodeParser } from "./opencode";
 export { createQwenParser, parseQwenOutput } from "./qwen";

--- a/packages/sdk-ts/src/parsers/kimi.ts
+++ b/packages/sdk-ts/src/parsers/kimi.ts
@@ -1,0 +1,377 @@
+/**
+ * Kimi Wire Protocol → ACP-style events parser.
+ *
+ * Native schema: MoonshotAI/kimi-cli src/kimi_cli/wire/types.py
+ * Output mode: `kimi --print --output-format stream-json`
+ *
+ * Kimi Wire message envelope: { "type": "TypeName", "payload": { ... } }
+ *
+ * Wire event types (wire/types.py):
+ * - TurnBegin        → lifecycle (skip)
+ * - TurnEnd          → lifecycle (skip)
+ * - StepBegin        → lifecycle (skip)
+ * - StepInterrupted  → lifecycle (skip)
+ * - CompactionBegin  → lifecycle (skip)
+ * - CompactionEnd    → lifecycle (skip)
+ * - StatusUpdate     → lifecycle (skip)
+ * - TextPart         → agent_message_chunk
+ * - ThinkPart        → agent_thought_chunk
+ * - ToolCall         → tool_call (pending)
+ * - ToolCallPart     → accumulate partial tool call
+ * - ToolResult       → tool_call_update (completed/failed)
+ * - ApprovalRequest  → skip (YOLO mode auto-approves in print mode)
+ * - ApprovalResponse → skip
+ * - SubagentEvent    → recursively parse inner event
+ *
+ * ACP output: parsers/types.ts (OutputEvent, SessionUpdate)
+ */
+
+import {
+  OutputEvent,
+  SessionUpdate,
+  ToolKind,
+  ToolCallContent,
+  ToolCallLocation,
+} from "./types";
+
+/** Map Kimi tool names to ACP ToolKind */
+const TOOL_KINDS: Record<string, ToolKind> = {
+  // File operations
+  ReadFile: "read",
+  ReadManyFiles: "read",
+  WriteFile: "edit",
+  PatchFile: "edit",
+  // Shell
+  Exec: "execute",
+  // Search
+  Glob: "search",
+  Grep: "search",
+  ListDir: "search",
+  // Web
+  MoonshotSearch: "fetch",
+  MoonshotFetch: "fetch",
+  WebSearch: "fetch",
+  WebFetch: "fetch",
+  // Agent
+  Task: "think",
+  // Media
+  ReadMediaFile: "read",
+};
+
+/**
+ * Create a Kimi parser instance.
+ * Stateful to track partial ToolCallPart accumulation.
+ */
+export function createKimiParser() {
+  // Track accumulated ToolCallPart arguments by tool call id
+  const toolCallPartBuffers: Map<string, { name: string; args: string }> = new Map();
+
+  return function parseKimiEvent(jsonLine: string): OutputEvent[] | null {
+    let data: any;
+    try {
+      data = JSON.parse(jsonLine);
+    } catch {
+      return null;
+    }
+
+    if (!data || typeof data !== "object") return null;
+
+    // Skip metadata lines
+    if ("_meta" in data || "_prompt" in data) {
+      return null;
+    }
+
+    // Kimi Wire envelope: { type: string, payload: object }
+    const type = data.type as string;
+    const payload = data.payload ?? {};
+
+    const events: OutputEvent[] = [];
+
+    switch (type) {
+      // Lifecycle events - skip
+      case "TurnBegin":
+      case "TurnEnd":
+      case "StepBegin":
+      case "StepInterrupted":
+      case "CompactionBegin":
+      case "CompactionEnd":
+      case "StatusUpdate":
+      case "ApprovalRequest":
+      case "ApprovalResponse":
+        return null;
+
+      // Text content from agent
+      case "TextPart": {
+        const text = payload.text;
+        if (typeof text === "string" && text.length > 0) {
+          events.push({
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text },
+            },
+          });
+        }
+        break;
+      }
+
+      // Thinking/reasoning content
+      case "ThinkPart": {
+        const thinking = payload.thinking;
+        if (typeof thinking === "string" && thinking.length > 0) {
+          events.push({
+            update: {
+              sessionUpdate: "agent_thought_chunk",
+              content: { type: "text", text: thinking },
+            },
+          });
+        }
+        break;
+      }
+
+      // Complete tool call (kosong.message.ToolCall format)
+      // { id, function: { name, arguments } }
+      case "ToolCall": {
+        const toolId = payload.id;
+        const fn = payload.function;
+        if (!fn) break;
+
+        const toolName = fn.name ?? "";
+        let input: unknown;
+        try {
+          input = fn.arguments ? JSON.parse(fn.arguments) : {};
+        } catch {
+          input = fn.arguments;
+        }
+
+        const { title, kind, content, locations } = getToolInfo(
+          toolName,
+          (typeof input === "object" && input !== null ? input : {}) as Record<string, unknown>
+        );
+
+        events.push({
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: toolId,
+            title,
+            kind,
+            status: "pending",
+            rawInput: input,
+            content,
+            locations,
+          },
+        });
+        break;
+      }
+
+      // Partial tool call streaming (accumulate arguments)
+      case "ToolCallPart": {
+        const toolId = payload.id ?? payload.tool_call_id;
+        const fn = payload.function;
+        if (!toolId || !fn) break;
+
+        const existing = toolCallPartBuffers.get(toolId);
+        if (existing) {
+          if (fn.arguments) existing.args += fn.arguments;
+        } else {
+          toolCallPartBuffers.set(toolId, {
+            name: fn.name ?? "",
+            args: fn.arguments ?? "",
+          });
+        }
+        // Don't emit until ToolCall or ToolResult arrives
+        break;
+      }
+
+      // Tool result (kosong.tooling.ToolResult format)
+      // { tool_call_id, return_value: { type: "ToolOk"|"ToolError", output?, message?, display? } }
+      case "ToolResult": {
+        const toolId = payload.tool_call_id;
+        if (!toolId) break;
+
+        // Clean up partial buffer
+        toolCallPartBuffers.delete(toolId);
+
+        const returnValue = payload.return_value ?? payload.content;
+        const isError =
+          returnValue?.type === "ToolError" ||
+          payload.is_error === true;
+
+        const content: ToolCallContent[] = [];
+
+        // Extract output text
+        const outputText = returnValue?.output ?? returnValue?.message ?? "";
+        if (typeof outputText === "string" && outputText.length > 0) {
+          content.push({
+            type: "content",
+            content: {
+              type: "text",
+              text: isError ? `\`\`\`\n${outputText}\n\`\`\`` : outputText,
+            },
+          });
+        }
+
+        // Extract display blocks (brief, diff, shell, etc.)
+        if (Array.isArray(returnValue?.display)) {
+          for (const block of returnValue.display) {
+            if (block.type === "brief" && block.content) {
+              content.push({
+                type: "content",
+                content: { type: "text", text: block.content },
+              });
+            }
+          }
+        }
+
+        // Also handle array content format
+        if (Array.isArray(returnValue?.content)) {
+          for (const item of returnValue.content) {
+            if (item.type === "text" && item.text) {
+              content.push({
+                type: "content",
+                content: {
+                  type: "text",
+                  text: isError ? `\`\`\`\n${item.text}\n\`\`\`` : item.text,
+                },
+              });
+            }
+          }
+        }
+
+        events.push({
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: toolId,
+            status: isError ? "failed" : "completed",
+            content,
+          },
+        });
+        break;
+      }
+
+      // Subagent events - recursively parse the inner event
+      case "SubagentEvent": {
+        const innerEvent = payload.event;
+        if (!innerEvent || typeof innerEvent !== "object") break;
+
+        // Inner event is a WireMessageEnvelope { type, payload }
+        const innerLine = JSON.stringify(innerEvent);
+        const innerResults = parseKimiEvent(innerLine);
+        if (innerResults) {
+          events.push(...innerResults);
+        }
+        break;
+      }
+
+      default:
+        return null;
+    }
+
+    return events.length > 0 ? events : null;
+  };
+
+  /**
+   * Get tool info from tool name and input parameters.
+   */
+  function getToolInfo(
+    toolName: string,
+    input: Record<string, unknown>
+  ): {
+    title: string;
+    kind: ToolKind;
+    content: ToolCallContent[];
+    locations: ToolCallLocation[];
+  } {
+    const kind = TOOL_KINDS[toolName] || "other";
+    const content: ToolCallContent[] = [];
+    const locations: ToolCallLocation[] = [];
+
+    let title = toolName;
+
+    switch (toolName) {
+      case "ReadFile": {
+        const path = (input.path ?? input.file_path ?? input.absolute_path) as string | undefined;
+        title = `Read ${path || "file"}`;
+        if (path) locations.push({ path });
+        break;
+      }
+
+      case "ReadManyFiles": {
+        const paths = input.paths as string[] | undefined;
+        title = `Read ${paths?.length || "multiple"} files`;
+        if (Array.isArray(paths)) {
+          for (const p of paths) locations.push({ path: p });
+        }
+        break;
+      }
+
+      case "WriteFile": {
+        const path = (input.path ?? input.file_path) as string | undefined;
+        title = `Write ${path || "file"}`;
+        if (path) {
+          locations.push({ path });
+          if (typeof input.content === "string") {
+            content.push({
+              type: "diff",
+              path,
+              oldText: null,
+              newText: input.content as string,
+            });
+          }
+        }
+        break;
+      }
+
+      case "PatchFile": {
+        const path = (input.path ?? input.file_path) as string | undefined;
+        title = `Edit ${path || "file"}`;
+        if (path) locations.push({ path });
+        break;
+      }
+
+      case "Exec":
+        title = input.command ? `\`${input.command}\`` : "Run command";
+        break;
+
+      case "Glob":
+        title = `Find ${input.pattern || "files"}`;
+        if (input.path) locations.push({ path: input.path as string });
+        break;
+
+      case "Grep":
+        title = `grep "${input.pattern || ""}"`;
+        if (input.path) locations.push({ path: input.path as string });
+        break;
+
+      case "ListDir":
+        title = `List ${input.path || "directory"}`;
+        if (input.path) locations.push({ path: input.path as string });
+        break;
+
+      case "MoonshotSearch":
+      case "WebSearch":
+        title = input.query ? `"${input.query}"` : "Web search";
+        break;
+
+      case "MoonshotFetch":
+      case "WebFetch":
+        title = input.url ? `Fetch ${input.url}` : "Web fetch";
+        break;
+
+      case "Task":
+        title = (input.description as string) || "Subagent task";
+        break;
+
+      case "ReadMediaFile": {
+        const path = (input.path ?? input.file_path) as string | undefined;
+        title = `Read media ${path || "file"}`;
+        if (path) locations.push({ path });
+        break;
+      }
+
+      default:
+        title = toolName;
+    }
+
+    return { title, kind, content, locations };
+  }
+}

--- a/packages/sdk-ts/src/parsers/opencode.ts
+++ b/packages/sdk-ts/src/parsers/opencode.ts
@@ -1,0 +1,299 @@
+/**
+ * OpenCode JSONL → ACP-style events parser.
+ *
+ * Native format: `opencode run --format json` outputs JSONL to stdout.
+ * Each line is a JSON object with a `type` field.
+ *
+ * OpenCode event types:
+ * - "step_start"  → lifecycle (skip)
+ * - "text"        → agent_message_chunk
+ * - "tool_use"    → tool_call + tool_call_update (tools arrive completed)
+ * - "step_finish" → lifecycle (skip)
+ * - "error"       → agent_message_chunk (error text)
+ *
+ * Key difference: tool_use events arrive already completed (status="completed"),
+ * so we emit both tool_call (pending) and tool_call_update (completed/failed)
+ * from a single event.
+ *
+ * Reference: https://takopi.dev/reference/runners/opencode/stream-json-cheatsheet/
+ * ACP output: parsers/types.ts (OutputEvent, SessionUpdate)
+ */
+
+import {
+  OutputEvent,
+  SessionUpdate,
+  ToolKind,
+  ToolCallContent,
+  ToolCallLocation,
+} from "./types";
+
+/** Map OpenCode tool names to ACP ToolKind */
+const TOOL_KINDS: Record<string, ToolKind> = {
+  // File operations
+  read: "read",
+  write: "edit",
+  edit: "edit",
+  patch: "edit",
+  multiedit: "edit",
+  // Shell
+  bash: "execute",
+  // Search
+  glob: "search",
+  grep: "search",
+  list: "search",
+  codesearch: "search",
+  // Web
+  webfetch: "fetch",
+  websearch: "fetch",
+  // Agent/planning
+  task: "think",
+  todoread: "other",
+  todowrite: "other",
+};
+
+/**
+ * Create an OpenCode parser instance.
+ */
+export function createOpenCodeParser(): (jsonLine: string) => OutputEvent[] | null {
+  return function parseOpenCodeEvent(jsonLine: string): OutputEvent[] | null {
+    let data: any;
+    try {
+      data = JSON.parse(jsonLine);
+    } catch {
+      return null;
+    }
+
+    if (!data || typeof data !== "object") return null;
+
+    const sessionId = data.sessionID;
+    const events: OutputEvent[] = [];
+
+    switch (data.type) {
+      // Lifecycle - skip
+      case "step_start":
+      case "step_finish":
+        return null;
+
+      // Text content from agent
+      case "text": {
+        const update = handleText(data);
+        if (update) events.push({ sessionId, update });
+        break;
+      }
+
+      // Tool use (arrives already completed)
+      case "tool_use": {
+        const updates = handleToolUse(data);
+        for (const update of updates) {
+          events.push({ sessionId, update });
+        }
+        break;
+      }
+
+      // Error events
+      case "error": {
+        const update = handleError(data);
+        if (update) events.push({ sessionId, update });
+        break;
+      }
+
+      default:
+        return null;
+    }
+
+    return events.length > 0 ? events : null;
+  };
+
+  /**
+   * Handle text events
+   * { type: "text", part: { text: string, time: { start, end } } }
+   */
+  function handleText(data: any): SessionUpdate | null {
+    const text = data.part?.text;
+    if (typeof text !== "string" || text.length === 0) return null;
+
+    return {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text },
+    };
+  }
+
+  /**
+   * Handle tool_use events
+   *
+   * OpenCode emits tool_use with completed status, so we emit both:
+   * 1. tool_call (pending) - for UI to show the tool card
+   * 2. tool_call_update (completed/failed) - with output
+   *
+   * { type: "tool_use", part: { callID, tool, state: { status, input, output, title, metadata, time } } }
+   */
+  function handleToolUse(data: any): SessionUpdate[] {
+    const part = data.part;
+    if (!part) return [];
+
+    const callId = part.callID;
+    const toolName = part.tool ?? "";
+    const state = part.state ?? {};
+    const input = state.input ?? {};
+    const output = state.output;
+    const title = state.title ?? state.metadata?.description ?? toolName;
+    const status = state.status;
+    const exitCode = state.metadata?.exit;
+
+    const { kind, content: callContent, locations } = getToolInfo(toolName, input);
+
+    const updates: SessionUpdate[] = [];
+
+    // Emit tool_call (pending)
+    updates.push({
+      sessionUpdate: "tool_call",
+      toolCallId: callId,
+      title,
+      kind,
+      status: "pending",
+      rawInput: input,
+      content: callContent,
+      locations,
+    });
+
+    // Emit tool_call_update (completed/failed)
+    const isFailed = status === "failed" || (exitCode !== undefined && exitCode !== 0);
+    const resultContent: ToolCallContent[] = [];
+
+    if (typeof output === "string" && output.length > 0) {
+      resultContent.push({
+        type: "content",
+        content: {
+          type: "text",
+          text: isFailed ? `\`\`\`\n${output}\n\`\`\`` : output,
+        },
+      });
+    }
+
+    updates.push({
+      sessionUpdate: "tool_call_update",
+      toolCallId: callId,
+      status: isFailed ? "failed" : "completed",
+      content: resultContent,
+    });
+
+    return updates;
+  }
+
+  /**
+   * Handle error events
+   * { type: "error", error: { name, data: { message } } }
+   */
+  function handleError(data: any): SessionUpdate | null {
+    const errorName = data.error?.name ?? "Error";
+    const message = data.error?.data?.message ?? data.error?.message ?? "Unknown error";
+
+    return {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: `❌ ${errorName}: ${message}` },
+    };
+  }
+
+  /**
+   * Get tool info from tool name and input parameters.
+   */
+  function getToolInfo(
+    toolName: string,
+    input: Record<string, unknown>
+  ): {
+    kind: ToolKind;
+    content: ToolCallContent[];
+    locations: ToolCallLocation[];
+  } {
+    const kind = TOOL_KINDS[toolName] || "other";
+    const content: ToolCallContent[] = [];
+    const locations: ToolCallLocation[] = [];
+
+    switch (toolName) {
+      case "read": {
+        const path = (input.file_path ?? input.path) as string | undefined;
+        if (path) locations.push({ path });
+        break;
+      }
+
+      case "write": {
+        const path = (input.file_path ?? input.path) as string | undefined;
+        if (path) {
+          locations.push({ path });
+          if (typeof input.content === "string") {
+            content.push({
+              type: "diff",
+              path,
+              oldText: null,
+              newText: input.content as string,
+            });
+          }
+        }
+        break;
+      }
+
+      case "edit":
+      case "patch":
+      case "multiedit": {
+        const path = (input.file_path ?? input.path) as string | undefined;
+        if (path) {
+          locations.push({ path });
+          if (input.old_string !== undefined || input.new_string !== undefined) {
+            content.push({
+              type: "diff",
+              path,
+              oldText: (input.old_string as string) ?? "",
+              newText: (input.new_string as string) ?? "",
+            });
+          }
+        }
+        break;
+      }
+
+      case "bash": {
+        const cmd = input.command as string | undefined;
+        if (cmd && input.description) {
+          content.push({
+            type: "content",
+            content: { type: "text", text: input.description as string },
+          });
+        }
+        break;
+      }
+
+      case "glob":
+      case "list": {
+        const path = (input.path ?? input.dir_path) as string | undefined;
+        if (path) locations.push({ path });
+        break;
+      }
+
+      case "grep":
+      case "codesearch": {
+        const path = input.path as string | undefined;
+        if (path) locations.push({ path });
+        break;
+      }
+
+      case "webfetch": {
+        // No special handling
+        break;
+      }
+
+      case "websearch": {
+        // No special handling
+        break;
+      }
+
+      case "task": {
+        // Subagent task
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    return { kind, content, locations };
+  }
+}

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -233,6 +233,59 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
       return `qwen "${prompt}" ${continueFlag}${skillsFlag}--auth-type openai --model ${prefixedModel} --yolo --output-format stream-json`;
     },
   },
+
+  kimi: {
+    image: "evolve-all",
+    apiKeyEnv: "KIMI_API_KEY",
+    baseUrlEnv: "KIMI_BASE_URL",
+    defaultModel: "kimi-k2.5",
+    models: [
+      { alias: "kimi-k2.5", modelId: "kimi-k2.5", description: "Latest multimodal, Agent Swarm capable" },
+      { alias: "kimi-k2-turbo-preview", modelId: "kimi-k2-turbo-preview", description: "Fast turbo model" },
+    ],
+    systemPromptFile: "AGENTS.md",
+    mcpConfig: {
+      settingsDir: "~/.kimi",
+      filename: "mcp.json",
+      format: "json",
+    },
+    skillsConfig: {
+      sourceDir: "/home/user/.evolve/skills",
+      targetDir: "/home/user/.kimi/skills",
+    },
+    defaultBaseUrl: "https://api.moonshot.ai/v1",
+    buildCommand: ({ prompt, model, isResume }) => {
+      const continueFlag = isResume ? "--continue " : "";
+      return `kimi --print --output-format stream-json --yolo ${continueFlag}--model ${model} --prompt "${prompt}"`;
+    },
+  },
+
+  opencode: {
+    image: "evolve-all",
+    apiKeyEnv: "OPENAI_API_KEY",
+    baseUrlEnv: "OPENAI_BASE_URL",
+    defaultModel: "anthropic/claude-sonnet-4-5",
+    models: [
+      { alias: "anthropic/claude-sonnet-4-5", modelId: "anthropic/claude-sonnet-4-5", description: "Balanced coding, features, tests" },
+      { alias: "anthropic/claude-opus-4-6", modelId: "anthropic/claude-opus-4-6", description: "Complex reasoning, R&D" },
+      { alias: "openai/gpt-5.2", modelId: "openai/gpt-5.2", description: "OpenAI flagship" },
+      { alias: "google/gemini-2.5-pro", modelId: "google/gemini-2.5-pro", description: "Google deep reasoning" },
+    ],
+    systemPromptFile: "AGENTS.md",
+    mcpConfig: {
+      settingsDir: ".",
+      filename: "opencode.json",
+      format: "json",
+    },
+    skillsConfig: {
+      sourceDir: "/home/user/.evolve/skills",
+      targetDir: "/home/user/.config/opencode/skills",
+    },
+    buildCommand: ({ prompt, model, isResume }) => {
+      const continueFlag = isResume ? "--continue " : "";
+      return `OPENCODE_PERMISSION='{"*":"allow"}' opencode run "${prompt}" ${continueFlag}--model ${model} --format json`;
+    },
+  },
 };
 
 // =============================================================================

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -115,7 +115,7 @@ export interface SandboxProvider {
 // =============================================================================
 
 /** Supported agent types (headless CLI agents only, no ACP) */
-export type AgentType = "claude" | "codex" | "gemini" | "qwen";
+export type AgentType = "claude" | "codex" | "gemini" | "qwen" | "kimi" | "opencode";
 
 /** Agent type constants for use in code */
 export const AGENT_TYPES = {
@@ -123,6 +123,8 @@ export const AGENT_TYPES = {
   CODEX: "codex",
   GEMINI: "gemini",
   QWEN: "qwen",
+  KIMI: "kimi",
+  OPENCODE: "opencode",
 } as const;
 
 // =============================================================================


### PR DESCRIPTION
Add proper support for Kimi CLI and OpenCode agents with parsers, correct registry entries, and MCP configuration writers.

Changes
--------
- parsers/kimi.ts (377 lines): Full Wire protocol parser mapping TurnBegin, TextPart, ThinkPart, ToolCall, ToolResult, SubagentEvent to ACP events
- parsers/opencode.ts (299 lines): JSONL parser for --format json output, emits both tool_call and tool_call_update (tools arrive completed)
- registry.ts: Fixed model names, buildCommand, systemPromptFile, MCP configs for both agents
- mcp/json.ts: Added writeKimiMcpConfig and writeOpenCodeConfig
- mcp/index.ts: Added routing for both agents
- types.ts: Updated AgentType union

Kimi CLI
---------
- Wire protocol parser mapping to ACP events
- Models: kimi-k2.5, kimi-k2-turbo-preview
- Command: kimi --print --output-format stream-json --yolo
- Reads AGENTS.md from project root (created via /init)
- MCP config: ~/.kimi/mcp.json with type field
- Tool names: ReadFile, WriteFile, PatchFile, Exec, Glob, Grep, ListDir, MoonshotSearch, MoonshotFetch, WebSearch, WebFetch, Task

OpenCode
---------
- JSONL parser for opencode run --format json
- Model-agnostic: uses provider/model format (e.g., anthropic/claude-sonnet-4-5)
- Default model: anthropic/claude-sonnet-4-5
- Command: OPENCODE_PERMISSION='{\*\:\allow\}' opencode run ... --format json
- Reads AGENTS.md for workspace instructions
- MCP config: opencode.json with mcp key (local command array, remote url)
- Tools: bash, read, write, edit, patch, multiedit, glob, grep, list, codesearch, webfetch, websearch, task

TODO
----
- Verify opencode-ai binary is installed in the evolve-all sandbox image
- Consider Multi-provider auth: Currently uses OPENAI_API_KEY for OpenCode; may need smarter resolution to match model provider
- Explore ACP mode alternative: OpenCode has opencode acp which speaks nd-JSON ACP natively. Currently using run --format json for parity with other agents.
