### PR TITLE
Add managed browser replay support

### DIFF
--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -12,7 +12,7 @@ class AgentResponse:
     stdout: str
     stderr: str
     session_id: str | None        # Dashboard session ID for traces/replays, when known
-    browser: dict | None          # Live browser URL, when remote browser is configured
+    browser: dict[str, str] | None  # live_url, when remote browser is configured
     checkpoint: CheckpointInfo | None  # Present when storage= configured and run succeeded
 
 @dataclass
@@ -23,6 +23,7 @@ class SessionStatus:
     active_process_id: str | None
     has_run: bool
     timestamp: str
+    browser: dict[str, str] | None  # live_url/session_id/session_tag, when available
 ```
 
 ### run

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -11,6 +11,8 @@ class AgentResponse:
     exit_code: int
     stdout: str
     stderr: str
+    session_id: str | None        # Dashboard session ID for traces/replays, when known
+    browser: dict | None          # Live browser URL, when remote browser is configured
     checkpoint: CheckpointInfo | None  # Present when storage= configured and run succeeded
 
 @dataclass
@@ -733,13 +735,15 @@ async with sessions() as session:
         info = await session.get(page.items[0].id)
         recent_events = await session.events(info.id, since=10)
         path = await session.download(info.id, to='./traces')
+        replay = await session.browser_replay(info.id)
 
         print(info.runtime_status)   # 'alive' | 'dead' | 'unknown'
         print(len(recent_events))    # Parsed JSONL objects
         print(path)                  # ./traces/{tag}.jsonl
+        print(replay.replay_url)     # Browser replay URL
 ```
 
-The `sessions()` factory returns a `SessionsClient` with four methods:
+The `sessions()` factory returns a `SessionsClient` with five methods:
 
 ```python
 page = await session.list(
@@ -754,6 +758,11 @@ page = await session.list(
 info = await session.get('session-id')
 events = await session.events('session-id', since=50)
 path = await session.download('session-id', to='./traces')
+replay = await session.browser_replay(
+    'session-id',
+    timeout_ms=600_000,  # optional; default 10 minutes
+    interval_ms=5_000,   # optional; default 5 seconds
+)
 ```
 
 - `list()` returns `SessionPage(items, next_cursor, has_more)`
@@ -761,6 +770,12 @@ path = await session.download('session-id', to='./traces')
   `runtime_status`, `created_at`, and `tool_stats`
 - `events()` returns parsed JSONL objects for programmatic inspection
 - `download()` saves the raw `.jsonl` trace file to disk and returns the path
+- `browser_replay()` waits for the managed browser replay and returns
+  `replay_url` plus `download_url`
+
+Replay processing starts when the managed browser is cleaned up, usually during
+`kill()` or session cleanup. If the client times out, processing continues
+server-side; call `browser_replay()` again later to fetch the same replay.
 
 This API is **gateway-only**. In BYOK/direct mode, historical traces remain
 available via local JSONL files in `~/.evolve-sdk/observability/sessions/`.

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -773,6 +773,9 @@ replay = await session.browser_replay(
 - `download()` saves the raw `.jsonl` trace file to disk and returns the path
 - `browser_replay()` waits for the managed browser replay and returns
   `replay_url` plus `download_url`
+  - Use `replay_url` in your UI for browser playback
+  - Use `download_url` when users need the raw `.mp4` file
+  - `suggested_start_seconds`, when present, is already applied to `replay_url`; keep the raw download unchanged
 
 Replay processing starts when the managed browser is cleaned up, usually during
 `kill()` or session cleanup. If the client times out, processing continues

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -44,7 +44,7 @@ class LifecycleEvent(TypedDict):
     sandbox: Literal["booting", "error", "ready", "running", "paused", "stopped"]
     agent: Literal["idle", "running", "interrupted", "error"]
     timestamp: str
-    browser: dict[str, str]  # optional, present after managed browser setup
+    browser: NotRequired[dict[str, str]]  # live_url/session_id/session_tag
     reason: Literal[
         "browser_ready",
         "sandbox_boot",

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -222,8 +222,8 @@ Browser automation URLs are parsed differently depending on which browser option
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` |
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` |
+| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
+| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | browser-use MCP | `browser='browser-use'` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
 
 ### Remote managed Actionbook and agent-browser
@@ -231,12 +231,12 @@ Browser automation URLs are parsed differently depending on which browser option
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
 ```python
-evolve.on(
-    'lifecycle',
-    lambda event: open_live_view(event['browser']['live_url'])
-    if event['reason'] == 'browser_ready'
-    else None,
-)
+def on_lifecycle(event):
+    if event['reason'] == 'browser_ready':
+        open_live_view(event['browser']['live_url'])
+        remember_session_id(event['browser']['session_id'])
+
+evolve.on('lifecycle', on_lifecycle)
 ```
 
 The same URL is also stored in trace metadata for replay or embedding after the trace exists:
@@ -245,11 +245,15 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 TraceMetadata = {
     "browser_provider": "actionbook | agent-browser",
     "browser_session_id": "...",
+    "dashboard_session_id": "...",
+    "browser_session_tag": "...",
     "browser_live_url": "...",
 }
 ```
 
-Use `event["browser"]["live_url"]` for immediate UI display, and `_meta["browser_live_url"]` from the session trace metadata for historical trace views.
+Use `event["browser"]["live_url"]` or `result.browser["live_url"]` for immediate
+UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
+`result.session_id` to `sessions().browser_replay()`.
 
 ---
 

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -7,6 +7,8 @@
 ```ts
 type AgentResponse = {
   sandboxId: string;
+  sessionId?: string;            // Dashboard session ID for traces/replays, when known
+  browser?: { liveUrl: string }; // Live browser URL, when remote browser is configured
   runId?: string;              // UUID for cost attribution (present for run(), undefined for executeCommand())
   exitCode: number;
   stdout: string;
@@ -707,17 +709,36 @@ import { sessions } from "@evolvingmachines/sdk";
 
 const session = sessions(); // uses EVOLVE_API_KEY
 
-const page = await session.list({ limit: 10, state: "ended", agent: "claude", tagPrefix: "my-proj", sort: "cost" });
+const page = await session.list({
+  limit: 10,
+  state: "ended",
+  agent: "claude",
+  tagPrefix: "my-proj",
+  sort: "cost",
+});
 const page2 = await session.list({ cursor: page.nextCursor });
 const info = await session.get(page.items[0].id);
 const events = await session.events(info.id, { since: 50 });
 const path = await session.download(info.id, { to: "./traces" });
+const replay = await session.browserReplay(info.id);
 ```
 
 - `list()` returns `SessionPage { items: SessionInfo[], nextCursor, hasMore }`
 - `get()` returns `SessionInfo` with `sandboxId`, `runtimeStatus`, `cost`, `stepCount`, `toolStats`, etc.
 - `events()` returns parsed JSONL objects; pass `since` for delta fetching
 - `download()` streams the raw `.jsonl` trace to disk and returns the file path
+- `browserReplay()` waits for the managed browser replay and returns `replayUrl` plus `downloadUrl`
+
+```ts
+const replay = await session.browserReplay(info.id, {
+  timeoutMs: 600_000, // optional; default 10 minutes
+  intervalMs: 5_000,  // optional; default 5 seconds
+});
+```
+
+Replay processing starts when the managed browser is cleaned up, usually during
+`kill()` or session cleanup. If the client times out, processing continues
+server-side; call `browserReplay()` again later to fetch the same replay.
 
 Gateway-only — requires `EVOLVE_API_KEY`. In BYOK/direct mode, traces remain
 available as local JSONL files in `~/.evolve-sdk/observability/sessions/`.

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -728,6 +728,9 @@ const replay = await session.browserReplay(info.id);
 - `events()` returns parsed JSONL objects; pass `since` for delta fetching
 - `download()` streams the raw `.jsonl` trace to disk and returns the file path
 - `browserReplay()` waits for the managed browser replay and returns `replayUrl` plus `downloadUrl`
+  - Use `replayUrl` in your UI for browser playback
+  - Use `downloadUrl` when users need the raw `.mp4` file
+  - `suggestedStartSeconds`, when present, is already applied to `replayUrl`; keep the raw download unchanged
 
 ```ts
 const replay = await session.browserReplay(info.id, {

--- a/docs/typescript/04-streaming.md
+++ b/docs/typescript/04-streaming.md
@@ -55,7 +55,11 @@ interface LifecycleEvent {
   agent: AgentRuntimeState;          // "idle" | "running" | "interrupted" | "error"
   timestamp: string;                 // ISO 8601
   reason: LifecycleReason;
-  browser?: { liveUrl: string };     // Present after managed browser setup
+  browser?: {
+    liveUrl: string;                 // Live browser view URL
+    sessionId?: string;              // Use with sessions().browserReplay()
+    sessionTag?: string;             // Use to correlate checkpoints
+  };
 }
 
 type LifecycleReason =
@@ -272,8 +276,8 @@ Browser automation URLs are parsed differently depending on which browser option
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed Actionbook | `.withBrowser()` or `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` |
-| Remote managed agent-browser | `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` |
+| Remote managed Actionbook | `.withBrowser()` or `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Remote managed agent-browser | `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
 | browser-use MCP | `.withBrowser("browser-use")` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
 
 ### Remote managed Actionbook and agent-browser
@@ -284,8 +288,12 @@ Managed browser sessions emit the live-view URL as soon as the browser is ready:
 evolve.on("lifecycle", (event) => {
   if (event.reason === "browser_ready") {
     openLiveView(event.browser!.liveUrl);
+    rememberSessionId(event.browser!.sessionId);
   }
 });
+
+const result = await evolve.run({ prompt: "QA the checkout flow" });
+openLiveView(result.browser?.liveUrl);
 ```
 
 The same URL is also stored in trace metadata for replay or embedding after the trace exists:
@@ -294,11 +302,15 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 type TraceMetadata = {
   browser_provider?: "actionbook" | "agent-browser";
   browser_session_id?: string;
+  dashboard_session_id?: string;
+  browser_session_tag?: string;
   browser_live_url?: string;
 };
 ```
 
-Use `event.browser.liveUrl` for immediate UI display, and `_meta.browser_live_url` from the session trace metadata for historical trace views.
+Use `event.browser.liveUrl` or `result.browser?.liveUrl` for immediate UI display.
+After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
+`sessions().browserReplay()`.
 
 ---
 

--- a/packages/sdk-py/bridge/src/adapter.ts
+++ b/packages/sdk-py/bridge/src/adapter.ts
@@ -738,6 +738,7 @@ export class EvolveAdapter {
       status: info.status,
       replay_url: info.replayUrl,
       download_url: info.downloadUrl,
+      suggested_start_seconds: info.suggestedStartSeconds,
       size_bytes: info.sizeBytes,
       ready_at: info.readyAt,
     };

--- a/packages/sdk-py/bridge/src/adapter.ts
+++ b/packages/sdk-py/bridge/src/adapter.ts
@@ -24,6 +24,7 @@ import {
   type StorageConfig,
   type SessionsClient as TSSessionsClient,
   type SessionInfo as TSSessionInfo,
+  type BrowserReplay as TSBrowserReplay,
 } from '../../../sdk-ts/dist/index.js';
 import { createE2BProvider } from '../../../e2b/dist/index.js';
 import { createDaytonaProvider } from '../../../daytona/dist/index.js';
@@ -66,9 +67,11 @@ import type {
   SessionsGetParams,
   SessionsEventsParams,
   SessionsDownloadParams,
+  SessionsBrowserReplayParams,
   SessionInfoResponse,
   SessionPageResponse,
   SessionEventsResponse,
+  BrowserReplayResponse,
   GetRunCostParams,
   RunCostResponse,
   SessionCostResponse,
@@ -287,6 +290,8 @@ export class EvolveAdapter {
         return this.sessionsEvents(params);
       case 'sessions_download':
         return this.sessionsDownload(params);
+      case 'sessions_browser_replay':
+        return this.sessionsBrowserReplay(params);
       // Multi-instance methods (for Swarm)
       case 'create_instance':
         return this.createInstance(params);
@@ -379,6 +384,8 @@ export class EvolveAdapter {
 
     return {
       sandbox_id: result.sandboxId,
+      session_id: result.sessionId,
+      browser: result.browser ? { live_url: result.browser.liveUrl } : undefined,
       run_id: result.runId,
       exit_code: result.exitCode,
       stdout: result.stdout,
@@ -397,6 +404,8 @@ export class EvolveAdapter {
 
     return {
       sandbox_id: result.sandboxId,
+      session_id: result.sessionId,
+      browser: result.browser ? { live_url: result.browser.liveUrl } : undefined,
       exit_code: result.exitCode,
       stdout: result.stdout,
       stderr: result.stderr,
@@ -478,7 +487,13 @@ export class EvolveAdapter {
       active_process_id: snapshot.activeProcessId,
       has_run: snapshot.hasRun,
       timestamp: snapshot.timestamp,
-      ...(snapshot.browser ? { browser: { live_url: snapshot.browser.liveUrl } } : {}),
+      ...(snapshot.browser ? {
+        browser: {
+          live_url: snapshot.browser.liveUrl,
+          session_id: snapshot.browser.sessionId,
+          session_tag: snapshot.browser.sessionTag,
+        },
+      } : {}),
     };
   }
 
@@ -690,6 +705,15 @@ export class EvolveAdapter {
     return { path };
   }
 
+  async sessionsBrowserReplay(params: SessionsBrowserReplayParams): Promise<BrowserReplayResponse> {
+    const client = this.getSessionsClient(params.sessions);
+    const replay = await client.browserReplay(params.id, {
+      timeoutMs: params.timeout_ms,
+      intervalMs: params.interval_ms,
+    });
+    return this.toBrowserReplayResponse(replay);
+  }
+
   /**
    * Convert TS SDK CheckpointInfo (camelCase) to bridge response (snake_case)
    */
@@ -705,6 +729,17 @@ export class EvolveAdapter {
       workspace_mode: info.workspaceMode,
       parent_id: info.parentId,
       comment: info.comment,
+    };
+  }
+
+  private toBrowserReplayResponse(info: TSBrowserReplay): BrowserReplayResponse {
+    return {
+      session_id: info.sessionId,
+      status: info.status,
+      replay_url: info.replayUrl,
+      download_url: info.downloadUrl,
+      size_bytes: info.sizeBytes,
+      ready_at: info.readyAt,
     };
   }
 
@@ -768,6 +803,8 @@ export class EvolveAdapter {
 
     return {
       sandbox_id: result.sandboxId,
+      session_id: result.sessionId,
+      browser: result.browser ? { live_url: result.browser.liveUrl } : undefined,
       run_id: result.runId,
       exit_code: result.exitCode,
       stdout: result.stdout,

--- a/packages/sdk-py/bridge/src/bridge.ts
+++ b/packages/sdk-py/bridge/src/bridge.ts
@@ -261,7 +261,13 @@ class Bridge {
         agent: event?.agent,
         timestamp: event?.timestamp,
         reason: event?.reason,
-        ...(event?.browser ? { browser: { live_url: event.browser.liveUrl } } : {}),
+        ...(event?.browser ? {
+          browser: {
+            live_url: event.browser.liveUrl,
+            session_id: event.browser.sessionId,
+            session_tag: event.browser.sessionTag,
+          },
+        } : {}),
       },
     }).catch(() => {});
   }

--- a/packages/sdk-py/bridge/src/types.ts
+++ b/packages/sdk-py/bridge/src/types.ts
@@ -419,6 +419,7 @@ export interface BrowserReplayResponse {
   status: 'ready';
   replay_url: string;
   download_url: string;
+  suggested_start_seconds?: number;
   size_bytes?: number;
   ready_at?: string;
 }

--- a/packages/sdk-py/bridge/src/types.ts
+++ b/packages/sdk-py/bridge/src/types.ts
@@ -225,6 +225,12 @@ export interface StatusResponse {
 
 export interface RunResponse {
   sandbox_id: string;
+  /** Dashboard session ID for trace/replay APIs, when known */
+  session_id?: string;
+  /** Managed browser runtime info, when a remote browser is configured */
+  browser?: {
+    live_url: string;
+  };
   /** Run ID for spend/cost attribution (present for run(), undefined for executeCommand()) */
   run_id?: string;
   exit_code: number;
@@ -263,6 +269,8 @@ export interface SessionStatusResponse {
   timestamp: string;
   browser?: {
     live_url: string;
+    session_id?: string;
+    session_tag?: string;
   };
 }
 
@@ -373,6 +381,13 @@ export interface SessionsDownloadParams {
   to?: string;
 }
 
+export interface SessionsBrowserReplayParams {
+  sessions?: SessionsConfigParams;
+  id: string;
+  timeout_ms?: number;
+  interval_ms?: number;
+}
+
 export interface SessionInfoResponse {
   id: string;
   tag: string;
@@ -397,6 +412,15 @@ export interface SessionPageResponse {
 
 export interface SessionEventsResponse {
   events: Record<string, any>[];
+}
+
+export interface BrowserReplayResponse {
+  session_id: string;
+  status: 'ready';
+  replay_url: string;
+  download_url: string;
+  size_bytes?: number;
+  ready_at?: string;
 }
 
 // =============================================================================

--- a/packages/sdk-py/evolve/__init__.py
+++ b/packages/sdk-py/evolve/__init__.py
@@ -33,6 +33,7 @@ from .results import (
     SessionInfo,
     SessionPage,
     SessionEvent,
+    BrowserReplay,
 )
 from .storage_client import StorageClient
 from .sessions_client import SessionsClient
@@ -132,7 +133,7 @@ def sessions(config: Optional[SessionsConfig] = None) -> SessionsClient:
         config: Optional API key / dashboard URL overrides
 
     Returns:
-        SessionsClient with list, get, events, download methods
+        SessionsClient with list, get, events, download, browser_replay methods
 
     Example:
         >>> from evolve import sessions
@@ -141,6 +142,7 @@ def sessions(config: Optional[SessionsConfig] = None) -> SessionsClient:
         ...     page = await client.list(limit=10, state='ended')
         ...     trace = await client.get(page.items[0].id)
         ...     await client.download(trace.id, to='./traces')
+        ...     await client.browser_replay(trace.id)
     """
     from .bridge import BridgeManager
     bridge = BridgeManager()
@@ -222,6 +224,7 @@ __all__ = [
     'SessionInfo',
     'SessionPage',
     'SessionEvent',
+    'BrowserReplay',
 
     # Standalone clients
     'StorageClient',

--- a/packages/sdk-py/evolve/agent.py
+++ b/packages/sdk-py/evolve/agent.py
@@ -305,6 +305,8 @@ class Evolve:
             exit_code=response['exit_code'],
             stdout=response['stdout'],
             stderr=response['stderr'],
+            session_id=response.get('session_id'),
+            browser=response.get('browser'),
             run_id=response.get('run_id'),
             checkpoint=_parse_checkpoint(response.get('checkpoint')),
         )
@@ -347,6 +349,8 @@ class Evolve:
             exit_code=response['exit_code'],
             stdout=response['stdout'],
             stderr=response['stderr'],
+            session_id=response.get('session_id'),
+            browser=response.get('browser'),
         )
 
     async def upload_context(

--- a/packages/sdk-py/evolve/results.py
+++ b/packages/sdk-py/evolve/results.py
@@ -43,6 +43,8 @@ class AgentResponse:
 
     Attributes:
         sandbox_id: Sandbox ID
+        session_id: Dashboard session ID for trace/replay APIs, when known
+        browser: Managed browser runtime info, when a remote browser is configured
         run_id: Run ID for spend/cost attribution (present for run(), None for execute_command())
         exit_code: Command exit code
         stdout: Standard output
@@ -53,6 +55,8 @@ class AgentResponse:
     exit_code: int
     stdout: str
     stderr: str
+    session_id: Optional[str] = None
+    browser: Optional[Dict[str, str]] = None
     run_id: Optional[str] = None
     checkpoint: Optional[CheckpointInfo] = None
 
@@ -175,3 +179,14 @@ class SessionPage:
     items: List[SessionInfo]
     next_cursor: Optional[str]
     has_more: bool
+
+
+@dataclass
+class BrowserReplay:
+    """Browser replay metadata and Dashboard-owned access URLs."""
+    session_id: str
+    status: Literal['ready']
+    replay_url: str
+    download_url: str
+    size_bytes: Optional[int] = None
+    ready_at: Optional[str] = None

--- a/packages/sdk-py/evolve/results.py
+++ b/packages/sdk-py/evolve/results.py
@@ -188,5 +188,6 @@ class BrowserReplay:
     status: Literal['ready']
     replay_url: str
     download_url: str
+    suggested_start_seconds: Optional[float] = None
     size_bytes: Optional[int] = None
     ready_at: Optional[str] = None

--- a/packages/sdk-py/evolve/sessions_client.py
+++ b/packages/sdk-py/evolve/sessions_client.py
@@ -3,8 +3,8 @@
 import asyncio
 from typing import Any, Dict, List, Literal, Optional
 
-from .results import SessionEvent, SessionInfo, SessionPage
-from .utils import _filter_none, _require_session_info
+from .results import BrowserReplay, SessionEvent, SessionInfo, SessionPage
+from .utils import _filter_none, _require_browser_replay, _require_session_info
 
 
 class SessionsClient:
@@ -108,6 +108,29 @@ class SessionsClient:
         await self._ensure_ready()
         response = await self._bridge.call('sessions_download', self._build_params(id=id, to=to))
         return response['path']
+
+    async def browser_replay(
+        self,
+        id: str,
+        *,
+        timeout_ms: Optional[int] = None,
+        interval_ms: Optional[int] = None,
+    ) -> BrowserReplay:
+        """Wait for browser replay readiness and return replay/download URLs."""
+        await self._ensure_ready()
+        effective_timeout_ms = timeout_ms if timeout_ms is not None else 600_000
+        effective_interval_ms = interval_ms if interval_ms is not None else 5_000
+        if effective_timeout_ms <= 0:
+            raise ValueError('timeout_ms must be positive')
+        if effective_interval_ms <= 0:
+            raise ValueError('interval_ms must be positive')
+        rpc_timeout_s = max(1.0, (effective_timeout_ms / 1000) + 30)
+        response = await self._bridge.call(
+            'sessions_browser_replay',
+            self._build_params(id=id, timeout_ms=timeout_ms, interval_ms=interval_ms),
+            timeout_s=rpc_timeout_s,
+        )
+        return _require_browser_replay(response)
 
     async def close(self) -> None:
         """Close the sessions client and release resources."""

--- a/packages/sdk-py/evolve/utils.py
+++ b/packages/sdk-py/evolve/utils.py
@@ -96,6 +96,29 @@ def _require_session_info(data: Optional[Dict[str, Any]]) -> 'SessionInfo':
     return result
 
 
+def _parse_browser_replay(data: Optional[Dict[str, Any]]) -> Optional['BrowserReplay']:
+    """Parse browser replay dict from bridge response into BrowserReplay."""
+    if not data:
+        return None
+    from .results import BrowserReplay  # noqa: E402
+    return BrowserReplay(
+        session_id=data['session_id'],
+        status=data['status'],
+        replay_url=data['replay_url'],
+        download_url=data['download_url'],
+        size_bytes=data.get('size_bytes'),
+        ready_at=data.get('ready_at'),
+    )
+
+
+def _require_browser_replay(data: Optional[Dict[str, Any]]) -> 'BrowserReplay':
+    """Like :func:`_parse_browser_replay` but raises on falsy *data*."""
+    result = _parse_browser_replay(data)
+    if result is None:
+        raise ValueError(f"Expected browser replay data, got: {data!r}")
+    return result
+
+
 def _encode_files_for_transport(
     files: Dict[str, Union[str, bytes]]
 ) -> Dict[str, Dict[str, str]]:

--- a/packages/sdk-py/evolve/utils.py
+++ b/packages/sdk-py/evolve/utils.py
@@ -106,6 +106,7 @@ def _parse_browser_replay(data: Optional[Dict[str, Any]]) -> Optional['BrowserRe
         status=data['status'],
         replay_url=data['replay_url'],
         download_url=data['download_url'],
+        suggested_start_seconds=data.get('suggested_start_seconds'),
         size_bytes=data.get('size_bytes'),
         ready_at=data.get('ready_at'),
     )

--- a/packages/sdk-py/tests/unit/test_sessions_client_api.py
+++ b/packages/sdk-py/tests/unit/test_sessions_client_api.py
@@ -110,6 +110,7 @@ class MockBridgeManager:
                 'status': 'ready',
                 'replay_url': 'https://dashboard.test/replay',
                 'download_url': 'https://dashboard.test/download',
+                'suggested_start_seconds': 20,
                 'size_bytes': 1234,
                 'ready_at': '2026-05-24T00:00:00.000Z',
             }
@@ -286,6 +287,7 @@ class TestSessionsClientBrowserReplay:
         assert replay.status == 'ready'
         assert replay.replay_url.endswith('/replay')
         assert replay.download_url.endswith('/download')
+        assert replay.suggested_start_seconds == 20
         assert replay.size_bytes == 1234
 
     @pytest.mark.asyncio

--- a/packages/sdk-py/tests/unit/test_sessions_client_api.py
+++ b/packages/sdk-py/tests/unit/test_sessions_client_api.py
@@ -13,7 +13,7 @@ Coverage:
 import pytest
 from unittest.mock import patch
 
-from evolve import SessionInfo, SessionPage, SessionsClient, SessionsConfig
+from evolve import BrowserReplay, SessionInfo, SessionPage, SessionsClient, SessionsConfig
 from evolve import sessions as sessions_factory
 
 
@@ -103,6 +103,16 @@ class MockBridgeManager:
 
         if method == 'sessions_download':
             return {'path': '/tmp/traces/demo-a.jsonl'}
+
+        if method == 'sessions_browser_replay':
+            return {
+                'session_id': params['id'],
+                'status': 'ready',
+                'replay_url': 'https://dashboard.test/replay',
+                'download_url': 'https://dashboard.test/download',
+                'size_bytes': 1234,
+                'ready_at': '2026-05-24T00:00:00.000Z',
+            }
 
         return {'status': 'ok'}
 
@@ -262,6 +272,56 @@ class TestSessionsClientDownload:
         params = calls[0][1]
         assert params['id'] == 'sess-1'
         assert params['to'] == '/output/traces'
+
+
+class TestSessionsClientBrowserReplay:
+    @pytest.mark.asyncio
+    async def test_returns_browser_replay(self):
+        client, _ = _make_client()
+
+        replay = await client.browser_replay('sess-1')
+
+        assert isinstance(replay, BrowserReplay)
+        assert replay.session_id == 'sess-1'
+        assert replay.status == 'ready'
+        assert replay.replay_url.endswith('/replay')
+        assert replay.download_url.endswith('/download')
+        assert replay.size_bytes == 1234
+
+    @pytest.mark.asyncio
+    async def test_passes_wait_options(self):
+        client, bridge = _make_client()
+
+        await client.browser_replay('sess-1', timeout_ms=600000, interval_ms=5000)
+
+        calls = _get_calls(bridge, 'sessions_browser_replay')
+        assert len(calls) == 1
+        params = calls[0][1]
+        assert params['id'] == 'sess-1'
+        assert params['timeout_ms'] == 600000
+        assert params['interval_ms'] == 5000
+        assert calls[0][2] == 630.0
+
+    @pytest.mark.asyncio
+    async def test_bridge_timeout_covers_default_wait(self):
+        client, bridge = _make_client()
+
+        await client.browser_replay('sess-1')
+
+        calls = _get_calls(bridge, 'sessions_browser_replay')
+        assert calls[0][2] == 630.0
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_polling_options(self):
+        client, bridge = _make_client()
+
+        with pytest.raises(ValueError, match='timeout_ms must be positive'):
+            await client.browser_replay('sess-1', timeout_ms=0)
+
+        with pytest.raises(ValueError, match='interval_ms must be positive'):
+            await client.browser_replay('sess-1', interval_ms=-1)
+
+        assert _get_calls(bridge, 'sessions_browser_replay') == []
 
 
 class TestStandaloneSessionsFactory:

--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -242,6 +242,15 @@ export class Agent {
 
   private browserRuntimeInfo(): BrowserRuntimeInfo | undefined {
     if (!this.managedBrowserSession) return undefined;
+    return {
+      liveUrl: this.managedBrowserSession.liveUrl,
+      sessionId: this.managedBrowserSession.sessionId,
+      sessionTag: this.managedBrowserSession.sessionTag,
+    };
+  }
+
+  private browserResponseInfo(): Pick<BrowserRuntimeInfo, "liveUrl"> | undefined {
+    if (!this.managedBrowserSession) return undefined;
     return { liveUrl: this.managedBrowserSession.liveUrl };
   }
 
@@ -1087,6 +1096,8 @@ export class Agent {
           ...(this.managedBrowserSession && this.options.managedBrowser ? {
             browser_provider: this.options.managedBrowser.provider,
             browser_session_id: this.managedBrowserSession.id,
+            dashboard_session_id: this.managedBrowserSession.sessionId,
+            browser_session_tag: this.managedBrowserSession.sessionTag,
             browser_live_url: this.managedBrowserSession.liveUrl,
           } : {}),
         },
@@ -1203,6 +1214,8 @@ export class Agent {
       this.watchBackgroundOperation(opId, "run", handle, callbacks, sandbox);
       return {
         sandboxId: sandbox.sandboxId,
+        sessionId: this.managedBrowserSession?.sessionId,
+        browser: this.browserResponseInfo(),
         runId,
         exitCode: 0,
         stdout: `Background process started with ID ${handle.processId}`,
@@ -1289,6 +1302,8 @@ export class Agent {
 
     return {
       sandboxId: sandbox.sandboxId,
+      sessionId: this.managedBrowserSession?.sessionId,
+      browser: this.browserResponseInfo(),
       runId,
       exitCode: result.exitCode,
       stdout: result.stdout,
@@ -1346,6 +1361,8 @@ export class Agent {
       this.watchBackgroundOperation(opId, "command", handle, callbacks);
       return {
         sandboxId: sandbox.sandboxId,
+        sessionId: this.managedBrowserSession?.sessionId,
+        browser: this.browserResponseInfo(),
         exitCode: 0,
         stdout: `Background process started with ID ${handle.processId}`,
         stderr: "",
@@ -1372,6 +1389,8 @@ export class Agent {
 
     return {
       sandboxId: sandbox.sandboxId,
+      sessionId: this.managedBrowserSession?.sessionId,
+      browser: this.browserResponseInfo(),
       exitCode: result.exitCode,
       // Prefer streaming-collected output; fall back to wait() result
       // (handles race condition where command completes before stream connects)
@@ -1684,17 +1703,29 @@ export class Agent {
   async kill(callbacks?: StreamCallbacks): Promise<void> {
     await this.rotateSession();
 
-    // Interrupt active operation before killing sandbox
-    if (this.activeCommand) {
-      await this.interrupt(callbacks);
+    let killError: unknown;
+
+    try {
+      // Interrupt active operation before killing sandbox
+      if (this.activeCommand) {
+        await this.interrupt(callbacks);
+      }
+
+      // Kill sandbox (terminates all processes inside)
+      if (this.sandbox) {
+        await this.sandbox.kill();
+        this.sandbox = undefined;
+      }
+    } catch (error) {
+      killError = error;
+    } finally {
+      await this.closeManagedBrowserSession();
     }
 
-    // Kill sandbox (terminates all processes inside)
-    if (this.sandbox) {
-      await this.sandbox.kill();
-      this.sandbox = undefined;
+    if (killError) {
+      throw killError;
     }
-    await this.closeManagedBrowserSession();
+
     // Session is no longer valid after sandbox termination.
     this.options.sandboxId = undefined;
     this.interruptedOperations.clear();

--- a/packages/sdk-ts/src/browser.ts
+++ b/packages/sdk-ts/src/browser.ts
@@ -21,10 +21,6 @@ const AGENT_BROWSER_CONFIG_PATH = `${AGENT_BROWSER_CONFIG_DIR}/config.json`;
 const ACTIONBOOK_CONFIG_DIR = "/home/user/.actionbook";
 const ACTIONBOOK_CONFIG_PATH = `${ACTIONBOOK_CONFIG_DIR}/config.toml`;
 
-// Dashboard create requests keep the existing managed-browser contract; the
-// SDK-level automation provider is tracked separately on ManagedBrowserConfig.
-const MANAGED_BROWSER_CREATE_PROVIDER = "actionbook";
-
 export interface NormalizedBrowserConfig {
   provider: "browser-use" | ManagedBrowserProvider;
   managed: boolean;
@@ -38,6 +34,8 @@ export interface ManagedBrowserConfig {
 
 export interface ManagedBrowserSession {
   id: string;
+  sessionId?: string;
+  sessionTag?: string;
   cdpUrl: string;
   liveUrl: string;
 }
@@ -129,7 +127,6 @@ export async function createManagedBrowserSession(
       accept: "application/json",
     },
     body: JSON.stringify({
-      provider: MANAGED_BROWSER_CREATE_PROVIDER,
       sessionTag,
       options: { remote: true },
     }),
@@ -141,12 +138,14 @@ export async function createManagedBrowserSession(
   }
 
   const data = await response.json() as Partial<ManagedBrowserSession>;
-  if (!data.id || !data.cdpUrl || !data.liveUrl) {
-    throw new Error("Managed browser session response missing id, cdpUrl, or liveUrl");
+  if (!data.id || !data.sessionId || !data.cdpUrl || !data.liveUrl) {
+    throw new Error("Managed browser session response missing id, sessionId, cdpUrl, or liveUrl");
   }
 
   return {
     id: data.id,
+    sessionId: data.sessionId,
+    sessionTag: data.sessionTag,
     cdpUrl: data.cdpUrl,
     liveUrl: data.liveUrl,
   };
@@ -162,7 +161,7 @@ export async function stopManagedBrowserSession(
       Authorization: `Bearer ${config.apiKey}`,
       accept: "application/json",
     },
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(5_000),
   });
 
   if (!response.ok && response.status !== 404) {

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -267,4 +267,6 @@ export {
   type SessionEvent,
   type GetEventsOptions,
   type DownloadSessionOptions,
+  type BrowserReplay,
+  type BrowserReplayOptions,
 } from "./sessions";

--- a/packages/sdk-ts/src/observability/session-logger.ts
+++ b/packages/sdk-ts/src/observability/session-logger.ts
@@ -15,12 +15,12 @@ import { homedir } from "os";
 import { randomBytes } from "crypto";
 import type { AgentType } from "../types";
 import {
-  DEFAULT_DASHBOARD_URL,
   SESSION_LOGS_DIR,
   DASHBOARD_BATCH_SIZE,
   DASHBOARD_FLUSH_INTERVAL_MS,
   DASHBOARD_MAX_RETRIES,
   DASHBOARD_RETRY_DELAY_MS,
+  getDashboardUrl,
 } from "../constants";
 import { createAgentParser, type AgentParser, type OutputEvent } from "../parsers";
 
@@ -88,7 +88,7 @@ export class SessionLogger {
     this.model = config.model;
     this.sandboxId = config.sandboxId;
     this.apiKey = config.apiKey;
-    this.dashboardUrl = DEFAULT_DASHBOARD_URL;
+    this.dashboardUrl = getDashboardUrl();
     this.observability = config.observability;
 
     // Use provided tag or generate one
@@ -371,11 +371,12 @@ export class SessionLogger {
   // ===========================================================================
 
   private validateConfig(config: SessionLoggerConfig): void {
+    const dashboardUrl = getDashboardUrl();
     if (
       config.apiKey &&
-      !DEFAULT_DASHBOARD_URL.startsWith("https://") &&
-      !DEFAULT_DASHBOARD_URL.includes("localhost") &&
-      !DEFAULT_DASHBOARD_URL.includes("127.0.0.1")
+      !dashboardUrl.startsWith("https://") &&
+      !dashboardUrl.includes("localhost") &&
+      !dashboardUrl.includes("127.0.0.1")
     ) {
       throw new Error("Dashboard URL must use HTTPS when API key is provided");
     }

--- a/packages/sdk-ts/src/sessions/index.ts
+++ b/packages/sdk-ts/src/sessions/index.ts
@@ -113,6 +113,7 @@ export function sessions(config?: SessionsConfig): SessionsClient {
       status: "ready",
       replayUrl: raw.replayUrl,
       downloadUrl: raw.downloadUrl,
+      suggestedStartSeconds: typeof raw.suggestedStartSeconds === "number" ? raw.suggestedStartSeconds : undefined,
       sizeBytes: typeof raw.sizeBytes === "number" ? raw.sizeBytes : undefined,
       readyAt: typeof raw.readyAt === "string" ? raw.readyAt : undefined,
     };

--- a/packages/sdk-ts/src/sessions/index.ts
+++ b/packages/sdk-ts/src/sessions/index.ts
@@ -13,6 +13,8 @@ import type {
   SessionEvent,
   GetEventsOptions,
   DownloadSessionOptions,
+  BrowserReplay,
+  BrowserReplayOptions,
 } from "./types";
 
 export type {
@@ -24,7 +26,20 @@ export type {
   SessionEvent,
   GetEventsOptions,
   DownloadSessionOptions,
+  BrowserReplay,
+  BrowserReplayOptions,
 } from "./types";
+
+const DEFAULT_BROWSER_REPLAY_TIMEOUT_MS = 600_000;
+const DEFAULT_BROWSER_REPLAY_INTERVAL_MS = 5_000;
+
+function positiveNumber(name: string, value: number | undefined, fallback: number): number {
+  const resolved = value ?? fallback;
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return resolved;
+}
 
 /**
  * Create a SessionsClient for querying past sessions and downloading traces.
@@ -85,6 +100,25 @@ export function sessions(config?: SessionsConfig): SessionsClient {
       toolStats: (raw.toolStats as Record<string, number>) || null,
     };
   }
+
+  function mapBrowserReplay(raw: Record<string, unknown>, id: string): BrowserReplay {
+    if (raw.status !== "ready") {
+      throw new Error(`Browser replay is not ready (status: ${String(raw.status || "unknown")})`);
+    }
+    if (typeof raw.replayUrl !== "string" || typeof raw.downloadUrl !== "string") {
+      throw new Error("Browser replay response missing replayUrl or downloadUrl");
+    }
+    return {
+      sessionId: (raw.sessionId as string) || id,
+      status: "ready",
+      replayUrl: raw.replayUrl,
+      downloadUrl: raw.downloadUrl,
+      sizeBytes: typeof raw.sizeBytes === "number" ? raw.sizeBytes : undefined,
+      readyAt: typeof raw.readyAt === "string" ? raw.readyAt : undefined,
+    };
+  }
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
   return {
     async list(options?: ListSessionsOptions): Promise<SessionPage> {
@@ -177,6 +211,61 @@ export function sessions(config?: SessionsConfig): SessionsClient {
       const nodeStream = Readable.fromWeb(res.body as import("stream/web").ReadableStream);
       await pipeline(nodeStream, createWriteStream(filePath));
       return filePath;
+    },
+
+    async browserReplay(
+      id: string,
+      options?: BrowserReplayOptions
+    ): Promise<BrowserReplay> {
+      const timeoutMs = positiveNumber("timeoutMs", options?.timeoutMs, DEFAULT_BROWSER_REPLAY_TIMEOUT_MS);
+      const intervalMs = positiveNumber("intervalMs", options?.intervalMs, DEFAULT_BROWSER_REPLAY_INTERVAL_MS);
+      const deadline = Date.now() + timeoutMs;
+      const path = `/api/sessions/${encodeURIComponent(id)}/browser-replay`;
+
+      while (true) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error(`Browser replay timed out after ${timeoutMs}ms`);
+        }
+
+        let res: Response;
+        try {
+          res = await fetch(`${dashboardUrl}${path}`, {
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              accept: "application/json",
+            },
+            signal: AbortSignal.timeout(Math.max(1, remainingMs)),
+          });
+        } catch (error) {
+          const name = (error as { name?: string }).name;
+          if (name === "AbortError" || name === "TimeoutError") {
+            throw new Error(`Browser replay timed out after ${timeoutMs}ms`);
+          }
+          throw error;
+        }
+
+        let data: Record<string, unknown> = {};
+        if (!res.ok) {
+          const text = await res.text().catch(() => "");
+          throw new Error(
+            `Dashboard API error (${res.status}): ${text || res.statusText}`
+          );
+        } else {
+          data = await res.json() as Record<string, unknown>;
+        }
+
+        if (data.status === "ready") return mapBrowserReplay(data, id);
+        if (data.status === "failed") {
+          const error = typeof data.error === "string" ? data.error : "unknown error";
+          throw new Error(`Browser replay failed: ${error}`);
+        }
+
+        if (Date.now() >= deadline) {
+          throw new Error(`Browser replay timed out after ${timeoutMs}ms`);
+        }
+        await sleep(Math.min(intervalMs, Math.max(0, deadline - Date.now())));
+      }
     },
   };
 }

--- a/packages/sdk-ts/src/sessions/types.ts
+++ b/packages/sdk-ts/src/sessions/types.ts
@@ -50,6 +50,24 @@ export interface DownloadSessionOptions {
   to?: string;
 }
 
+/** Options for waiting on browser replay readiness */
+export interface BrowserReplayOptions {
+  /** Max time to wait for replay readiness (default: 600000ms) */
+  timeoutMs?: number;
+  /** Poll interval while replay is processing (default: 5000ms) */
+  intervalMs?: number;
+}
+
+/** Browser replay metadata and access URLs */
+export interface BrowserReplay {
+  sessionId: string;
+  status: "ready";
+  replayUrl: string;
+  downloadUrl: string;
+  sizeBytes?: number;
+  readyAt?: string;
+}
+
 /** Options for fetching parsed events */
 export interface GetEventsOptions {
   /** Return only events after this index (delta fetching) */
@@ -74,4 +92,6 @@ export interface SessionsClient {
   events(id: string, options?: GetEventsOptions): Promise<SessionEvent[]>;
   /** Download raw JSONL trace file. Returns the file path. */
   download(id: string, options?: DownloadSessionOptions): Promise<string>;
+  /** Wait for browser replay and return Dashboard-owned replay/download URLs. */
+  browserReplay(id: string, options?: BrowserReplayOptions): Promise<BrowserReplay>;
 }

--- a/packages/sdk-ts/src/sessions/types.ts
+++ b/packages/sdk-ts/src/sessions/types.ts
@@ -64,6 +64,7 @@ export interface BrowserReplay {
   status: "ready";
   replayUrl: string;
   downloadUrl: string;
+  suggestedStartSeconds?: number;
   sizeBytes?: number;
   readyAt?: string;
 }

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -495,6 +495,10 @@ export type LifecycleReason =
 /** Browser runtime info exposed to host applications. */
 export interface BrowserRuntimeInfo {
   liveUrl: string;
+  /** Dashboard session ID for trace/replay APIs, present for managed browsers. */
+  sessionId?: string;
+  /** Session tag for checkpoint correlation, present for managed browsers. */
+  sessionTag?: string;
 }
 
 /** Lifecycle event emitted by the runtime */
@@ -526,6 +530,12 @@ export interface SessionStatus {
 export interface AgentResponse {
   /** Sandbox ID for session management */
   sandboxId: string;
+
+  /** Dashboard session ID for trace/replay APIs, present in gateway mode when known. */
+  sessionId?: string;
+
+  /** Managed browser runtime info, present when a remote browser is configured. */
+  browser?: Pick<BrowserRuntimeInfo, "liveUrl">;
 
   /** Run ID for spend/cost attribution (present for run(), undefined for executeCommand()) */
   runId?: string;

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -274,7 +274,7 @@ async function testManagedActionbookConfigUsesProxyOnly(): Promise<void> {
     config?.includes('cdp_endpoint = "wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token"') ?? false,
     "Actionbook config receives proxied CDP endpoint"
   );
-  assert(!config?.toLowerCase().includes("driver"), "Actionbook config does not expose provider name");
+  assert(!config?.includes("_managedTransport"), "Actionbook config does not expose transport selector");
 }
 
 async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
@@ -326,7 +326,7 @@ async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
     config?.includes("wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token") ?? false,
     "agent-browser config receives proxied CDP endpoint"
   );
-  assert(!config?.toLowerCase().includes("driver"), "agent-browser config does not expose provider name");
+  assert(!config?.includes("_managedTransport"), "agent-browser config does not expose transport selector");
 }
 
 async function main(): Promise<void> {

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -256,7 +256,7 @@ async function testManagedBrowserLifecycle(): Promise<void> {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     if (url === "https://dashboard.test/api/browser-sessions" && init?.method === "POST") {
-      return new Response(JSON.stringify({ id: "browser_123", cdpUrl, liveUrl }), {
+      return new Response(JSON.stringify({ id: "browser_123", sessionId: "session_db_123", sessionTag: "evolve-browser", cdpUrl, liveUrl }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
@@ -286,6 +286,8 @@ async function testManagedBrowserLifecycle(): Promise<void> {
   try {
     const result = await kit.run({ prompt: "test prompt", timeoutMs: 10_000 });
     assertEqual(result.exitCode, 0, "run() with managed browser returns success");
+    assertEqual(result.sessionId, "session_db_123", "run() exposes Dashboard session id");
+    assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed browser live URL");
     assert(!JSON.stringify(provider.createOptions?.envs).includes("proxy-token"), "sandbox env does not include CDP token");
 
     const config = sandbox.files.writes.get("/home/user/.actionbook/config.toml");
@@ -297,6 +299,7 @@ async function testManagedBrowserLifecycle(): Promise<void> {
 
     const browserReady = events.find((event) => event.reason === "browser_ready");
     assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes live URL immediately");
+    assertEqual(browserReady?.browser?.sessionId, "session_db_123", "browser_ready exposes Dashboard session id");
     assert(
       events.findIndex((event) => event.reason === "browser_ready") < events.findIndex((event) => event.reason === "sandbox_ready"),
       "browser_ready is emitted before sandbox ready"
@@ -329,7 +332,7 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
     const url = String(input);
     if (url === "https://dashboard.test/api/browser-sessions" && init?.method === "POST") {
       createBody = JSON.parse(String(init.body));
-      return new Response(JSON.stringify({ id: "browser_456", cdpUrl, liveUrl }), {
+      return new Response(JSON.stringify({ id: "browser_456", sessionId: "session_db_456", sessionTag: "evolve-agent-browser", cdpUrl, liveUrl }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
@@ -359,8 +362,12 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
   try {
     const result = await kit.run({ prompt: "test prompt", timeoutMs: 10_000 });
     assertEqual(result.exitCode, 0, "run() with managed agent-browser returns success");
-    assertEqual(createBody.provider, "actionbook", "managed browser create contract is preserved");
+    assert(!("provider" in createBody), "managed browser create does not expose automation provider");
     assertEqual(createBody.options?.remote, true, "managed browser create uses remote option");
+    assert(!("_managedTransport" in createBody.options), "managed browser create does not expose transport selector");
+    assert(!JSON.stringify(createBody).toLowerCase().includes("driver"), "managed browser create does not expose transport vendor");
+    assert(!JSON.stringify(createBody).toLowerCase().includes("browser-use"), "managed browser create does not expose transport vendor");
+    assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed agent-browser live URL");
     assertEqual(
       provider.createOptions?.envs?.AGENT_BROWSER_CONFIG,
       "/home/user/.agent-browser/config.json",
@@ -378,6 +385,7 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
 
     const browserReady = events.find((event) => event.reason === "browser_ready");
     assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes agent-browser live URL");
+    assertEqual(browserReady?.browser?.sessionId, "session_db_456", "browser_ready exposes agent-browser Dashboard session id");
   } finally {
     await kit.kill();
     globalThis.fetch = previousFetch;

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -295,7 +295,7 @@ async function testManagedBrowserLifecycle(): Promise<void> {
     assert(config !== undefined, "Actionbook config file written");
     assert(config?.includes('mode = "cloud"') ?? false, "Actionbook config sets cloud mode");
     assert(config?.includes(cdpUrl) ?? false, "Actionbook config uses proxied CDP endpoint");
-    assert(!config?.toLowerCase().includes("driver"), "Actionbook config does not expose provider name");
+    assert(!config?.includes("_managedTransport"), "Actionbook config does not expose transport selector");
 
     const browserReady = events.find((event) => event.reason === "browser_ready");
     assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes live URL immediately");
@@ -365,8 +365,6 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
     assert(!("provider" in createBody), "managed browser create does not expose automation provider");
     assertEqual(createBody.options?.remote, true, "managed browser create uses remote option");
     assert(!("_managedTransport" in createBody.options), "managed browser create does not expose transport selector");
-    assert(!JSON.stringify(createBody).toLowerCase().includes("driver"), "managed browser create does not expose transport vendor");
-    assert(!JSON.stringify(createBody).toLowerCase().includes("browser-use"), "managed browser create does not expose transport vendor");
     assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed agent-browser live URL");
     assertEqual(
       provider.createOptions?.envs?.AGENT_BROWSER_CONFIG,
@@ -381,7 +379,7 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
     const parsedConfig = JSON.parse(config!);
     assert(!("session" in parsedConfig), "agent-browser config leaves session default to agent-browser");
     assert(config?.includes(cdpUrl) ?? false, "agent-browser config uses proxied CDP endpoint");
-    assert(!config?.toLowerCase().includes("driver"), "agent-browser config does not expose provider name");
+    assert(!config?.includes("_managedTransport"), "agent-browser config does not expose transport selector");
 
     const browserReady = events.find((event) => event.reason === "browser_ready");
     assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes agent-browser live URL");

--- a/packages/sdk-ts/tests/unit/sessions-client.test.ts
+++ b/packages/sdk-ts/tests/unit/sessions-client.test.ts
@@ -465,6 +465,7 @@ async function testBrowserReplayReady() {
         status: "ready",
         replayUrl: "https://dashboard.test/sessions/sess-browser/browser-replay/replay_1?token=t",
         downloadUrl: "https://dashboard.test/api/sessions/sess-browser/browser-replay/replay_1/download?token=t",
+        suggestedStartSeconds: 20,
         sizeBytes: 1234,
         readyAt: "2026-05-24T00:00:00.000Z",
       },
@@ -476,6 +477,7 @@ async function testBrowserReplayReady() {
     assertEqual(replay.sessionId, "sess-browser", "maps sessionId");
     assertEqual(replay.status, "ready", "maps status");
     assertEqual(replay.sizeBytes, 1234, "maps sizeBytes");
+    assertEqual(replay.suggestedStartSeconds, 20, "maps suggestedStartSeconds");
     assert(replay.replayUrl.includes("/browser-replay/"), "maps replayUrl");
     assert(replay.downloadUrl.includes("/download"), "maps downloadUrl");
     assert(fetchCalls[0]?.init?.signal instanceof AbortSignal, "sets fetch timeout signal");

--- a/packages/sdk-ts/tests/unit/sessions-client.test.ts
+++ b/packages/sdk-ts/tests/unit/sessions-client.test.ts
@@ -139,6 +139,7 @@ async function testAcceptsConfigApiKey() {
     assert(typeof s.get === "function", "has get method");
     assert(typeof s.events === "function", "has events method");
     assert(typeof s.download === "function", "has download method");
+    assert(typeof s.browserReplay === "function", "has browserReplay method");
   } finally {
     restoreFetch();
   }
@@ -453,6 +454,148 @@ async function testDownloadNoBody() {
   }
 }
 
+async function testBrowserReplayReady() {
+  console.log("\n--- browserReplay() returns ready replay URLs ---");
+  installMockFetch();
+  try {
+    setMockResponse("/api/sessions/sess-browser/browser-replay", {
+      status: 200,
+      body: {
+        sessionId: "sess-browser",
+        status: "ready",
+        replayUrl: "https://dashboard.test/sessions/sess-browser/browser-replay/replay_1?token=t",
+        downloadUrl: "https://dashboard.test/api/sessions/sess-browser/browser-replay/replay_1/download?token=t",
+        sizeBytes: 1234,
+        readyAt: "2026-05-24T00:00:00.000Z",
+      },
+    });
+
+    const s = sessions({ apiKey: "test-key", dashboardUrl: "http://localhost:3000" });
+    const replay = await s.browserReplay("sess-browser", { timeoutMs: 100, intervalMs: 1 });
+
+    assertEqual(replay.sessionId, "sess-browser", "maps sessionId");
+    assertEqual(replay.status, "ready", "maps status");
+    assertEqual(replay.sizeBytes, 1234, "maps sizeBytes");
+    assert(replay.replayUrl.includes("/browser-replay/"), "maps replayUrl");
+    assert(replay.downloadUrl.includes("/download"), "maps downloadUrl");
+    assert(fetchCalls[0]?.init?.signal instanceof AbortSignal, "sets fetch timeout signal");
+  } finally {
+    restoreFetch();
+  }
+}
+
+async function testBrowserReplayPollsUntilReady() {
+  console.log("\n--- browserReplay() polls processing until ready ---");
+  installMockFetch();
+  try {
+    let calls = 0;
+    (globalThis as any).fetch = async (url: string | URL, init?: RequestInit) => {
+      fetchCalls.push({ url: url.toString(), init });
+      calls++;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => calls === 1
+          ? { sessionId: "sess-browser", status: "processing" }
+          : {
+              sessionId: "sess-browser",
+              status: "ready",
+              replayUrl: "https://dashboard.test/replay",
+              downloadUrl: "https://dashboard.test/download",
+            },
+        text: async () => "{}",
+        body: null,
+      } as unknown as Response;
+    };
+
+    const s = sessions({ apiKey: "test-key", dashboardUrl: "http://localhost:3000" });
+    const replay = await s.browserReplay("sess-browser", { timeoutMs: 100, intervalMs: 1 });
+
+    assertEqual(calls, 2, "polls twice");
+    assertEqual(replay.status, "ready", "returns ready replay");
+  } finally {
+    restoreFetch();
+  }
+}
+
+async function testBrowserReplayThrowsOn404() {
+  console.log("\n--- browserReplay() throws on 404 ---");
+  installMockFetch();
+  try {
+    setMockResponse("/api/sessions/sess-missing/browser-replay", {
+      status: 404,
+      body: { error: "Browser replay not found" },
+    });
+
+    const s = sessions({ apiKey: "test-key", dashboardUrl: "http://localhost:3000" });
+    let threw = false;
+    try {
+      await s.browserReplay("sess-missing", { timeoutMs: 100, intervalMs: 1 });
+    } catch (e: any) {
+      threw = true;
+      assert(e.message.includes("404"), "error includes 404");
+    }
+
+    assert(threw, "throws instead of polling wrong session");
+  } finally {
+    restoreFetch();
+  }
+}
+
+async function testBrowserReplayFailedThrows() {
+  console.log("\n--- browserReplay() throws on failed replay ---");
+  installMockFetch();
+  try {
+    setMockResponse("/api/sessions/sess-failed/browser-replay", {
+      status: 200,
+      body: { sessionId: "sess-failed", status: "failed", error: "copy failed" },
+    });
+
+    const s = sessions({ apiKey: "test-key", dashboardUrl: "http://localhost:3000" });
+    let threw = false;
+    try {
+      await s.browserReplay("sess-failed", { timeoutMs: 50, intervalMs: 1 });
+    } catch (e: any) {
+      threw = true;
+      assert(e.message.includes("copy failed"), "error includes failure reason");
+    }
+    assert(threw, "throws on failed replay");
+  } finally {
+    restoreFetch();
+  }
+}
+
+async function testBrowserReplayRejectsInvalidPollingOptions() {
+  console.log("\n--- browserReplay() rejects invalid polling options ---");
+  installMockFetch();
+  try {
+    const s = sessions({ apiKey: "test-key", dashboardUrl: "http://localhost:3000" });
+
+    let threwTimeout = false;
+    try {
+      await s.browserReplay("sess-browser", { timeoutMs: 0 });
+    } catch (e: any) {
+      threwTimeout = true;
+      assert(e.message.includes("timeoutMs must be a positive number"), "rejects timeoutMs=0");
+    }
+    assert(threwTimeout, "throws on invalid timeoutMs");
+
+    let threwInterval = false;
+    try {
+      await s.browserReplay("sess-browser", { intervalMs: -1 });
+    } catch (e: any) {
+      threwInterval = true;
+      assert(e.message.includes("intervalMs must be a positive number"), "rejects intervalMs=-1");
+    }
+    assert(threwInterval, "throws on invalid intervalMs");
+    assertEqual(fetchCalls.length, 0, "does not call dashboard for invalid options");
+  } finally {
+    restoreFetch();
+  }
+}
+
 // =============================================================================
 // RUN
 // =============================================================================
@@ -471,6 +614,11 @@ async function main() {
   await testApiErrorHandling();
   await testDownloadStreaming();
   await testDownloadNoBody();
+  await testBrowserReplayReady();
+  await testBrowserReplayPollsUntilReady();
+  await testBrowserReplayThrowsOn404();
+  await testBrowserReplayFailedThrows();
+  await testBrowserReplayRejectsInvalidPollingOptions();
 
   console.log(`\n${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- add provider-neutral managed browser metadata to run lifecycle/results
- add sessions browser replay helpers for listing, waiting, and downloading replay artifacts
- keep public SDK/docs provider-neutral while documenting live/replay usage

## Verification
- npm run test:ts:unit
- npm run build
- python -m pytest tests/unit -q in packages/sdk-py
- 3 independent reviewer agents returned READY after the dashboard origin fallback fix