### PR TITLE
chore: remove obsolete experimental skills flags

### DIFF
--- a/assets/docker/Dockerfile
+++ b/assets/docker/Dockerfile
@@ -120,11 +120,6 @@ RUN git clone --depth 1 --filter=blob:none --sparse https://github.com/evolving-
     && rm -rf /tmp/evolve
 
 # ---------------------------------------------------------------------------
-# Gemini settings (enable experimental skills)
-# ---------------------------------------------------------------------------
-RUN echo '{"experimental":{"skills":true}}' > /home/user/.gemini/settings.json
-
-# ---------------------------------------------------------------------------
 # Gemini Extensions (Nano Banana for image generation)
 # ---------------------------------------------------------------------------
 RUN echo y | gemini extensions install https://github.com/gemini-cli-extensions/nanobanana || true

--- a/assets/e2b/template.ts
+++ b/assets/e2b/template.ts
@@ -85,9 +85,6 @@ export const template = Template()
   // Clone skills from evolve repo (sparse checkout for skills/ only)
   .runCmd('git clone --depth 1 --filter=blob:none --sparse https://github.com/evolving-machines-lab/evolve.git /tmp/evolve && cd /tmp/evolve && git sparse-checkout set skills && mv skills/* ~/.evolve/skills/ && rm -rf /tmp/evolve')
 
-  // Enable Gemini experimental skills
-  .runCmd('echo \'{"experimental":{"skills":true}}\' > ~/.gemini/settings.json')
-
   // ---------------------------------------------------------------------------
   // Gemini Extensions (Nano Banana for image generation)
   // ---------------------------------------------------------------------------

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -276,7 +276,6 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     skillsConfig: {
       sourceDir: "/home/user/.evolve/skills",
       targetDir: "/home/user/.qwen/skills",
-      enableFlag: "--experimental-skills",
     },
     // Source-verified: Qwen reads customHeaders from settings.json model.generationConfig,
     // not from env vars. The SDK writes headers to this path before each run.
@@ -284,15 +283,14 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
       headersPath: "model.generationConfig.customHeaders",
     },
     defaultBaseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-    buildCommand: ({ prompt, model, isResume, isDirectMode, skills }) => {
+    buildCommand: ({ prompt, model, isResume, isDirectMode }) => {
       const continueFlag = isResume ? "--continue " : "";
-      const skillsFlag = skills?.length ? "--experimental-skills " : "";
       // Only add dashscope/ prefix for gateway mode (LiteLLM routing)
       const prefixedModel = isDirectMode || model.startsWith("dashscope/")
         ? model
         : `dashscope/${model}`;
       // --auth-type openai is required in non-interactive mode when env vars don't include OPENAI_MODEL
-      return `qwen "${prompt}" ${continueFlag}${skillsFlag}--auth-type openai --model ${prefixedModel} --yolo --output-format stream-json`;
+      return `qwen "${prompt}" ${continueFlag}--auth-type openai --model ${prefixedModel} --yolo --output-format stream-json`;
     },
   },
 

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -143,8 +143,6 @@ export interface SkillsConfig {
   sourceDir: string;
   /** Target directory where skills are copied for this CLI */
   targetDir: string;
-  /** CLI flag to enable skills (e.g., "--experimental-skills") */
-  enableFlag?: string;
 }
 
 /** Reasoning effort for models that support it (Codex only) */


### PR DESCRIPTION
## Summary
- Remove `{"experimental":{"skills":true}}` from Gemini settings in Dockerfile and E2B template — skills are now stable in Gemini CLI
- Remove `--experimental-skills` flag from Qwen Code build command and registry — Qwen moved to an extensions model, flag is no longer recognized
- Remove `enableFlag` from `SkillsConfig` type (no agent uses it anymore)

## Images rebuilt
- [x] E2B template (`evolve-all`) — built successfully
- [ ] Docker Hub (`evolvingmachines/evolve-all:latest`) — push in progress
- [ ] Modal — pending Docker push
- [ ] Daytona — pending Docker push

## Test plan
- [ ] Run a Gemini agent with skills, verify skills load without experimental flag
- [ ] Run a Qwen agent with skills, verify skills load without `--experimental-skills`