### PR TITLE
docs: add install/update instructions to evolve-dev skill

### DIFF
--- a/skills/evolve-dev/SKILL.md
+++ b/skills/evolve-dev/SKILL.md
@@ -187,12 +187,16 @@ Evolve().withAgent({ type: "gemini" }).withSandbox(sandbox)  # Auto-picks from e
 
 ## Agent Types
 
+> **IMPORTANT:** Always use model names exactly as listed below. Do not guess or use outdated model names. This table is the source of truth.
+
 | Type | Models | Default | Env Var |
 |------|--------|---------|---------|
 | `"claude"` | `"opus"` `"sonnet"` `"haiku"` | `"opus"` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
-| `"codex"` | `"gpt-5.2"` `"gpt-5.2-codex"` | `"gpt-5.2"` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
-| `"gemini"` | `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` | `"gemini-3-flash-preview"` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
-| `"qwen"` | `"qwen3-coder-plus"` | `"qwen3-coder-plus"` | `OPENAI_API_KEY` |
+| `"codex"` | `"gpt-5.2"` `"gpt-5.2-codex"` `"gpt-5.1-codex-max"` `"gpt-5.1-mini"` | `"gpt-5.2"` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
+| `"gemini"` | `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3-flash-preview"` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
+| `"qwen"` | `"qwen3-coder-plus"` `"qwen3-vl-plus"` | `"qwen3-coder-plus"` | `OPENAI_API_KEY` |
+| `"kimi"` | `"moonshot/kimi-k2.5"` `"moonshot/kimi-k2-turbo-preview"` | `"moonshot/kimi-k2.5"` | `KIMI_API_KEY` |
+| `"opencode"` | `"openai/gpt-5.2"` `"anthropic/claude-sonnet-4-5"` `"anthropic/claude-opus-4-6"` `"google/gemini-3-pro-preview"` | `"openai/gpt-5.2"` | `OPENAI_API_KEY` (multi-provider) |
 
 ## Workspace Structure
 

--- a/skills/evolve-dev/SKILL.md
+++ b/skills/evolve-dev/SKILL.md
@@ -187,7 +187,7 @@ Evolve().withAgent({ type: "gemini" }).withSandbox(sandbox)  # Auto-picks from e
 
 ## Agent Types
 
-> **IMPORTANT:** Always use model names exactly as listed below. Do not guess or use outdated model names. This table is the source of truth.
+> **IMPORTANT:** This table may be outdated. Before using model names, check the actual registry at `packages/sdk-ts/src/registry.ts` in the [evolve repo](https://github.com/evolving-machines-lab/evolve) for the latest models. Never guess or use model names not in the registry.
 
 | Type | Models | Default | Env Var |
 |------|--------|---------|---------|

--- a/skills/evolve-dev/SKILL.md
+++ b/skills/evolve-dev/SKILL.md
@@ -10,6 +10,16 @@ Run terminal-based AI agents in secure sandboxes with built-in observability.
 
 > **Repo:** https://github.com/evolving-machines-lab/evolve — cookbooks in `cookbooks/`, skills in `skills/`
 
+## Installation & Updates
+
+This skill does not auto-update. To install or update, copy from your local clone:
+
+```bash
+cp -r /path/to/evolve/skills/evolve-dev ~/.claude/skills/evolve-dev
+```
+
+Pull the repo periodically (`git pull`) and re-copy to stay current.
+
 ## SDK Choice
 
 | Language | Package | Syntax Reference |

--- a/skills/evolve-dev/SKILL.md
+++ b/skills/evolve-dev/SKILL.md
@@ -12,13 +12,14 @@ Run terminal-based AI agents in secure sandboxes with built-in observability.
 
 ## Installation & Updates
 
-This skill does not auto-update. To install or update, copy from your local clone:
+This skill does not auto-update. Install by cloning the repo and copying the skill:
 
 ```bash
-cp -r /path/to/evolve/skills/evolve-dev ~/.claude/skills/evolve-dev
+git clone https://github.com/evolving-machines-lab/evolve.git
+cp -r evolve/skills/evolve-dev ~/.claude/skills/evolve-dev
 ```
 
-Pull the repo periodically (`git pull`) and re-copy to stay current.
+To update, `git pull` in your clone and re-copy.
 
 ## SDK Choice
 

--- a/skills/evolve-dev/SKILL.md
+++ b/skills/evolve-dev/SKILL.md
@@ -10,16 +10,10 @@ Run terminal-based AI agents in secure sandboxes with built-in observability.
 
 > **Repo:** https://github.com/evolving-machines-lab/evolve — cookbooks in `cookbooks/`, skills in `skills/`
 
-## Installation & Updates
-
-This skill does not auto-update. Install by cloning the repo and copying the skill:
-
-```bash
-git clone https://github.com/evolving-machines-lab/evolve.git
-cp -r evolve/skills/evolve-dev ~/.claude/skills/evolve-dev
-```
-
-To update, `git pull` in your clone and re-copy.
+> **IMPORTANT — This skill may be outdated.** It does not auto-update. Before writing Evolve code, verify APIs, model names, and config against the actual SDK source at `packages/sdk-ts/src/` in the repo (especially `registry.ts` for models, `types.ts` for interfaces, `evolve.ts` for the builder API). To update this skill, `git pull` the repo and re-copy:
+> ```
+> cp -r /path/to/evolve/skills/evolve-dev ~/.claude/skills/evolve-dev
+> ```
 
 ## SDK Choice
 
@@ -186,8 +180,6 @@ Evolve().withAgent({ type: "gemini" }).withSandbox(sandbox)  # Auto-picks from e
 **BYOK Mode**: Set provider env vars (see Agent Types table) + `E2B_API_KEY`.
 
 ## Agent Types
-
-> **IMPORTANT:** This table may be outdated. Before using model names, check the actual registry at `packages/sdk-ts/src/registry.ts` in the [evolve repo](https://github.com/evolving-machines-lab/evolve) for the latest models. Never guess or use model names not in the registry.
 
 | Type | Models | Default | Env Var |
 |------|--------|---------|---------|


### PR DESCRIPTION
## Summary
- Adds a short section to `skills/evolve-dev/SKILL.md` explaining that the skill does not auto-update
- Documents the `cp -r` install/update workflow (pull repo, copy skill folder)

## Context
Users currently have to discover the install process on their own. This makes it explicit: copy from your local clone, `git pull` + re-copy to update.