### PR TITLE
fix(e2b): keep Actionbook daemon detached

### DIFF
--- a/assets/docker/Dockerfile
+++ b/assets/docker/Dockerfile
@@ -28,6 +28,7 @@ USER root
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/home/user/.local/bin:${PATH}"
 
 # ---------------------------------------------------------------------------
 # System packages
@@ -87,6 +88,21 @@ RUN npm install -g mcp-remote
 # Agent Browser CLI (headless browser automation for AI agents)
 # ---------------------------------------------------------------------------
 RUN npm install -g agent-browser @actionbookdev/cli
+
+# TEMPORARY ACTIONBOOK DAEMON WORKAROUND.
+# Remove this RUN block and the matching E2B template runCmd only after
+# @actionbookdev/cli includes actionbook/actionbook#611.
+RUN REAL_ACTIONBOOK="$(command -v actionbook)" \
+    && mkdir -p /home/user/.local/bin \
+    && printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -euo pipefail' \
+        "REAL_ACTIONBOOK=\"$REAL_ACTIONBOOK\"" \
+        'if [[ "${1:-}" == "browser" && "${2:-}" == "start" ]]; then exec /usr/bin/setsid "$REAL_ACTIONBOOK" "$@"; fi' \
+        'exec "$REAL_ACTIONBOOK" "$@"' \
+        > /home/user/.local/bin/actionbook \
+    && chmod +x /home/user/.local/bin/actionbook \
+    && chown -R user:user /home/user/.local
 
 # ---------------------------------------------------------------------------
 # User setup

--- a/assets/e2b/template.ts
+++ b/assets/e2b/template.ts
@@ -71,6 +71,11 @@ export const template = Template()
   // ---------------------------------------------------------------------------
   .runCmd('npm install -g agent-browser @actionbookdev/cli')
 
+  // TEMPORARY ACTIONBOOK DAEMON WORKAROUND.
+  // Remove this runCmd and the matching Dockerfile block only after
+  // @actionbookdev/cli includes actionbook/actionbook#611.
+  .runCmd('REAL_ACTIONBOOK="$(command -v actionbook)" && mkdir -p /home/user/.local/bin && printf \'%s\\n\' \'#!/usr/bin/env bash\' \'set -euo pipefail\' "REAL_ACTIONBOOK=\\"$REAL_ACTIONBOOK\\"" \'if [[ "${1:-}" == "browser" && "${2:-}" == "start" ]]; then exec /usr/bin/setsid "$REAL_ACTIONBOOK" "$@"; fi\' \'exec "$REAL_ACTIONBOOK" "$@"\' > /home/user/.local/bin/actionbook && chmod +x /home/user/.local/bin/actionbook && chown -R user:user /home/user/.local')
+
   // ---------------------------------------------------------------------------
   // User setup
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a compact E2B template shim for `actionbook browser start`
- run Actionbook browser-start through `setsid` so its daemon survives short-lived headless shell process cleanup
- leave all non-start Actionbook commands unchanged

## Validation
- `npx tsx -e "import './assets/e2b/template.ts'; console.log('template import ok')"`
- `git diff --check`
- live E2B/Codex smoke with the exact template command: wrapper generated at `/home/user/.local/bin/actionbook`; separate Codex `/bin/sh -lc` calls ran `browser start`, `list-sessions`, `goto https://example.com`, and `title`; result was `1 session`, title `Example Domain`, and no `SESSION_NOT_FOUND`.

## Note
This is a temporary template-level compatibility shim while upstream Actionbook PR #611 is open.
