### PR TITLE
fix: grant contents:write permission to docs sync workflow

### DIFF
--- a/.github/workflows/sync-docs-to-skill.yml
+++ b/.github/workflows/sync-docs-to-skill.yml
@@ -7,6 +7,9 @@ on:
       - 'docs/typescript/[0-9]*.md'
       - 'docs/python/[0-9]*.md'
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: write` to the `sync-docs-to-skill.yml` workflow so `github-actions[bot]` can push commits.
- Without this, the workflow fails with `403: Permission denied`.

## Test plan
- [x] Merge and verify next docs change triggers a successful sync