### PR TITLE
docs: clarify browser automation recommendation

### DIFF
--- a/.claude/skills/evolve/references/python/01-getting-started.md
+++ b/.claude/skills/evolve/references/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser with dashboard live view, `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook, or `browser='browser-use'` for browser-use MCP.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the recommended managed browser path with live view and replay. `browser='browser-use'` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/.claude/skills/evolve/references/python/02-configuration.md
+++ b/.claude/skills/evolve/references/python/02-configuration.md
@@ -275,6 +275,7 @@ Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': T
 
 - Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
 - Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Prefer `browser={'provider': 'agent-browser', 'remote': True}` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
 - Use the provider string form for local dogfooding or local app testing.
 - Object configs default `remote` to `False` unless you set `remote=True`.
 - browser-use requires Gateway mode because Evolve injects the MCP server.
@@ -283,7 +284,7 @@ Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': T
 |--------|-----------|--------------|
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
 | Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `browser='browser-use'` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
+| browser-use MCP | `browser='browser-use'` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
 
 Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
 

--- a/.claude/skills/evolve/references/python/04-streaming.md
+++ b/.claude/skills/evolve/references/python/04-streaming.md
@@ -220,11 +220,13 @@ class BrowserUseResponse(TypedDict):
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
+Use remote managed agent-browser for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| browser-use MCP | `browser='browser-use'` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
+| browser-use MCP | `browser='browser-use'` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
 ### Remote managed Actionbook and agent-browser
 
@@ -259,7 +261,7 @@ UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 
 ## BrowserUseResponse Extraction
 
-browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Browser tool responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
+browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
 
 > **Detection:** Browser-use tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
 

--- a/.claude/skills/evolve/references/typescript/01-getting-started.md
+++ b/.claude/skills/evolve/references/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for remote managed agent-browser automation with dashboard live view. Use `.withBrowser({ provider: "actionbook", remote: true })` for remote managed Actionbook, or `.withBrowser("browser-use")` for browser-use MCP.
+- **Browser Automation:** Call `.withBrowser()` for the recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` enables remote managed agent-browser; `.withBrowser({ provider: "actionbook", remote: true })` enables remote managed Actionbook; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
+| Browser | `.withBrowser()` is the recommended managed browser path with live view and replay. `.withBrowser("browser-use")` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/.claude/skills/evolve/references/typescript/02-configuration.md
+++ b/.claude/skills/evolve/references/typescript/02-configuration.md
@@ -279,6 +279,7 @@ Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-
 
 - Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
 - Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Prefer `.withBrowser()` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
 - Use the provider string form for local dogfooding or local app testing.
 - Object configs default `remote` to `false` unless you set `remote: true`.
 - browser-use requires Gateway mode because Evolve injects the MCP server.
@@ -287,7 +288,7 @@ Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-
 |--------|-----------|--------------|
 | Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
 | Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `.withBrowser("browser-use")` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
+| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
 
 Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
 

--- a/.claude/skills/evolve/references/typescript/04-streaming.md
+++ b/.claude/skills/evolve/references/typescript/04-streaming.md
@@ -274,11 +274,13 @@ interface DiffContent {
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
+Use `.withBrowser()` for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
 | Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
 | Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| browser-use MCP | `.withBrowser("browser-use")` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
+| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
 ### Remote managed Actionbook and agent-browser
 
@@ -316,7 +318,7 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ## BrowserUseResponse
 
-browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Browser tool responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
+browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
 
 > **Detection:** Browser-use tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
 

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser with dashboard live view, `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook, or `browser='browser-use'` for browser-use MCP.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the recommended managed browser path with live view and replay. `browser='browser-use'` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -275,6 +275,7 @@ Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': T
 
 - Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
 - Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Prefer `browser={'provider': 'agent-browser', 'remote': True}` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
 - Use the provider string form for local dogfooding or local app testing.
 - Object configs default `remote` to `False` unless you set `remote=True`.
 - browser-use requires Gateway mode because Evolve injects the MCP server.
@@ -283,7 +284,7 @@ Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': T
 |--------|-----------|--------------|
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
 | Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `browser='browser-use'` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
+| browser-use MCP | `browser='browser-use'` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
 
 Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
 

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -220,11 +220,13 @@ class BrowserUseResponse(TypedDict):
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
+Use remote managed agent-browser for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| browser-use MCP | `browser='browser-use'` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
+| browser-use MCP | `browser='browser-use'` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
 ### Remote managed Actionbook and agent-browser
 
@@ -259,7 +261,7 @@ UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 
 ## BrowserUseResponse Extraction
 
-browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Browser tool responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
+browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
 
 > **Detection:** Browser-use tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
 

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for remote managed agent-browser automation with dashboard live view. Use `.withBrowser({ provider: "actionbook", remote: true })` for remote managed Actionbook, or `.withBrowser("browser-use")` for browser-use MCP.
+- **Browser Automation:** Call `.withBrowser()` for the recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` enables remote managed agent-browser; `.withBrowser({ provider: "actionbook", remote: true })` enables remote managed Actionbook; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
+| Browser | `.withBrowser()` is the recommended managed browser path with live view and replay. `.withBrowser("browser-use")` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -279,6 +279,7 @@ Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-
 
 - Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
 - Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Prefer `.withBrowser()` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
 - Use the provider string form for local dogfooding or local app testing.
 - Object configs default `remote` to `false` unless you set `remote: true`.
 - browser-use requires Gateway mode because Evolve injects the MCP server.
@@ -287,7 +288,7 @@ Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-
 |--------|-----------|--------------|
 | Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
 | Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `.withBrowser("browser-use")` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
+| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
 
 Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
 

--- a/docs/typescript/04-streaming.md
+++ b/docs/typescript/04-streaming.md
@@ -274,11 +274,13 @@ interface DiffContent {
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
+Use `.withBrowser()` for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
 | Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
 | Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| browser-use MCP | `.withBrowser("browser-use")` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
+| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
 ### Remote managed Actionbook and agent-browser
 
@@ -316,7 +318,7 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ## BrowserUseResponse
 
-browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Browser tool responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
+browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
 
 > **Detection:** Browser-use tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
 

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for remote managed agent-browser with dashboard live view, `browser={'provider': 'actionbook', 'remote': True}` for remote managed Actionbook, or `browser='browser-use'` for browser-use MCP.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser; `browser={'provider': 'actionbook', 'remote': True}` enables remote managed Actionbook; `browser='browser-use'` enables browser-use MCP | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the recommended managed browser path with live view and replay. `browser='browser-use'` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/skills/evolve/references/python/02-configuration.md
+++ b/skills/evolve/references/python/02-configuration.md
@@ -275,6 +275,7 @@ Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': T
 
 - Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
 - Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Prefer `browser={'provider': 'agent-browser', 'remote': True}` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
 - Use the provider string form for local dogfooding or local app testing.
 - Object configs default `remote` to `False` unless you set `remote=True`.
 - browser-use requires Gateway mode because Evolve injects the MCP server.
@@ -283,7 +284,7 @@ Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': T
 |--------|-----------|--------------|
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
 | Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `browser='browser-use'` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
+| browser-use MCP | `browser='browser-use'` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
 
 Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
 

--- a/skills/evolve/references/python/04-streaming.md
+++ b/skills/evolve/references/python/04-streaming.md
@@ -220,11 +220,13 @@ class BrowserUseResponse(TypedDict):
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
+Use remote managed agent-browser for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
 | Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
 | Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| browser-use MCP | `browser='browser-use'` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
+| browser-use MCP | `browser='browser-use'` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
 ### Remote managed Actionbook and agent-browser
 
@@ -259,7 +261,7 @@ UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 
 ## BrowserUseResponse Extraction
 
-browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Browser tool responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
+browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
 
 > **Detection:** Browser-use tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
 

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for remote managed agent-browser automation with dashboard live view. Use `.withBrowser({ provider: "actionbook", remote: true })` for remote managed Actionbook, or `.withBrowser("browser-use")` for browser-use MCP.
+- **Browser Automation:** Call `.withBrowser()` for the recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` enables remote managed agent-browser; `.withBrowser({ provider: "actionbook", remote: true })` enables remote managed Actionbook; `.withBrowser("browser-use")` enables browser-use MCP | Via skills or MCP |
+| Browser | `.withBrowser()` is the recommended managed browser path with live view and replay. `.withBrowser("browser-use")` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/skills/evolve/references/typescript/02-configuration.md
+++ b/skills/evolve/references/typescript/02-configuration.md
@@ -279,6 +279,7 @@ Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-
 
 - Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
 - Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
+- Prefer `.withBrowser()` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
 - Use the provider string form for local dogfooding or local app testing.
 - Object configs default `remote` to `false` unless you set `remote: true`.
 - browser-use requires Gateway mode because Evolve injects the MCP server.
@@ -287,7 +288,7 @@ Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-
 |--------|-----------|--------------|
 | Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
 | Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `.withBrowser("browser-use")` | browser-use MCP server, with live/screenshot URLs parsed from browser-use tool responses |
+| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
 
 Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
 

--- a/skills/evolve/references/typescript/04-streaming.md
+++ b/skills/evolve/references/typescript/04-streaming.md
@@ -274,11 +274,13 @@ interface DiffContent {
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
+Use `.withBrowser()` for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
 | Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
 | Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| browser-use MCP | `.withBrowser("browser-use")` | `tool_call_update` content from browser-use tools; parse embedded `live_url` and `screenshot_url` JSON fields |
+| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
 ### Remote managed Actionbook and agent-browser
 
@@ -316,7 +318,7 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ## BrowserUseResponse
 
-browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Browser tool responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
+browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
 
 > **Detection:** Browser-use tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
 


### PR DESCRIPTION
## Summary
- Clarify that .withBrowser() is the recommended managed browser path with live view and replay
- Keep browser-use documented as an advanced MCP option with MCP output parsing guidance
- Sync Evolve skill references for Codex and Claude

## Checks
- git diff --check
- docs and skill reference files compared with cmp