### PR TITLE
Use agent-browser default session in managed config

### DIFF
--- a/packages/sdk-ts/src/browser.ts
+++ b/packages/sdk-ts/src/browser.ts
@@ -24,7 +24,6 @@ const ACTIONBOOK_CONFIG_PATH = `${ACTIONBOOK_CONFIG_DIR}/config.toml`;
 // Dashboard create requests keep the existing managed-browser contract; the
 // SDK-level automation provider is tracked separately on ManagedBrowserConfig.
 const MANAGED_BROWSER_CREATE_PROVIDER = "actionbook";
-const MANAGED_BROWSER_SESSION_ID = "s1";
 
 export interface NormalizedBrowserConfig {
   provider: "browser-use" | ManagedBrowserProvider;
@@ -102,7 +101,6 @@ export function getManagedBrowserSandboxSetup(
       {
         path: AGENT_BROWSER_CONFIG_PATH,
         data: `${JSON.stringify({
-          session: MANAGED_BROWSER_SESSION_ID,
           cdp: session.cdpUrl,
         }, null, 2)}\n`,
       },

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -320,7 +320,8 @@ async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
   const config = writes.get("/home/user/.agent-browser/config.json");
   assert(dirs.includes("/home/user/.agent-browser"), "agent-browser config directory created");
   assert(config !== undefined, "agent-browser config written");
-  assert(config?.includes('"session": "s1"'), "agent-browser config pins session s1");
+  const parsedConfig = JSON.parse(config!);
+  assert(!("session" in parsedConfig), "agent-browser config leaves session default to agent-browser");
   assert(
     config?.includes("wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token") ?? false,
     "agent-browser config receives proxied CDP endpoint"

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -371,7 +371,8 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
     const config = sandbox.files.writes.get("/home/user/.agent-browser/config.json");
     assert(sandbox.files.dirs.includes("/home/user/.agent-browser"), "agent-browser config directory created");
     assert(config !== undefined, "agent-browser config file written");
-    assert(config?.includes('"session": "s1"') ?? false, "agent-browser config pins session s1");
+    const parsedConfig = JSON.parse(config!);
+    assert(!("session" in parsedConfig), "agent-browser config leaves session default to agent-browser");
     assert(config?.includes(cdpUrl) ?? false, "agent-browser config uses proxied CDP endpoint");
     assert(!config?.toLowerCase().includes("driver"), "agent-browser config does not expose provider name");
 


### PR DESCRIPTION
## Summary
- remove the hardcoded agent-browser session id from managed remote browser config
- keep only the proxied CDP endpoint in the generated agent-browser config
- update focused tests to assert the session key is omitted

## Tests
- npm run build
- npm run test:unit:browser
- tsx tests/unit/session-runtime.test.ts
- pytest -q tests/unit/test_auth_config.py