### PR TITLE
Fix Gemini gateway passthrough path

### DIFF
--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -43,7 +43,7 @@ import { getAgentConfig, type AgentRegistryEntry } from "./registry";
 import { writeMcpConfig, writeCodexSpendProvider, writeJsonSpendHeaders, writeKimiSpendConfig, writeDroidGatewaySettings } from "./mcp";
 import { createAgentParser, type AgentParser } from "./parsers";
 import type { OutputEvent } from "./parsers/types";
-import { DEFAULT_TIMEOUT_MS, DEFAULT_WORKING_DIR, DEFAULT_DASHBOARD_URL, LITELLM_CUSTOMER_ID_HEADER, LITELLM_TAGS_HEADER, RUN_TAG_PREFIX, getGatewayUrl, getGeminiGatewayUrl } from "./constants";
+import { DEFAULT_TIMEOUT_MS, DEFAULT_WORKING_DIR, DEFAULT_DASHBOARD_URL, LITELLM_CUSTOMER_ID_HEADER, LITELLM_TAGS_HEADER, RUN_TAG_PREFIX, getGatewayUrl } from "./constants";
 import { buildWorkerSystemPrompt } from "./prompts";
 import { isZodSchema } from "./utils";
 import { SessionLogger } from "./observability";
@@ -466,9 +466,7 @@ export class Agent {
       }
     } else if (!this.agentConfig.isDirectMode) {
       // Gateway mode: route through Evolve gateway
-      const gatewayUrl = this.registry.usePassthroughGateway
-        ? getGeminiGatewayUrl()
-        : getGatewayUrl();
+      const gatewayUrl = getGatewayUrl(this.registry.gatewayPath);
 
       if (this.registry.gatewayConfigEnv) {
         // Session-level: only customer-id header. Per-run tag added in buildRunEnvs().
@@ -558,9 +556,7 @@ export class Agent {
    * Source-verified: model.headers → provider.ts:1061 → llm.ts:221 → HTTP request.
    */
   private buildGatewayConfigJson(headers: Record<string, string>): string {
-    const gatewayUrl = this.registry.usePassthroughGateway
-      ? getGeminiGatewayUrl()
-      : getGatewayUrl();
+    const gatewayUrl = getGatewayUrl(this.registry.gatewayPath);
     const selectedModel = this.resolveCommandModel(this.agentConfig.model || this.registry.defaultModel);
 
     // Start from user-provided config if available, preserving non-litellm settings

--- a/packages/sdk-ts/src/constants.ts
+++ b/packages/sdk-ts/src/constants.ts
@@ -9,7 +9,7 @@
 // =============================================================================
 
 /**
- * Get the gateway base URL at runtime
+ * Get the gateway URL at runtime
  *
  * All agent requests are routed through this gateway which provides:
  * - Single API key for all providers
@@ -19,26 +19,16 @@
  * Note: Uses a function to ensure env var is read at runtime (not build time)
  * when using bundlers with environment variable inlining.
  *
+ * @param path Optional gateway path prefix for provider passthrough routes
  * @internal
  */
-export function getGatewayUrl(): string {
-  return (
+export function getGatewayUrl(path = ""): string {
+  const baseUrl =
     process.env.EVOLVE_GATEWAY_URL ||
-    "https://swarmkit-gateway-692833842999.us-central1.run.app"
-  );
-}
-
-/**
- * Get the Gemini passthrough URL
- *
- * Uses LiteLLM's /gemini passthrough endpoint to preserve native @google/genai SDK
- * format including systemInstruction. Without this, system prompts get dropped
- * during OpenAI format translation.
- *
- * @internal
- */
-export function getGeminiGatewayUrl(): string {
-  return `${getGatewayUrl()}`;
+    "https://swarmkit-gateway-692833842999.us-central1.run.app";
+  if (!path) return baseUrl;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${baseUrl}${normalizedPath}`;
 }
 
 /**
@@ -53,7 +43,7 @@ export function getGeminiGatewayUrl(): string {
  * @internal
  */
 export function getE2BGatewayUrl(): string {
-  return `${getGatewayUrl()}/e2b`;
+  return getGatewayUrl("/e2b");
 }
 
 /**
@@ -73,7 +63,7 @@ export function getGatewayMcpServers(apiKey: string): Record<string, { type: "ht
   return {
     "browser-use": {
       type: "http",
-      url: `${getGatewayUrl()}/browser_use/mcp`,
+      url: getGatewayUrl("/browser_use/mcp"),
       headers: { "x-litellm-api-key": `Bearer ${apiKey}` },
     },
   };

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -84,8 +84,8 @@ export interface AgentRegistryEntry {
   /** Extra setup step (e.g., codex login) */
   setupCommand?: string;
 
-  /** Whether this agent uses passthrough gateway (Gemini) */
-  usePassthroughGateway?: boolean;
+  /** Gateway path prefix for CLIs that use a provider-native passthrough endpoint */
+  gatewayPath?: string;
   /** Default base URL for direct mode (only needed if provider requires specific endpoint, e.g., Qwen → Dashscope) */
   defaultBaseUrl?: string;
   /** Available beta headers for this agent (for reference) */
@@ -266,7 +266,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     // by customHeaderUtils.ts (comma-separated via /,(?=\s*[^,:]+:)/). Not in public docs.
     customHeadersEnv: "GEMINI_CLI_CUSTOM_HEADERS",
     customHeadersFormat: "comma",
-    usePassthroughGateway: true,
+    gatewayPath: "/gemini",
     buildCommand: ({ prompt, model, isResume }) => {
       const resumeFlag = isResume ? "--resume latest " : "";
       return `gemini "${prompt}" ${resumeFlag}--model ${model} --yolo --output-format stream-json`;

--- a/packages/sdk-ts/tests/unit/auth-config.test.ts
+++ b/packages/sdk-ts/tests/unit/auth-config.test.ts
@@ -22,7 +22,8 @@
 
 import { resolveAgentConfig } from "../../src/utils/config.js";
 import { resolveDefaultSandbox } from "../../src/utils/sandbox.js";
-import { getE2BGatewayUrl } from "../../src/constants.js";
+import { getE2BGatewayUrl, getGatewayUrl } from "../../src/constants.js";
+import { AGENT_REGISTRY } from "../../src/registry.js";
 
 // =============================================================================
 // TEST HELPERS
@@ -353,6 +354,21 @@ async function runTests(): Promise<void> {
     });
     assertEqual(result.model, "gpt-5.2", "preserves model in gateway mode");
     assertEqual(result.reasoningEffort, "high", "preserves reasoningEffort in gateway mode");
+  }
+
+  clearEnv();
+  process.env.EVOLVE_API_KEY = "env-evolve-key";
+  {
+    assertEqual(
+      AGENT_REGISTRY.gemini.gatewayPath,
+      "/gemini",
+      "Gemini declares native LiteLLM passthrough path in registry"
+    );
+    assertEqual(
+      getGatewayUrl(AGENT_REGISTRY.gemini.gatewayPath),
+      "https://swarmkit-gateway-692833842999.us-central1.run.app/gemini",
+      "Gemini gateway URL is derived from registry path"
+    );
   }
 
   // EVOLVE_API_KEY takes priority over provider env vars


### PR DESCRIPTION
## Summary
- move provider-native gateway passthrough paths into the agent registry
- route Gemini through the LiteLLM /gemini passthrough path
- keep E2B and browser-use gateway URLs on the same normalized helper

## Tests
- npm run build --workspace=@evolvingmachines/sdk
- npm run test:unit:auth --workspace=@evolvingmachines/sdk
- git diff --check