### PR TITLE
Default managed browser to agent-browser

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events, browser live/replay, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -105,7 +105,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser-use detection & URL extraction | [TS](references/typescript/04-streaming.md#browseruseresponse) | [PY](references/python/04-streaming.md#browseruseresponse-extraction) |
+| Browser automation live URLs, replay URLs, and browser-use URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -37,7 +37,7 @@ from evolve import Evolve, ComposioSetup, ComposioConfig
 
 evolve = Evolve(
     system_prompt='You are Manus Evolve, a powerful AI agent. You can execute code, browse the web, manage files, and solve complex tasks.',
-    browser={'provider': 'actionbook', 'remote': True},  # optional: remote managed browser automation in Gateway mode
+    browser={'provider': 'agent-browser', 'remote': True},  # optional: remote managed browser automation in Gateway mode
     skills=['pdf', 'docx', 'pptx'],
     composio=ComposioSetup(
         user_id='user_123',
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook browser automation with dashboard live view, `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser, or `browser='browser-use'` for browser-use MCP.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser with dashboard live view, `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook, or `browser='browser-use'` for browser-use MCP.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -165,7 +165,7 @@ evolve = Evolve(
     schema=MyPydanticModel,
 
     # (optional) Gateway browser automation
-    browser={'provider': 'actionbook', 'remote': True},
+    browser={'provider': 'agent-browser', 'remote': True},
 
     # (optional) Install plugins/extensions for the selected agent before first run
     plugins={
@@ -254,7 +254,7 @@ COMPOSIO_API_KEY=...
 from evolve import Evolve
 
 evolve = Evolve(
-    browser={'provider': 'actionbook', 'remote': True},
+    browser={'provider': 'agent-browser', 'remote': True},
     skills=['pptx'],
 )
 
@@ -271,19 +271,25 @@ await evolve.run(prompt='Browse Hacker News top 5 articles and create a slide de
 
 ### Browser Automation
 
-Browser automation is opt-in. `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook for extra stealth capabilities and dashboard live view. For local dogfooding or local app testing, use the provider string form; object configs default `remote` to `False` unless you set `remote=True`. browser-use also requires Gateway mode because Evolve injects the MCP server.
+Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser with dashboard live view.
+
+- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
+- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Use the provider string form for local dogfooding or local app testing.
+- Object configs default `remote` to `False` unless you set `remote=True`.
+- browser-use requires Gateway mode because Evolve injects the MCP server.
 
 | Option | Configure | What you get |
 |--------|-----------|--------------|
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
+| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
+| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
 | browser-use MCP | `browser='browser-use'` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
 
 Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
 
 ```python
-Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook browser with live view
 Evolve(browser={'provider': 'agent-browser', 'remote': True})  # remote managed agent-browser with live view
+Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook with live view
 Evolve(browser='actionbook')  # Actionbook skills only
 Evolve(browser='agent-browser')  # agent-browser skills only
 Evolve(browser='browser-use')  # browser-use MCP

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -222,8 +222,8 @@ Browser automation URLs are parsed differently depending on which browser option
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
+| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | browser-use MCP | `browser='browser-use'` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
 
 ### Remote managed Actionbook and agent-browser

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -43,7 +43,7 @@ import { Evolve } from "@evolvingmachines/sdk";
 
 const evolve = new Evolve()
     .withSystemPrompt("You are Manus Evolve, a powerful AI agent. You can execute code, browse the web, manage files, and solve complex tasks.")
-    .withBrowser()  // optional; defaults to remote managed Actionbook browser automation in Gateway mode
+    .withBrowser()  // optional; defaults to remote managed agent-browser automation in Gateway mode
     .withSkills(["pdf", "docx", "pptx"])
     .withComposio("user_123", { toolkits: ["gmail", "notion", "exa"] });  // 1000+ integrations via Composio
 
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for remote managed Actionbook browser automation with dashboard live view. Use `.withBrowser({ provider: "agent-browser", remote: true })` for remote managed agent-browser, or `.withBrowser("browser-use")` for browser-use MCP.
+- **Browser Automation:** Call `.withBrowser()` for remote managed agent-browser automation with dashboard live view. Use `.withBrowser({ provider: "actionbook", remote: true })` for remote managed Actionbook, or `.withBrowser("browser-use")` for browser-use MCP.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` enables remote managed Actionbook; `.withBrowser({ provider: "agent-browser", remote: true })` enables remote managed agent-browser; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
+| Browser | `.withBrowser()` enables remote managed agent-browser; `.withBrowser({ provider: "actionbook", remote: true })` enables remote managed Actionbook; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -165,7 +165,7 @@ const evolve = new Evolve()
     //     required: ["summary", "score"],
     // })
 
-    // (optional) Gateway browser automation (.withBrowser() defaults to remote managed Actionbook)
+    // (optional) Gateway browser automation (.withBrowser() defaults to remote managed agent-browser)
     .withBrowser()
 
     // (optional) Install plugins/extensions for the selected agent before first run
@@ -275,20 +275,26 @@ await evolve.run({ prompt: "Browse Hacker News top 5 articles and create a slide
 
 ### Browser Automation
 
-Browser automation is opt-in. `.withBrowser()` defaults to remote managed Actionbook for extra stealth capabilities and dashboard live view. For local dogfooding or local app testing, use the provider string form; object configs default `remote` to `false` unless you set `remote: true`. browser-use also requires Gateway mode because Evolve injects the MCP server.
+Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-browser with dashboard live view.
+
+- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
+- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Use the provider string form for local dogfooding or local app testing.
+- Object configs default `remote` to `false` unless you set `remote: true`.
+- browser-use requires Gateway mode because Evolve injects the MCP server.
 
 | Option | Configure | What you get |
 |--------|-----------|--------------|
-| Remote managed Actionbook (default) | `.withBrowser()` or `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
-| Remote managed agent-browser | `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
+| Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
+| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
 | browser-use MCP | `.withBrowser("browser-use")` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
 
 Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
 
 ```ts
-new Evolve().withBrowser(); // remote managed Actionbook browser with live view
-new Evolve().withBrowser({ provider: "actionbook", remote: true }); // explicit remote managed mode
-new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // remote managed agent-browser with live view
+new Evolve().withBrowser(); // remote managed agent-browser with live view
+new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // explicit default
+new Evolve().withBrowser({ provider: "actionbook", remote: true }); // remote managed Actionbook with live view
 new Evolve().withBrowser("actionbook"); // Actionbook skills only
 new Evolve().withBrowser("agent-browser"); // agent-browser skills only
 new Evolve().withBrowser("browser-use"); // browser-use MCP

--- a/docs/typescript/04-streaming.md
+++ b/docs/typescript/04-streaming.md
@@ -276,8 +276,8 @@ Browser automation URLs are parsed differently depending on which browser option
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed Actionbook | `.withBrowser()` or `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| Remote managed agent-browser | `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
 | browser-use MCP | `.withBrowser("browser-use")` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
 
 ### Remote managed Actionbook and agent-browser

--- a/packages/sdk-py/evolve/agent.py
+++ b/packages/sdk-py/evolve/agent.py
@@ -91,8 +91,8 @@ class Evolve:
             schema_options: Validation options (mode: 'strict' or 'loose', default: 'loose')
             composio: Composio Tool Router setup for 500+ external service integrations
             storage: Storage configuration for checkpoint persistence (BYOK S3 or gateway mode)
-            browser: Browser automation provider. Use 'actionbook' or 'agent-browser'
-                for local skills-only mode, {'provider': 'actionbook'|'agent-browser', 'remote': True}
+            browser: Browser automation provider. Use 'agent-browser' or 'actionbook'
+                for local skills-only mode, {'provider': 'agent-browser'|'actionbook', 'remote': True}
                 for managed remote browser automation, or 'browser-use' for browser-use MCP.
             plugins: Agent plugins/extensions to install in the sandbox user profile before first run.
         """

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -237,20 +237,20 @@ export class Evolve extends EventEmitter {
   /**
    * Enable browser automation.
    *
-   * .withBrowser() defaults to Actionbook with Evolve-managed remote browser
-   * transport in gateway mode. Pass "actionbook" or "agent-browser" for local
+   * .withBrowser() defaults to agent-browser with Evolve-managed remote browser
+   * transport in gateway mode. Pass "agent-browser" or "actionbook" for local
    * skills-only mode, or "browser-use" to use the browser-use MCP server.
    *
    * @example
    * kit.withBrowser("browser-use") // browser-use MCP provider
    *
    * @example
-   * kit.withBrowser() // defaults to remote managed Actionbook
+   * kit.withBrowser() // defaults to remote managed agent-browser
    *
    * @example
    * kit.withBrowser({ provider: "agent-browser", remote: true }) // managed remote agent-browser
    */
-  withBrowser(provider: BrowserConfig | false = { provider: "actionbook", remote: true }): this {
+  withBrowser(provider: BrowserConfig | false = { provider: "agent-browser", remote: true }): this {
     if (provider === false) {
       delete this.config.browser;
     } else {

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -179,8 +179,8 @@ async function testAgentBrowserStringAddsSkillsOnly(): Promise<void> {
   assert(!options.browserPrompt, "string agent-browser does not add managed browser prompt");
 }
 
-async function testManagedActionbookDefault(): Promise<void> {
-  console.log("\n[8] withBrowser(): defaults to remote managed Actionbook");
+async function testManagedAgentBrowserDefault(): Promise<void> {
+  console.log("\n[8] withBrowser(): defaults to remote managed agent-browser");
 
   const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
   process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
@@ -191,11 +191,12 @@ async function testManagedActionbookDefault(): Promise<void> {
       .withBrowser();
 
     const options = await getInitializedAgentOptions(kit);
-    assert(options.skills.includes("actionbook"), "default browser adds actionbook skill");
-    assertEqual(options.managedBrowser.provider, "actionbook", "managed browser tracks actionbook provider");
+    assert(options.skills.includes("agent-browser"), "default browser adds agent-browser skill");
+    assert(!options.skills.includes("actionbook"), "default browser does not add actionbook skill");
+    assertEqual(options.managedBrowser.provider, "agent-browser", "managed browser tracks agent-browser provider");
     assertEqual(options.managedBrowser.apiKey, "evolve-key", "managed browser uses Evolve API key");
     assertEqual(options.managedBrowser.dashboardUrl, "https://dashboard.test", "managed browser uses dashboard URL");
-    assert(options.browserPrompt.includes("Actionbook is preconfigured"), "managed browser prompt added");
+    assert(options.browserPrompt.includes("agent-browser CDP connection is already configured"), "managed browser prompt added");
   } finally {
     if (previousDashboardUrl === undefined) {
       delete process.env.EVOLVE_DASHBOARD_URL;
@@ -225,7 +226,7 @@ async function testManagedActionbookRequiresGatewayMode(): Promise<void> {
   const kit = new Evolve()
     .withAgent({ type: "claude", providerApiKey: "provider-key" })
     .withSandbox(fakeSandboxProvider)
-    .withBrowser();
+    .withBrowser({ provider: "actionbook", remote: true });
 
   try {
     await getInitializedAgentOptions(kit);
@@ -244,7 +245,7 @@ async function testManagedActionbookConfigUsesProxyOnly(): Promise<void> {
   const kit = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
     .withSandbox(fakeSandboxProvider)
-    .withBrowser();
+    .withBrowser({ provider: "actionbook", remote: true });
   await (kit as any).initializeAgent();
   const agent = ((kit as any).agent as any);
   agent.managedBrowserSession = {
@@ -341,7 +342,7 @@ async function main(): Promise<void> {
   await testBrowserUseRemoteObjectRejected();
   await testActionbookStringAddsSkillsOnly();
   await testAgentBrowserStringAddsSkillsOnly();
-  await testManagedActionbookDefault();
+  await testManagedAgentBrowserDefault();
   await testActionbookObjectRemoteDefaultsFalse();
   await testManagedActionbookRequiresGatewayMode();
   await testManagedActionbookConfigUsesProxyOnly();

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -290,12 +290,16 @@ async function testManagedBrowserLifecycle(): Promise<void> {
     assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed browser live URL");
     assert(!JSON.stringify(provider.createOptions?.envs).includes("proxy-token"), "sandbox env does not include CDP token");
 
-    const config = sandbox.files.writes.get("/home/user/.actionbook/config.toml");
-    assert(sandbox.files.dirs.includes("/home/user/.actionbook"), "Actionbook config directory created");
-    assert(config !== undefined, "Actionbook config file written");
-    assert(config?.includes('mode = "cloud"') ?? false, "Actionbook config sets cloud mode");
-    assert(config?.includes(cdpUrl) ?? false, "Actionbook config uses proxied CDP endpoint");
-    assert(!config?.includes("_managedTransport"), "Actionbook config does not expose transport selector");
+    assertEqual(
+      provider.createOptions?.envs?.AGENT_BROWSER_CONFIG,
+      "/home/user/.agent-browser/config.json",
+      "sandbox env points agent-browser to managed config"
+    );
+    const config = sandbox.files.writes.get("/home/user/.agent-browser/config.json");
+    assert(sandbox.files.dirs.includes("/home/user/.agent-browser"), "agent-browser config directory created");
+    assert(config !== undefined, "agent-browser config file written");
+    assert(config?.includes(cdpUrl) ?? false, "agent-browser config uses proxied CDP endpoint");
+    assert(!config?.includes("_managedTransport"), "agent-browser config does not expose transport selector");
 
     const browserReady = events.find((event) => event.reason === "browser_ready");
     assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes live URL immediately");

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events, browser live/replay, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -105,7 +105,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser-use detection & URL extraction | [TS](references/typescript/04-streaming.md#browseruseresponse) | [PY](references/python/04-streaming.md#browseruseresponse-extraction) |
+| Browser automation live URLs, replay URLs, and browser-use URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -37,7 +37,7 @@ from evolve import Evolve, ComposioSetup, ComposioConfig
 
 evolve = Evolve(
     system_prompt='You are Manus Evolve, a powerful AI agent. You can execute code, browse the web, manage files, and solve complex tasks.',
-    browser={'provider': 'actionbook', 'remote': True},  # optional: remote managed browser automation in Gateway mode
+    browser={'provider': 'agent-browser', 'remote': True},  # optional: remote managed browser automation in Gateway mode
     skills=['pdf', 'docx', 'pptx'],
     composio=ComposioSetup(
         user_id='user_123',
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook browser automation with dashboard live view, `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser, or `browser='browser-use'` for browser-use MCP.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser with dashboard live view, `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook, or `browser='browser-use'` for browser-use MCP.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/skills/evolve/references/python/02-configuration.md
+++ b/skills/evolve/references/python/02-configuration.md
@@ -165,7 +165,7 @@ evolve = Evolve(
     schema=MyPydanticModel,
 
     # (optional) Gateway browser automation
-    browser={'provider': 'actionbook', 'remote': True},
+    browser={'provider': 'agent-browser', 'remote': True},
 
     # (optional) Install plugins/extensions for the selected agent before first run
     plugins={
@@ -254,7 +254,7 @@ COMPOSIO_API_KEY=...
 from evolve import Evolve
 
 evolve = Evolve(
-    browser={'provider': 'actionbook', 'remote': True},
+    browser={'provider': 'agent-browser', 'remote': True},
     skills=['pptx'],
 )
 
@@ -271,19 +271,25 @@ await evolve.run(prompt='Browse Hacker News top 5 articles and create a slide de
 
 ### Browser Automation
 
-Browser automation is opt-in. `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook for extra stealth capabilities and dashboard live view. For local dogfooding or local app testing, use the provider string form; object configs default `remote` to `False` unless you set `remote=True`. browser-use also requires Gateway mode because Evolve injects the MCP server.
+Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser with dashboard live view.
+
+- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
+- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Use the provider string form for local dogfooding or local app testing.
+- Object configs default `remote` to `False` unless you set `remote=True`.
+- browser-use requires Gateway mode because Evolve injects the MCP server.
 
 | Option | Configure | What you get |
 |--------|-----------|--------------|
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
+| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
+| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
 | browser-use MCP | `browser='browser-use'` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
 
 Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
 
 ```python
-Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook browser with live view
 Evolve(browser={'provider': 'agent-browser', 'remote': True})  # remote managed agent-browser with live view
+Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook with live view
 Evolve(browser='actionbook')  # Actionbook skills only
 Evolve(browser='agent-browser')  # agent-browser skills only
 Evolve(browser='browser-use')  # browser-use MCP

--- a/skills/evolve/references/python/04-streaming.md
+++ b/skills/evolve/references/python/04-streaming.md
@@ -222,8 +222,8 @@ Browser automation URLs are parsed differently depending on which browser option
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
+| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | browser-use MCP | `browser='browser-use'` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
 
 ### Remote managed Actionbook and agent-browser

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -43,7 +43,7 @@ import { Evolve } from "@evolvingmachines/sdk";
 
 const evolve = new Evolve()
     .withSystemPrompt("You are Manus Evolve, a powerful AI agent. You can execute code, browse the web, manage files, and solve complex tasks.")
-    .withBrowser()  // optional; defaults to remote managed Actionbook browser automation in Gateway mode
+    .withBrowser()  // optional; defaults to remote managed agent-browser automation in Gateway mode
     .withSkills(["pdf", "docx", "pptx"])
     .withComposio("user_123", { toolkits: ["gmail", "notion", "exa"] });  // 1000+ integrations via Composio
 
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for remote managed Actionbook browser automation with dashboard live view. Use `.withBrowser({ provider: "agent-browser", remote: true })` for remote managed agent-browser, or `.withBrowser("browser-use")` for browser-use MCP.
+- **Browser Automation:** Call `.withBrowser()` for remote managed agent-browser automation with dashboard live view. Use `.withBrowser({ provider: "actionbook", remote: true })` for remote managed Actionbook, or `.withBrowser("browser-use")` for browser-use MCP.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` enables remote managed Actionbook; `.withBrowser({ provider: "agent-browser", remote: true })` enables remote managed agent-browser; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
+| Browser | `.withBrowser()` enables remote managed agent-browser; `.withBrowser({ provider: "actionbook", remote: true })` enables remote managed Actionbook; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/skills/evolve/references/typescript/02-configuration.md
+++ b/skills/evolve/references/typescript/02-configuration.md
@@ -165,7 +165,7 @@ const evolve = new Evolve()
     //     required: ["summary", "score"],
     // })
 
-    // (optional) Gateway browser automation (.withBrowser() defaults to remote managed Actionbook)
+    // (optional) Gateway browser automation (.withBrowser() defaults to remote managed agent-browser)
     .withBrowser()
 
     // (optional) Install plugins/extensions for the selected agent before first run
@@ -275,20 +275,26 @@ await evolve.run({ prompt: "Browse Hacker News top 5 articles and create a slide
 
 ### Browser Automation
 
-Browser automation is opt-in. `.withBrowser()` defaults to remote managed Actionbook for extra stealth capabilities and dashboard live view. For local dogfooding or local app testing, use the provider string form; object configs default `remote` to `false` unless you set `remote: true`. browser-use also requires Gateway mode because Evolve injects the MCP server.
+Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-browser with dashboard live view.
+
+- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
+- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Use the provider string form for local dogfooding or local app testing.
+- Object configs default `remote` to `false` unless you set `remote: true`.
+- browser-use requires Gateway mode because Evolve injects the MCP server.
 
 | Option | Configure | What you get |
 |--------|-----------|--------------|
-| Remote managed Actionbook (default) | `.withBrowser()` or `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
-| Remote managed agent-browser | `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, extra stealth capabilities, dashboard live view |
+| Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
+| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
 | browser-use MCP | `.withBrowser("browser-use")` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
 
 Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
 
 ```ts
-new Evolve().withBrowser(); // remote managed Actionbook browser with live view
-new Evolve().withBrowser({ provider: "actionbook", remote: true }); // explicit remote managed mode
-new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // remote managed agent-browser with live view
+new Evolve().withBrowser(); // remote managed agent-browser with live view
+new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // explicit default
+new Evolve().withBrowser({ provider: "actionbook", remote: true }); // remote managed Actionbook with live view
 new Evolve().withBrowser("actionbook"); // Actionbook skills only
 new Evolve().withBrowser("agent-browser"); // agent-browser skills only
 new Evolve().withBrowser("browser-use"); // browser-use MCP

--- a/skills/evolve/references/typescript/04-streaming.md
+++ b/skills/evolve/references/typescript/04-streaming.md
@@ -276,8 +276,8 @@ Browser automation URLs are parsed differently depending on which browser option
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed Actionbook | `.withBrowser()` or `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| Remote managed agent-browser | `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
 | browser-use MCP | `.withBrowser("browser-use")` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
 
 ### Remote managed Actionbook and agent-browser


### PR DESCRIPTION
## Summary
- Make .withBrowser() default to remote managed agent-browser in the TypeScript SDK
- Update TypeScript/Python browser docs and Evolve skill references to make agent-browser the recommended default
- Update browser config/session runtime tests for the new default

## Checks
- npm run build
- npm run test:ts:unit
- npm run test:py:unit