### PR TITLE
fix: update docs footer and tests to BSL-1.1

### DIFF
--- a/docs-site/src/app/layout.jsx
+++ b/docs-site/src/app/layout.jsx
@@ -24,7 +24,7 @@ const navbar = (
 
 const footer = (
   <Footer>
-    Apache-2.0 {new Date().getFullYear()} © Evolving Machines.
+    BSL-1.1 {new Date().getFullYear()} © Evolving Machines.
   </Footer>
 );
 

--- a/docs-site/tests/integration.mjs
+++ b/docs-site/tests/integration.mjs
@@ -154,7 +154,7 @@ if (pyGettingStarted) {
 console.log('\n=== Footer ===');
 
 if (navSource) {
-  assert(navSource.includes('Apache-2.0'), 'Footer contains "Apache-2.0"');
+  assert(navSource.includes('BSL-1.1'), 'Footer contains "BSL-1.1"');
   assert(navSource.includes('Evolving Machines'), 'Footer contains "Evolving Machines"');
 }
 

--- a/docs-site/tests/unit.mjs
+++ b/docs-site/tests/unit.mjs
@@ -154,7 +154,7 @@ assert(layoutContent.includes('docsRepositoryBase'), 'layout has docsRepositoryB
 assert(layoutContent.includes('github.com/evolving-machines-lab/evolve'), 'layout has correct GitHub URL');
 assert(layoutContent.includes('projectLink'), 'layout has projectLink');
 assert(layoutContent.includes('Evolve SDK'), 'layout has Evolve SDK text');
-assert(layoutContent.includes('Apache-2.0'), 'layout has Apache-2.0 in footer');
+assert(layoutContent.includes('BSL-1.1'), 'layout has BSL-1.1 in footer');
 assert(layoutContent.includes('search={false}'), 'layout has search disabled');
 
 // --- Summary ---

--- a/docs-site/tests/visual.spec.mjs
+++ b/docs-site/tests/visual.spec.mjs
@@ -74,7 +74,7 @@ test('footer is present', async ({ page }) => {
   await page.goto('/typescript/01-getting-started');
   const footer = page.locator('footer');
   await expect(footer).toBeVisible();
-  await expect(footer).toContainText('Apache-2.0');
+  await expect(footer).toContainText('BSL-1.1');
   await expect(footer).toContainText('Evolving Machines');
 });
 


### PR DESCRIPTION
## Summary

- Update docs site footer from `Apache-2.0` to `BSL-1.1`
- Update 3 test assertions (unit, integration, visual) to match

Follows up on #38.

## Test plan

- [ ] Unit, integration, and visual tests pass with updated assertions