### PR TITLE
feat: Harbor parity — execute_command options, file ops, resource config

### DIFF
--- a/packages/daytona/src/index.ts
+++ b/packages/daytona/src/index.ts
@@ -124,6 +124,7 @@ export interface SandboxRunOptions {
   timeoutMs?: number;
   envs?: Record<string, string>;
   cwd?: string;
+  user?: string;
   onStdout?: (data: string) => void;
   onStderr?: (data: string) => void;
 }

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -125,6 +125,7 @@ export interface SandboxRunOptions {
   timeoutMs?: number;
   envs?: Record<string, string>;
   cwd?: string;
+  user?: string;
   onStdout?: (data: string) => void;
   onStderr?: (data: string) => void;
 }
@@ -283,6 +284,10 @@ export interface E2BConfig {
   defaultTimeoutMs?: number;
   /** E2B template ID (default: 'evolve-all'). Create custom templates at https://e2b.dev/docs/sandbox-template */
   templateId?: string;
+  /** Number of CPUs for the sandbox */
+  cpuCount?: number;
+  /** Memory in MB for the sandbox */
+  memoryMb?: number;
 }
 
 /** Internal resolved config with required apiKey */
@@ -290,6 +295,8 @@ interface ResolvedE2BConfig {
   apiKey: string;
   defaultTimeoutMs?: number;
   templateId?: string;
+  cpuCount?: number;
+  memoryMb?: number;
 }
 
 // ============================================================
@@ -306,6 +313,7 @@ class E2BCommands implements SandboxCommands {
         timeoutMs: options?.timeoutMs,
         envs: options?.envs,
         cwd: options?.cwd,
+        user: options?.user,
         onStdout: options?.onStdout,
         onStderr: options?.onStderr,
       });
@@ -334,6 +342,7 @@ class E2BCommands implements SandboxCommands {
       timeoutMs: options?.timeoutMs,
       envs: options?.envs,
       cwd: options?.cwd,
+      user: options?.user,
       onStdout: options?.onStdout,
       onStderr: options?.onStderr,
     });
@@ -551,11 +560,15 @@ export class E2BProvider implements SandboxProvider {
   private readonly apiKey: string;
   private readonly defaultTimeoutMs: number;
   private readonly templateId?: string;
+  private readonly cpuCount?: number;
+  private readonly memoryMb?: number;
 
   constructor(config: ResolvedE2BConfig) {
     this.apiKey = config.apiKey;
     this.defaultTimeoutMs = config.defaultTimeoutMs ?? 3600000;
     this.templateId = config.templateId;
+    this.cpuCount = config.cpuCount;
+    this.memoryMb = config.memoryMb;
   }
 
   async create(options: SandboxCreateOptions): Promise<SandboxInstance> {
@@ -568,6 +581,8 @@ export class E2BProvider implements SandboxProvider {
       envs: options.envs,
       metadata: options.metadata,
       timeoutMs,
+      ...(this.cpuCount && { cpuCount: this.cpuCount }),
+      ...(this.memoryMb && { memoryMb: this.memoryMb }),
     });
 
     if (options.workingDirectory) {

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -125,6 +125,7 @@ export interface SandboxRunOptions {
   timeoutMs?: number;
   envs?: Record<string, string>;
   cwd?: string;
+  user?: string;
   onStdout?: (data: string) => void;
   onStderr?: (data: string) => void;
 }

--- a/packages/sdk-py/bridge/src/types.ts
+++ b/packages/sdk-py/bridge/src/types.ts
@@ -103,9 +103,30 @@ export interface ExecuteCommandParams {
   command: string;
   timeout_ms?: number;
   background?: boolean;
+  cwd?: string;
+  envs?: Record<string, string>;
+  user?: string;
 }
 
 export interface UploadFilesParams {
+  files: EncodedFileMap;
+}
+
+export interface ReadFileParams {
+  path: string;
+}
+
+export interface ReadFileResponse {
+  content: string;
+  encoding: 'text' | 'base64';
+}
+
+export interface DownloadDirParams {
+  path: string;
+  recursive?: boolean;
+}
+
+export interface DownloadDirResponse {
   files: EncodedFileMap;
 }
 

--- a/packages/sdk-py/evolve/config.py
+++ b/packages/sdk-py/evolve/config.py
@@ -80,10 +80,14 @@ class E2BProvider:
         api_key: E2B API key (defaults to E2B_API_KEY env var)
         timeout_ms: Sandbox timeout in milliseconds (default: 3600000 = 1 hour)
         template_id: E2B template ID (default: 'evolve-all'). Create custom templates at https://e2b.dev/docs/sandbox-template
+        cpu_count: Number of CPUs for the sandbox (default: provider default)
+        memory_mb: Memory in MB for the sandbox (default: provider default)
     """
     api_key: Optional[str] = None
     timeout_ms: int = 3600000
     template_id: Optional[str] = None
+    cpu_count: Optional[int] = None
+    memory_mb: Optional[int] = None
 
     @property
     def type(self) -> Literal['e2b']:
@@ -100,6 +104,10 @@ class E2BProvider:
             result['defaultTimeoutMs'] = self.timeout_ms
         if self.template_id:
             result['templateId'] = self.template_id
+        if self.cpu_count is not None:
+            result['cpuCount'] = self.cpu_count
+        if self.memory_mb is not None:
+            result['memoryMb'] = self.memory_mb
         return result
 
 

--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -889,7 +889,7 @@ export class Agent {
     options: ExecuteCommandOptions = {},
     callbacks?: StreamCallbacks
   ): Promise<AgentResponse> {
-    const { timeoutMs = DEFAULT_TIMEOUT_MS, background = false } = options;
+    const { timeoutMs = DEFAULT_TIMEOUT_MS, background = false, cwd, envs, user } = options;
     if (this.activeCommand) {
       throw new Error(
         "Agent is already running. Call interrupt(), wait for the active/background command to finish, or create a new Evolve instance."
@@ -915,10 +915,12 @@ export class Agent {
     };
 
     const handle = await sandbox.commands.spawn(command, {
-      cwd: this.workingDir,
+      cwd: cwd ?? this.workingDir,
       timeoutMs,
       onStdout,
       onStderr,
+      ...(envs && { envs }),
+      ...(user && { user }),
     });
     const opId = this.beginOperation("command", handle, callbacks, "command_start");
 

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -33,7 +33,7 @@ import { isZodSchema, resolveAgentConfig, resolveDefaultSandbox } from "./utils"
 import { composioHelpers } from "./composio";
 import { getGatewayMcpServers, DEFAULT_DASHBOARD_URL } from "./constants";
 import { resolveStorageConfig, listCheckpoints } from "./storage";
-import type { CheckpointInfo } from "./types";
+import type { CheckpointInfo, ExecuteCommandOptions } from "./types";
 
 // =============================================================================
 // TYPES
@@ -510,7 +510,7 @@ export class Evolve extends EventEmitter {
    */
   async executeCommand(
     command: string,
-    options: { timeoutMs?: number; background?: boolean } = {}
+    options: ExecuteCommandOptions = {}
   ): Promise<AgentResponse> {
     if (!this.agent) {
       await this.initializeAgent();

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -54,6 +54,7 @@ export interface SandboxRunOptions {
   timeoutMs?: number;
   envs?: Record<string, string>;
   cwd?: string;
+  user?: string;
   onStdout?: (data: string) => void;
   onStderr?: (data: string) => void;
 }
@@ -373,6 +374,15 @@ export interface ExecuteCommandOptions {
 
   /** Run in background (default: false) */
   background?: boolean;
+
+  /** Working directory for the command (default: working_directory from init) */
+  cwd?: string;
+
+  /** Environment variables to set for this command */
+  envs?: Record<string, string>;
+
+  /** User to run the command as (e.g., 'root') */
+  user?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds features to close the gap between Evolve SDK and Harbor for evaluation workloads (Terminal-Bench 2.0, LiveCodeBench). These are the top gaps identified from building [evolve-bench](https://github.com/tshrjn/evole-bench).

### Changes

- **`execute_command` with `cwd`, `envs`, `user`** — Run commands with custom working directory, environment variables, and user context. Threaded through the full stack: TS SDK types → agent.ts → evolve.ts → bridge types → bridge adapter → Python SDK.

- **`upload_dir()` / `download_dir()` / `read_file()`** — Python SDK convenience methods for directory uploads (local → sandbox), directory downloads (sandbox → local), and single file reads from sandbox. Built on existing `upload_files` and new bridge RPC methods.

- **`E2BProvider(cpu_count, memory_mb)`** — Resource configuration for E2B sandboxes. Forwarded through to `E2BSandbox.create()`.

- **`user` in `SandboxRunOptions`** — Added across all provider interfaces (E2B, Daytona, Modal) for consistency. E2B implementation forwards to the SDK's native `user` option.

### Files Changed (10 files, +242/-9)

| Layer | File | Changes |
|-------|------|---------|
| TS SDK | `sdk-ts/src/types.ts` | Add `cwd/envs/user` to `ExecuteCommandOptions`, `user` to `SandboxRunOptions` |
| TS SDK | `sdk-ts/src/agent.ts` | Forward new options to `sandbox.commands.spawn()` |
| TS SDK | `sdk-ts/src/evolve.ts` | Use typed `ExecuteCommandOptions` |
| E2B | `e2b/src/index.ts` | Add `cpuCount/memoryMb` to config, forward `user` in run/spawn |
| Daytona | `daytona/src/index.ts` | Add `user` to `SandboxRunOptions` interface |
| Modal | `modal/src/index.ts` | Add `user` to `SandboxRunOptions` interface |
| Bridge | `sdk-py/bridge/src/types.ts` | Add `cwd/envs/user` to `ExecuteCommandParams`, add `ReadFile`/`DownloadDir` types |
| Bridge | `sdk-py/bridge/src/adapter.ts` | Forward execute_command options, add `readFile`/`downloadDir` handlers |
| Python SDK | `sdk-py/evolve/agent.py` | Add `cwd/envs/user` to `execute_command()`, add `upload_dir`/`download_dir`/`read_file` |
| Python SDK | `sdk-py/evolve/config.py` | Add `cpu_count/memory_mb` to `E2BProvider` |

### Usage Examples

```python
# execute_command with cwd, envs, user
result = await evolve.execute_command('ls -la', cwd='/tmp', user='root')
result = await evolve.execute_command('echo $MY_VAR', envs={'MY_VAR': 'hello'})

# Upload/download directories
await evolve.upload_dir('./tests', '/tests')
await evolve.download_dir('/app/output', './results')

# Read single file
content = await evolve.read_file('/app/result.json')

# E2B with resource config
sandbox = E2BProvider(cpu_count=4, memory_mb=8192)
```

### Test plan

- [x] `npx tsc --noEmit` passes for sdk-ts and e2b packages (no new type errors)
- [x] Bridge type errors are pre-existing (checkpoint/storage features not yet published in sdk-ts)
- [ ] Integration test with evolve-termbench using the new `execute_command(cwd=..., user=...)` params

🤖 Generated with [Claude Code](https://claude.com/claude-code)