### PR TITLE
Route managed E2B through dashboard

### DIFF
--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -502,7 +502,7 @@ class E2BSandboxImpl implements SandboxInstance {
   readonly commands: SandboxCommands;
   readonly files: SandboxFiles;
 
-  constructor(private sandbox: E2BSandbox) {
+  constructor(private sandbox: E2BSandbox, private apiKey: string) {
     this.commands = new E2BCommands(sandbox);
     this.files = new E2BFiles(sandbox);
   }
@@ -542,7 +542,7 @@ class E2BSandboxImpl implements SandboxInstance {
   }
 
   async pause(): Promise<void> {
-    await this.sandbox.betaPause();
+    await this.sandbox.betaPause({ apiKey: this.apiKey });
   }
 }
 
@@ -575,7 +575,7 @@ export class E2BProvider implements SandboxProvider {
       await sandbox.files.makeDir(options.workingDirectory);
     }
 
-    return new E2BSandboxImpl(sandbox);
+    return new E2BSandboxImpl(sandbox, this.apiKey);
   }
 
   async connect(sandboxId: string, timeoutMs?: number): Promise<SandboxInstance> {
@@ -583,7 +583,7 @@ export class E2BProvider implements SandboxProvider {
       apiKey: this.apiKey,
       timeoutMs: timeoutMs ?? this.defaultTimeoutMs,
     });
-    return new E2BSandboxImpl(sandbox);
+    return new E2BSandboxImpl(sandbox, this.apiKey);
   }
 
   async list(options?: SandboxListOptions): Promise<SandboxInfo[]> {

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -280,6 +280,8 @@ export interface SandboxProvider {
 export interface E2BConfig {
   /** E2B API key. Default: reads from E2B_API_KEY env var */
   apiKey?: string;
+  /** @internal E2B API base URL override, used for managed gateway routing */
+  apiUrl?: string;
   defaultTimeoutMs?: number;
   /** E2B template ID (default: 'evolve-all'). Create custom templates at https://e2b.dev/docs/sandbox-template */
   templateId?: string;
@@ -288,6 +290,7 @@ export interface E2BConfig {
 /** Internal resolved config with required apiKey */
 interface ResolvedE2BConfig {
   apiKey: string;
+  apiUrl?: string;
   defaultTimeoutMs?: number;
   templateId?: string;
 }
@@ -502,7 +505,7 @@ class E2BSandboxImpl implements SandboxInstance {
   readonly commands: SandboxCommands;
   readonly files: SandboxFiles;
 
-  constructor(private sandbox: E2BSandbox, private apiKey: string) {
+  constructor(private sandbox: E2BSandbox, private apiKey: string, private apiUrl?: string) {
     this.commands = new E2BCommands(sandbox);
     this.files = new E2BFiles(sandbox);
   }
@@ -542,18 +545,23 @@ class E2BSandboxImpl implements SandboxInstance {
   }
 
   async pause(): Promise<void> {
-    await this.sandbox.betaPause({ apiKey: this.apiKey });
+    await this.sandbox.betaPause({
+      apiKey: this.apiKey,
+      apiUrl: this.apiUrl,
+    } as Parameters<E2BSandbox["betaPause"]>[0]);
   }
 }
 
 export class E2BProvider implements SandboxProvider {
   readonly providerType = "e2b" as const;
   private readonly apiKey: string;
+  private readonly apiUrl?: string;
   private readonly defaultTimeoutMs: number;
   private readonly templateId?: string;
 
   constructor(config: ResolvedE2BConfig) {
     this.apiKey = config.apiKey;
+    this.apiUrl = config.apiUrl;
     this.defaultTimeoutMs = config.defaultTimeoutMs ?? 3600000;
     this.templateId = config.templateId;
   }
@@ -565,6 +573,7 @@ export class E2BProvider implements SandboxProvider {
     // Map generic 'image' to E2B's 'templateId'
     const sandbox = await E2BSandbox.create(templateId, {
       apiKey: this.apiKey,
+      apiUrl: this.apiUrl,
       envs: options.envs,
       metadata: options.metadata,
       timeoutMs,
@@ -575,26 +584,28 @@ export class E2BProvider implements SandboxProvider {
       await sandbox.files.makeDir(options.workingDirectory);
     }
 
-    return new E2BSandboxImpl(sandbox, this.apiKey);
+    return new E2BSandboxImpl(sandbox, this.apiKey, this.apiUrl);
   }
 
   async connect(sandboxId: string, timeoutMs?: number): Promise<SandboxInstance> {
     const sandbox = await E2BSandbox.connect(sandboxId, {
       apiKey: this.apiKey,
+      apiUrl: this.apiUrl,
       timeoutMs: timeoutMs ?? this.defaultTimeoutMs,
     });
-    return new E2BSandboxImpl(sandbox, this.apiKey);
+    return new E2BSandboxImpl(sandbox, this.apiKey, this.apiUrl);
   }
 
   async list(options?: SandboxListOptions): Promise<SandboxInfo[]> {
     const paginator = E2BSandbox.list({
       apiKey: this.apiKey,
+      apiUrl: this.apiUrl,
       query: {
         state: options?.state,
         metadata: options?.metadata,
       },
       limit: options?.limit ?? 100,
-    });
+    } as Parameters<typeof E2BSandbox.list>[0]);
 
     const items = await paginator.nextItems();
 

--- a/packages/sdk-ts/src/constants.ts
+++ b/packages/sdk-ts/src/constants.ts
@@ -32,6 +32,22 @@ export function getGatewayUrl(path = ""): string {
 }
 
 /**
+ * Get the dashboard URL at runtime.
+ *
+ * Dashboard-owned resource routes enforce per-user ownership for stateful
+ * managed services before calling the provider gateway.
+ *
+ * @param path Optional dashboard path
+ * @internal
+ */
+export function getDashboardUrl(path = ""): string {
+  const baseUrl = process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL;
+  if (!path) return baseUrl;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${baseUrl.replace(/\/$/, "")}${normalizedPath}`;
+}
+
+/**
  * Get the E2B passthrough URL
  *
  * Routes E2B control plane requests (sandbox create/connect) through the gateway.
@@ -43,7 +59,7 @@ export function getGatewayUrl(path = ""): string {
  * @internal
  */
 export function getE2BGatewayUrl(): string {
-  return getGatewayUrl("/e2b");
+  return getDashboardUrl("/api/managed/e2b");
 }
 
 /**

--- a/packages/sdk-ts/src/utils/sandbox.ts
+++ b/packages/sdk-ts/src/utils/sandbox.ts
@@ -36,6 +36,11 @@ export async function resolveDefaultSandbox(): Promise<SandboxProvider> {
   if (e2bKey) {
     try {
       const { createE2BProvider } = await import("@evolvingmachines/e2b");
+      // Older managed-mode SDKs wrote the Dashboard E2B route into this global.
+      // Direct/BYOK mode must never inherit that managed control-plane URL.
+      if (process.env.E2B_API_URL === getE2BGatewayUrl()) {
+        delete process.env.E2B_API_URL;
+      }
       return createE2BProvider({ apiKey: e2bKey });
     } catch (e) {
       const error = e as Error;
@@ -94,11 +99,9 @@ export async function resolveDefaultSandbox(): Promise<SandboxProvider> {
 
       // Route E2B control plane through Dashboard so Evolve can enforce
       // per-user sandbox ownership before the provider gateway injects E2B_API_KEY.
-      // Note: Sandbox.list() only reads apiUrl from env var (not from options),
-      // so this is the only way to ensure all operations go through managed routing.
-      process.env.E2B_API_URL = getE2BGatewayUrl();
-
-      return createE2BProvider({ apiKey: evolveKey });
+      // Keep this on the provider instance rather than process.env so later BYOK
+      // E2B providers in the same process cannot inherit managed routing.
+      return createE2BProvider({ apiKey: evolveKey, apiUrl: getE2BGatewayUrl() });
     } catch (e) {
       const error = e as Error;
       if (error.message?.includes("Cannot find module") || error.message?.includes("MODULE_NOT_FOUND")) {

--- a/packages/sdk-ts/src/utils/sandbox.ts
+++ b/packages/sdk-ts/src/utils/sandbox.ts
@@ -92,9 +92,10 @@ export async function resolveDefaultSandbox(): Promise<SandboxProvider> {
     try {
       const { createE2BProvider } = await import("@evolvingmachines/e2b");
 
-      // Route E2B control plane through gateway
+      // Route E2B control plane through Dashboard so Evolve can enforce
+      // per-user sandbox ownership before the provider gateway injects E2B_API_KEY.
       // Note: Sandbox.list() only reads apiUrl from env var (not from options),
-      // so this is the only way to ensure all operations go through gateway
+      // so this is the only way to ensure all operations go through managed routing.
       process.env.E2B_API_URL = getE2BGatewayUrl();
 
       return createE2BProvider({ apiKey: evolveKey });

--- a/packages/sdk-ts/tests/unit/auth-config.test.ts
+++ b/packages/sdk-ts/tests/unit/auth-config.test.ts
@@ -13,8 +13,8 @@
  *     6. OAuth env var → OAuth direct mode (Claude only)
  *
  * Tests resolveDefaultSandbox() priority:
- *   1. EVOLVE_API_KEY → gateway mode (revenue)
- *   2. E2B_API_KEY → direct E2B
+ *   1. E2B_API_KEY → direct E2B
+ *   2. EVOLVE_API_KEY → gateway mode
  *
  * Usage:
  *   npx tsx tests/unit/auth-config.test.ts
@@ -107,6 +107,7 @@ function clearEnv(): void {
   delete process.env.FACTORY_API_KEY;
   delete process.env.FACTORY_BASE_URL;
   delete process.env.E2B_API_KEY;
+  delete process.env.E2B_API_URL;
   delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
 }
 
@@ -550,12 +551,11 @@ async function runTests(): Promise<void> {
     const provider = await resolveDefaultSandbox();
     assert(provider !== null, "returns a provider");
     assertEqual(provider.providerType, "e2b", "provider type is e2b");
-    assertEqual(process.env.E2B_API_URL, getE2BGatewayUrl(), "sets E2B_API_URL for gateway routing");
+    assertEqual(process.env.E2B_API_URL, undefined, "does not mutate E2B_API_URL for gateway routing");
   }
 
-  // EVOLVE_API_KEY takes priority over E2B_API_KEY
+  // E2B_API_KEY takes priority over EVOLVE_API_KEY for sandbox billing/BYOK
   clearEnv();
-  delete process.env.E2B_API_URL;
   process.env.EVOLVE_API_KEY = "evolve-gateway-key";
   process.env.E2B_API_KEY = "e2b-direct-key";
   {
@@ -569,7 +569,6 @@ async function runTests(): Promise<void> {
   // -------------------------------------------------------------------------
 
   clearEnv();
-  delete process.env.E2B_API_URL;
   process.env.E2B_API_KEY = "e2b-direct-key";
   {
     const provider = await resolveDefaultSandbox();
@@ -578,12 +577,35 @@ async function runTests(): Promise<void> {
     assert(process.env.E2B_API_URL === undefined, "E2B_API_URL not set in direct mode");
   }
 
+  clearEnv();
+  process.env.EVOLVE_API_KEY = "evolve-gateway-key";
+  {
+    await resolveDefaultSandbox();
+    assertEqual(process.env.E2B_API_URL, undefined, "managed mode keeps E2B_API_URL unset");
+  }
+
+  process.env.E2B_API_URL = getE2BGatewayUrl();
+  delete process.env.EVOLVE_API_KEY;
+  process.env.E2B_API_KEY = "e2b-direct-key";
+  {
+    const provider = await resolveDefaultSandbox();
+    assertEqual(provider.providerType, "e2b", "direct E2B still resolves after managed mode");
+    assertEqual(process.env.E2B_API_URL, undefined, "direct mode clears stale managed E2B_API_URL");
+  }
+
+  clearEnv();
+  process.env.E2B_API_URL = "https://api.e2b.example";
+  process.env.E2B_API_KEY = "e2b-direct-key";
+  {
+    await resolveDefaultSandbox();
+    assertEqual(process.env.E2B_API_URL, "https://api.e2b.example", "direct mode preserves custom E2B_API_URL");
+  }
+
   // -------------------------------------------------------------------------
   console.log("\nError cases (sandbox)");
   // -------------------------------------------------------------------------
 
   clearEnv();
-  delete process.env.E2B_API_URL;
   await assertRejects(
     () => resolveDefaultSandbox(),
     "No sandbox provider configured",


### PR DESCRIPTION
## Summary
- Route gateway-mode E2B control plane calls through the Dashboard managed resource API.
- Keep sandbox data-plane operations unchanged.

## Verification
- npm run build
- npm run test:ts:unit

## Deploy notes
- Depends on matching Dashboard and LiteLLM gateway PRs being deployed.