### PR TITLE
docs: simplify browser automation guidance

### DIFF
--- a/.claude/skills/evolve/SKILL.md
+++ b/.claude/skills/evolve/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, browser live/replay, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events, browser live/replay, parsing tool calls, legacy `browser-use` fallback | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -105,7 +105,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser automation live URLs, replay URLs, and browser-use URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
+| Browser automation live URLs, replay URLs, and legacy `browser-use` URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/.claude/skills/evolve/references/python/01-getting-started.md
+++ b/.claude/skills/evolve/references/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the default and recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the recommended managed browser path with live view and replay. `browser='browser-use'` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. `browser='browser-use'` remains available as a legacy fallback for now. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/.claude/skills/evolve/references/python/02-configuration.md
+++ b/.claude/skills/evolve/references/python/02-configuration.md
@@ -271,39 +271,19 @@ await evolve.run(prompt='Browse Hacker News top 5 articles and create a slide de
 
 ### Browser Automation
 
-Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser with dashboard live view.
-
-- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
-- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
-- Prefer `browser={'provider': 'agent-browser', 'remote': True}` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
-- Use the provider string form for local dogfooding or local app testing.
-- Object configs default `remote` to `False` unless you set `remote=True`.
-- browser-use requires Gateway mode because Evolve injects the MCP server.
-
-| Option | Configure | What you get |
-|--------|-----------|--------------|
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `browser='browser-use'` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
-
-Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
+Browser automation is opt-in. Use `browser={'provider': 'agent-browser', 'remote': True}` for browser, QA, dogfooding, and website automation tasks.
 
 ```python
-Evolve(browser={'provider': 'agent-browser', 'remote': True})  # remote managed agent-browser with live view
-Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook with live view
-Evolve(browser='actionbook')  # Actionbook skills only
-Evolve(browser='agent-browser')  # agent-browser skills only
-Evolve(browser='browser-use')  # browser-use MCP
+Evolve(browser={'provider': 'agent-browser', 'remote': True})  # managed browser with dashboard live view and replay
 ```
 
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `actionbook` | Browser action engine for web automation | [skills/actionbook](https://github.com/evolving-machines-lab/evolve/tree/main/skills/actionbook) |
-| `active-research` | Browser-enabled research workflows | [skills/active-research](https://github.com/evolving-machines-lab/evolve/tree/main/skills/active-research) |
-| `extract` | Browser data extraction workflows | [skills/extract](https://github.com/evolving-machines-lab/evolve/tree/main/skills/extract) |
-| `agent-browser` | CLI-based headless browser automation for AI agents | [skills/agent-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/agent-browser) |
-| `dev-browser` | Browser automation with persistent page state | [skills/dev-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/dev-browser) |
-| `webapp-testing` | Test web applications | [skills/webapp-testing](https://github.com/evolving-machines-lab/evolve/tree/main/skills/webapp-testing) |
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+
+`browser-use` remains available only as a legacy fallback for now:
+
+```python
+Evolve(browser='browser-use')  # legacy fallback: parse MCP output, no managed replay
+```
 
 ### Agent Plugins
 

--- a/.claude/skills/evolve/references/python/03-runtime.md
+++ b/.claude/skills/evolve/references/python/03-runtime.md
@@ -82,7 +82,7 @@ evolve.on('lifecycle', lambda event: print(event['reason'], event['sandbox']))
 | `stdout` | `str` | Raw JSONL output |
 | `stderr` | `str` | Error output |
 
-For full type definitions, all event interfaces, browser-use detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 

--- a/.claude/skills/evolve/references/python/04-streaming.md
+++ b/.claude/skills/evolve/references/python/04-streaming.md
@@ -120,15 +120,15 @@ ToolKind = Literal[
     "think",       # Task (subagent)
     "fetch",       # WebFetch, WebSearch
     "switch_mode", # ExitPlanMode
-    "other",       # MCP tools (including browser-use), unknown
+    "other",       # MCP tools (including `browser-use`), unknown
 ]
 
-# IMPORTANT: Browser-use MCP tools have kind="other", not "browser" or "fetch".
+# IMPORTANT: `browser-use` MCP tools have kind="other", not "browser" or "fetch".
 # To identify browser tools in your UI, check if title starts with "browser-use:"
 # (e.g., "browser-use: browser_task", "browser-use: monitor_task")
 
 def is_browser_use_tool(title: str | None) -> bool:
-    """Helper to detect browser-use tools."""
+    """Helper to detect `browser-use` tools."""
     return "browser-use" in (title or "").lower()
 
 ToolCallStatus = Literal["pending", "in_progress", "completed", "failed"]
@@ -220,15 +220,14 @@ class BrowserUseResponse(TypedDict):
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
-Use remote managed agent-browser for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+Use the recommended managed browser config for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| browser-use MCP | `browser='browser-use'` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Recommended managed browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
+| Legacy `browser-use` fallback | `browser='browser-use'` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
-### Remote managed Actionbook and agent-browser
+### Managed Browser
 
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
@@ -245,7 +244,6 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 
 ```python
 TraceMetadata = {
-    "browser_provider": "actionbook | agent-browser",
     "browser_session_id": "...",
     "dashboard_session_id": "...",
     "browser_session_tag": "...",
@@ -261,9 +259,9 @@ UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 
 ## BrowserUseResponse Extraction
 
-browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
+`browser-use` is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
 
-> **Detection:** Browser-use tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
+> **Detection:** `browser-use` tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
 
 **Extraction function** (use regex first for speed and malformed JSON tolerance, then JSON fallback):
 
@@ -273,7 +271,7 @@ import json
 from typing import Optional
 
 def extract_browser_use_urls(text: str) -> dict[str, Optional[str]]:
-    """Extract browser-use URLs from tool response text.
+    """Extract `browser-use` URLs from tool response text.
 
     Returns:
         {"live_url": str | None, "screenshot_url": str | None}
@@ -382,7 +380,7 @@ def handle_event(event: OutputEvent) -> None:
             content=update_data.get("content"),
         )
 
-        # 2. Extract browser-use URLs if present (first-party integration)
+        # 2. Extract `browser-use` URLs if present (first-party integration)
         for c in update_data.get("content") or []:
             if c.get("type") == "content":
                 inner = c.get("content", {})
@@ -412,6 +410,6 @@ evolve.on("content", handle_event)
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
 8. **Use `cast()` for narrowing** — TypedDict unions need explicit casting after checking `sessionUpdate`
-9. **Detect browser-use by title** — Browser-use MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
+9. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
 
 ---

--- a/.claude/skills/evolve/references/typescript/01-getting-started.md
+++ b/.claude/skills/evolve/references/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for the recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
+- **Browser Automation:** Call `.withBrowser()` for the default and recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the recommended managed browser path with live view and replay. `.withBrowser("browser-use")` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/.claude/skills/evolve/references/typescript/02-configuration.md
+++ b/.claude/skills/evolve/references/typescript/02-configuration.md
@@ -275,40 +275,19 @@ await evolve.run({ prompt: "Browse Hacker News top 5 articles and create a slide
 
 ### Browser Automation
 
-Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-browser with dashboard live view.
-
-- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
-- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
-- Prefer `.withBrowser()` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
-- Use the provider string form for local dogfooding or local app testing.
-- Object configs default `remote` to `false` unless you set `remote: true`.
-- browser-use requires Gateway mode because Evolve injects the MCP server.
-
-| Option | Configure | What you get |
-|--------|-----------|--------------|
-| Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
-| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
-
-Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
+Browser automation is opt-in. Use `.withBrowser()` for browser, QA, dogfooding, and website automation tasks.
 
 ```ts
-new Evolve().withBrowser(); // remote managed agent-browser with live view
-new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // explicit default
-new Evolve().withBrowser({ provider: "actionbook", remote: true }); // remote managed Actionbook with live view
-new Evolve().withBrowser("actionbook"); // Actionbook skills only
-new Evolve().withBrowser("agent-browser"); // agent-browser skills only
-new Evolve().withBrowser("browser-use"); // browser-use MCP
+new Evolve().withBrowser(); // managed browser with dashboard live view and replay
 ```
 
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `actionbook` | Browser action engine for web automation | [skills/actionbook](https://github.com/evolving-machines-lab/evolve/tree/main/skills/actionbook) |
-| `active-research` | Browser-enabled research workflows | [skills/active-research](https://github.com/evolving-machines-lab/evolve/tree/main/skills/active-research) |
-| `extract` | Browser data extraction workflows | [skills/extract](https://github.com/evolving-machines-lab/evolve/tree/main/skills/extract) |
-| `agent-browser` | CLI-based headless browser automation for AI agents | [skills/agent-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/agent-browser) |
-| `dev-browser` | Browser automation with persistent page state | [skills/dev-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/dev-browser) |
-| `webapp-testing` | Test web applications | [skills/webapp-testing](https://github.com/evolving-machines-lab/evolve/tree/main/skills/webapp-testing) |
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+
+`browser-use` remains available only as a legacy fallback for now:
+
+```ts
+new Evolve().withBrowser("browser-use"); // legacy fallback: parse MCP output, no managed replay
+```
 
 ### Agent Plugins
 

--- a/.claude/skills/evolve/references/typescript/03-runtime.md
+++ b/.claude/skills/evolve/references/typescript/03-runtime.md
@@ -77,7 +77,7 @@ evolve.on("lifecycle", (event: LifecycleEvent) => {
 | `stdout` | `string` | Raw JSONL output |
 | `stderr` | `string` | Error output |
 
-For full type definitions, all event interfaces, browser-use detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 

--- a/.claude/skills/evolve/references/typescript/04-streaming.md
+++ b/.claude/skills/evolve/references/typescript/04-streaming.md
@@ -226,13 +226,13 @@ type ToolKind =
   | "think"       // Task (subagent)
   | "fetch"       // WebFetch, WebSearch
   | "switch_mode" // ExitPlanMode
-  | "other";      // MCP tools (including browser-use), unknown
+  | "other";      // MCP tools (including `browser-use`), unknown
 ```
 
-> **Important:** Browser-use MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
+> **Important:** `browser-use` MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
 
 ```typescript
-// Helper to detect browser-use tools
+// Helper to detect `browser-use` tools
 function isBrowserUseTool(title?: string): boolean {
   return title?.toLowerCase().includes('browser-use') ?? false;
 }
@@ -274,15 +274,14 @@ interface DiffContent {
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
-Use `.withBrowser()` for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+Use `.withBrowser()` for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Recommended managed browser | `.withBrowser()` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Legacy `browser-use` fallback | `.withBrowser("browser-use")` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
-### Remote managed Actionbook and agent-browser
+### Managed Browser
 
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
@@ -302,7 +301,6 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 
 ```typescript
 type TraceMetadata = {
-  browser_provider?: "actionbook" | "agent-browser";
   browser_session_id?: string;
   dashboard_session_id?: string;
   browser_session_tag?: string;
@@ -318,9 +316,9 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ## BrowserUseResponse
 
-browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
+`browser-use` is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
 
-> **Detection:** Browser-use tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
+> **Detection:** `browser-use` tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
 
 ```typescript
 interface BrowserUseResponse {
@@ -373,7 +371,7 @@ function extractBrowserUseUrls(text: string): { liveUrl?: string; screenshotUrl?
 ```typescript
 import type { OutputEvent } from "@evolvingmachines/sdk";
 
-// Helper to detect browser-use tools (they have kind: "other")
+// Helper to detect `browser-use` tools (they have kind: "other")
 function isBrowserUseTool(title?: string): boolean {
   return title?.toLowerCase().includes('browser-use') ?? false;
 }
@@ -402,16 +400,16 @@ function handleEvent(event: OutputEvent): void {
       break;
 
     case "tool_call":
-      // Store title for browser-use detection on updates
+      // Store title for `browser-use` detection on updates
       toolTitles.set(update.toolCallId, update.title);
 
-      // Determine effective kind for UI (browser-use has kind: "other")
+      // Determine effective kind for UI (`browser-use` has kind: "other")
       const effectiveKind = isBrowserUseTool(update.title) ? "browser" : update.kind;
 
       ui.addTool({
         id: update.toolCallId,
         title: update.title,
-        kind: effectiveKind,  // Use "browser" for browser-use tools
+        kind: effectiveKind,  // Use "browser" for `browser-use` tools
         status: update.status,
         locations: update.locations,
       });
@@ -424,7 +422,7 @@ function handleEvent(event: OutputEvent): void {
         content: update.content,
       });
 
-      // 2. Extract browser-use URLs if this is a browser-use tool
+      // 2. Extract `browser-use` URLs if this is a `browser-use` tool
       const title = toolTitles.get(update.toolCallId);
       if (isBrowserUseTool(title)) {
         for (const c of update.content ?? []) {
@@ -457,6 +455,6 @@ evolve.on("content", handleEvent);
 5. **Support images** — `ContentBlock` includes `ImageContent`
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
-8. **Detect browser-use by title** — Browser-use MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
+8. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
 
 ---

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, browser live/replay, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events, browser live/replay, parsing tool calls, legacy `browser-use` fallback | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -105,7 +105,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser automation live URLs, replay URLs, and browser-use URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
+| Browser automation live URLs, replay URLs, and legacy `browser-use` URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the default and recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the recommended managed browser path with live view and replay. `browser='browser-use'` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. `browser='browser-use'` remains available as a legacy fallback for now. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -271,39 +271,19 @@ await evolve.run(prompt='Browse Hacker News top 5 articles and create a slide de
 
 ### Browser Automation
 
-Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser with dashboard live view.
-
-- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
-- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
-- Prefer `browser={'provider': 'agent-browser', 'remote': True}` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
-- Use the provider string form for local dogfooding or local app testing.
-- Object configs default `remote` to `False` unless you set `remote=True`.
-- browser-use requires Gateway mode because Evolve injects the MCP server.
-
-| Option | Configure | What you get |
-|--------|-----------|--------------|
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `browser='browser-use'` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
-
-Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
+Browser automation is opt-in. Use `browser={'provider': 'agent-browser', 'remote': True}` for browser, QA, dogfooding, and website automation tasks.
 
 ```python
-Evolve(browser={'provider': 'agent-browser', 'remote': True})  # remote managed agent-browser with live view
-Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook with live view
-Evolve(browser='actionbook')  # Actionbook skills only
-Evolve(browser='agent-browser')  # agent-browser skills only
-Evolve(browser='browser-use')  # browser-use MCP
+Evolve(browser={'provider': 'agent-browser', 'remote': True})  # managed browser with dashboard live view and replay
 ```
 
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `actionbook` | Browser action engine for web automation | [skills/actionbook](https://github.com/evolving-machines-lab/evolve/tree/main/skills/actionbook) |
-| `active-research` | Browser-enabled research workflows | [skills/active-research](https://github.com/evolving-machines-lab/evolve/tree/main/skills/active-research) |
-| `extract` | Browser data extraction workflows | [skills/extract](https://github.com/evolving-machines-lab/evolve/tree/main/skills/extract) |
-| `agent-browser` | CLI-based headless browser automation for AI agents | [skills/agent-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/agent-browser) |
-| `dev-browser` | Browser automation with persistent page state | [skills/dev-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/dev-browser) |
-| `webapp-testing` | Test web applications | [skills/webapp-testing](https://github.com/evolving-machines-lab/evolve/tree/main/skills/webapp-testing) |
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+
+`browser-use` remains available only as a legacy fallback for now:
+
+```python
+Evolve(browser='browser-use')  # legacy fallback: parse MCP output, no managed replay
+```
 
 ### Agent Plugins
 

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -82,7 +82,7 @@ evolve.on('lifecycle', lambda event: print(event['reason'], event['sandbox']))
 | `stdout` | `str` | Raw JSONL output |
 | `stderr` | `str` | Error output |
 
-For full type definitions, all event interfaces, browser-use detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -120,15 +120,15 @@ ToolKind = Literal[
     "think",       # Task (subagent)
     "fetch",       # WebFetch, WebSearch
     "switch_mode", # ExitPlanMode
-    "other",       # MCP tools (including browser-use), unknown
+    "other",       # MCP tools (including `browser-use`), unknown
 ]
 
-# IMPORTANT: Browser-use MCP tools have kind="other", not "browser" or "fetch".
+# IMPORTANT: `browser-use` MCP tools have kind="other", not "browser" or "fetch".
 # To identify browser tools in your UI, check if title starts with "browser-use:"
 # (e.g., "browser-use: browser_task", "browser-use: monitor_task")
 
 def is_browser_use_tool(title: str | None) -> bool:
-    """Helper to detect browser-use tools."""
+    """Helper to detect `browser-use` tools."""
     return "browser-use" in (title or "").lower()
 
 ToolCallStatus = Literal["pending", "in_progress", "completed", "failed"]
@@ -220,15 +220,14 @@ class BrowserUseResponse(TypedDict):
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
-Use remote managed agent-browser for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+Use the recommended managed browser config for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| browser-use MCP | `browser='browser-use'` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Recommended managed browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
+| Legacy `browser-use` fallback | `browser='browser-use'` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
-### Remote managed Actionbook and agent-browser
+### Managed Browser
 
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
@@ -245,7 +244,6 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 
 ```python
 TraceMetadata = {
-    "browser_provider": "actionbook | agent-browser",
     "browser_session_id": "...",
     "dashboard_session_id": "...",
     "browser_session_tag": "...",
@@ -261,9 +259,9 @@ UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 
 ## BrowserUseResponse Extraction
 
-browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
+`browser-use` is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
 
-> **Detection:** Browser-use tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
+> **Detection:** `browser-use` tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
 
 **Extraction function** (use regex first for speed and malformed JSON tolerance, then JSON fallback):
 
@@ -273,7 +271,7 @@ import json
 from typing import Optional
 
 def extract_browser_use_urls(text: str) -> dict[str, Optional[str]]:
-    """Extract browser-use URLs from tool response text.
+    """Extract `browser-use` URLs from tool response text.
 
     Returns:
         {"live_url": str | None, "screenshot_url": str | None}
@@ -382,7 +380,7 @@ def handle_event(event: OutputEvent) -> None:
             content=update_data.get("content"),
         )
 
-        # 2. Extract browser-use URLs if present (first-party integration)
+        # 2. Extract `browser-use` URLs if present (first-party integration)
         for c in update_data.get("content") or []:
             if c.get("type") == "content":
                 inner = c.get("content", {})
@@ -412,6 +410,6 @@ evolve.on("content", handle_event)
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
 8. **Use `cast()` for narrowing** — TypedDict unions need explicit casting after checking `sessionUpdate`
-9. **Detect browser-use by title** — Browser-use MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
+9. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
 
 ---

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for the recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
+- **Browser Automation:** Call `.withBrowser()` for the default and recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the recommended managed browser path with live view and replay. `.withBrowser("browser-use")` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -275,40 +275,19 @@ await evolve.run({ prompt: "Browse Hacker News top 5 articles and create a slide
 
 ### Browser Automation
 
-Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-browser with dashboard live view.
-
-- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
-- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
-- Prefer `.withBrowser()` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
-- Use the provider string form for local dogfooding or local app testing.
-- Object configs default `remote` to `false` unless you set `remote: true`.
-- browser-use requires Gateway mode because Evolve injects the MCP server.
-
-| Option | Configure | What you get |
-|--------|-----------|--------------|
-| Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
-| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
-
-Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
+Browser automation is opt-in. Use `.withBrowser()` for browser, QA, dogfooding, and website automation tasks.
 
 ```ts
-new Evolve().withBrowser(); // remote managed agent-browser with live view
-new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // explicit default
-new Evolve().withBrowser({ provider: "actionbook", remote: true }); // remote managed Actionbook with live view
-new Evolve().withBrowser("actionbook"); // Actionbook skills only
-new Evolve().withBrowser("agent-browser"); // agent-browser skills only
-new Evolve().withBrowser("browser-use"); // browser-use MCP
+new Evolve().withBrowser(); // managed browser with dashboard live view and replay
 ```
 
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `actionbook` | Browser action engine for web automation | [skills/actionbook](https://github.com/evolving-machines-lab/evolve/tree/main/skills/actionbook) |
-| `active-research` | Browser-enabled research workflows | [skills/active-research](https://github.com/evolving-machines-lab/evolve/tree/main/skills/active-research) |
-| `extract` | Browser data extraction workflows | [skills/extract](https://github.com/evolving-machines-lab/evolve/tree/main/skills/extract) |
-| `agent-browser` | CLI-based headless browser automation for AI agents | [skills/agent-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/agent-browser) |
-| `dev-browser` | Browser automation with persistent page state | [skills/dev-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/dev-browser) |
-| `webapp-testing` | Test web applications | [skills/webapp-testing](https://github.com/evolving-machines-lab/evolve/tree/main/skills/webapp-testing) |
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+
+`browser-use` remains available only as a legacy fallback for now:
+
+```ts
+new Evolve().withBrowser("browser-use"); // legacy fallback: parse MCP output, no managed replay
+```
 
 ### Agent Plugins
 

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -77,7 +77,7 @@ evolve.on("lifecycle", (event: LifecycleEvent) => {
 | `stdout` | `string` | Raw JSONL output |
 | `stderr` | `string` | Error output |
 
-For full type definitions, all event interfaces, browser-use detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 

--- a/docs/typescript/04-streaming.md
+++ b/docs/typescript/04-streaming.md
@@ -226,13 +226,13 @@ type ToolKind =
   | "think"       // Task (subagent)
   | "fetch"       // WebFetch, WebSearch
   | "switch_mode" // ExitPlanMode
-  | "other";      // MCP tools (including browser-use), unknown
+  | "other";      // MCP tools (including `browser-use`), unknown
 ```
 
-> **Important:** Browser-use MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
+> **Important:** `browser-use` MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
 
 ```typescript
-// Helper to detect browser-use tools
+// Helper to detect `browser-use` tools
 function isBrowserUseTool(title?: string): boolean {
   return title?.toLowerCase().includes('browser-use') ?? false;
 }
@@ -274,15 +274,14 @@ interface DiffContent {
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
-Use `.withBrowser()` for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+Use `.withBrowser()` for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Recommended managed browser | `.withBrowser()` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Legacy `browser-use` fallback | `.withBrowser("browser-use")` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
-### Remote managed Actionbook and agent-browser
+### Managed Browser
 
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
@@ -302,7 +301,6 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 
 ```typescript
 type TraceMetadata = {
-  browser_provider?: "actionbook" | "agent-browser";
   browser_session_id?: string;
   dashboard_session_id?: string;
   browser_session_tag?: string;
@@ -318,9 +316,9 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ## BrowserUseResponse
 
-browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
+`browser-use` is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
 
-> **Detection:** Browser-use tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
+> **Detection:** `browser-use` tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
 
 ```typescript
 interface BrowserUseResponse {
@@ -373,7 +371,7 @@ function extractBrowserUseUrls(text: string): { liveUrl?: string; screenshotUrl?
 ```typescript
 import type { OutputEvent } from "@evolvingmachines/sdk";
 
-// Helper to detect browser-use tools (they have kind: "other")
+// Helper to detect `browser-use` tools (they have kind: "other")
 function isBrowserUseTool(title?: string): boolean {
   return title?.toLowerCase().includes('browser-use') ?? false;
 }
@@ -402,16 +400,16 @@ function handleEvent(event: OutputEvent): void {
       break;
 
     case "tool_call":
-      // Store title for browser-use detection on updates
+      // Store title for `browser-use` detection on updates
       toolTitles.set(update.toolCallId, update.title);
 
-      // Determine effective kind for UI (browser-use has kind: "other")
+      // Determine effective kind for UI (`browser-use` has kind: "other")
       const effectiveKind = isBrowserUseTool(update.title) ? "browser" : update.kind;
 
       ui.addTool({
         id: update.toolCallId,
         title: update.title,
-        kind: effectiveKind,  // Use "browser" for browser-use tools
+        kind: effectiveKind,  // Use "browser" for `browser-use` tools
         status: update.status,
         locations: update.locations,
       });
@@ -424,7 +422,7 @@ function handleEvent(event: OutputEvent): void {
         content: update.content,
       });
 
-      // 2. Extract browser-use URLs if this is a browser-use tool
+      // 2. Extract `browser-use` URLs if this is a `browser-use` tool
       const title = toolTitles.get(update.toolCallId);
       if (isBrowserUseTool(title)) {
         for (const c of update.content ?? []) {
@@ -457,6 +455,6 @@ evolve.on("content", handleEvent);
 5. **Support images** — `ContentBlock` includes `ImageContent`
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
-8. **Detect browser-use by title** — Browser-use MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
+8. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
 
 ---

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -44,7 +44,7 @@ await evolve.run({ prompt: "Hello world" });
 | `.withContext()` / `.withFiles()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSystemPrompt()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSchema()` (Zod / JSON Schema) | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
-| `.withBrowser()` / `.withBrowser("browser-use")` | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
+| `.withBrowser()` / legacy `.withBrowser("browser-use")` | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
 | `.withPlugins()` | [Configuration → Agent Plugins](./02-configuration.md#agent-plugins) |
 | `.withSkills()` | [Configuration → Agent Skills](./02-configuration.md#agent-skills) |
 | `.withComposio()` (1000+ integrations) | [Configuration → Composio](./02-configuration.md#composio-tool-router) |

--- a/packages/sdk-py/evolve/agent.py
+++ b/packages/sdk-py/evolve/agent.py
@@ -91,9 +91,9 @@ class Evolve:
             schema_options: Validation options (mode: 'strict' or 'loose', default: 'loose')
             composio: Composio Tool Router setup for 500+ external service integrations
             storage: Storage configuration for checkpoint persistence (BYOK S3 or gateway mode)
-            browser: Browser automation provider. Use 'agent-browser' or 'actionbook'
-                for local skills-only mode, {'provider': 'agent-browser'|'actionbook', 'remote': True}
-                for managed remote browser automation, or 'browser-use' for browser-use MCP.
+            browser: Browser automation provider. Use {'provider': 'agent-browser', 'remote': True}
+                for managed remote browser automation, or 'browser-use' as a legacy
+                `browser-use` MCP fallback.
             plugins: Agent plugins/extensions to install in the sandbox user profile before first run.
         """
         self.config = config

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -238,11 +238,11 @@ export class Evolve extends EventEmitter {
    * Enable browser automation.
    *
    * .withBrowser() defaults to agent-browser with Evolve-managed remote browser
-   * transport in gateway mode. Pass "agent-browser" or "actionbook" for local
-   * skills-only mode, or "browser-use" to use the browser-use MCP server.
+   * transport in gateway mode. Pass "browser-use" only as a legacy `browser-use`
+   * MCP fallback.
    *
    * @example
-   * kit.withBrowser("browser-use") // browser-use MCP provider
+   * kit.withBrowser("browser-use") // legacy `browser-use` MCP fallback
    *
    * @example
    * kit.withBrowser() // defaults to remote managed agent-browser

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, browser live/replay, parsing tool calls, browser-use | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events, browser live/replay, parsing tool calls, legacy `browser-use` fallback | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -105,7 +105,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser automation live URLs, replay URLs, and browser-use URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
+| Browser automation live URLs, replay URLs, and legacy `browser-use` URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the default and recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the recommended managed browser path with live view and replay. `browser='browser-use'` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. `browser='browser-use'` remains available as a legacy fallback for now. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/skills/evolve/references/python/02-configuration.md
+++ b/skills/evolve/references/python/02-configuration.md
@@ -271,39 +271,19 @@ await evolve.run(prompt='Browse Hacker News top 5 articles and create a slide de
 
 ### Browser Automation
 
-Browser automation is opt-in. `browser={'provider': 'agent-browser', 'remote': True}` enables remote managed agent-browser with dashboard live view.
-
-- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
-- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
-- Prefer `browser={'provider': 'agent-browser', 'remote': True}` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
-- Use the provider string form for local dogfooding or local app testing.
-- Object configs default `remote` to `False` unless you set `remote=True`.
-- browser-use requires Gateway mode because Evolve injects the MCP server.
-
-| Option | Configure | What you get |
-|--------|-----------|--------------|
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `browser='browser-use'` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
-
-Use `browser='actionbook'` or `browser='agent-browser'` to install only that provider's skills without managed live browser transport.
+Browser automation is opt-in. Use `browser={'provider': 'agent-browser', 'remote': True}` for browser, QA, dogfooding, and website automation tasks.
 
 ```python
-Evolve(browser={'provider': 'agent-browser', 'remote': True})  # remote managed agent-browser with live view
-Evolve(browser={'provider': 'actionbook', 'remote': True})  # remote managed Actionbook with live view
-Evolve(browser='actionbook')  # Actionbook skills only
-Evolve(browser='agent-browser')  # agent-browser skills only
-Evolve(browser='browser-use')  # browser-use MCP
+Evolve(browser={'provider': 'agent-browser', 'remote': True})  # managed browser with dashboard live view and replay
 ```
 
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `actionbook` | Browser action engine for web automation | [skills/actionbook](https://github.com/evolving-machines-lab/evolve/tree/main/skills/actionbook) |
-| `active-research` | Browser-enabled research workflows | [skills/active-research](https://github.com/evolving-machines-lab/evolve/tree/main/skills/active-research) |
-| `extract` | Browser data extraction workflows | [skills/extract](https://github.com/evolving-machines-lab/evolve/tree/main/skills/extract) |
-| `agent-browser` | CLI-based headless browser automation for AI agents | [skills/agent-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/agent-browser) |
-| `dev-browser` | Browser automation with persistent page state | [skills/dev-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/dev-browser) |
-| `webapp-testing` | Test web applications | [skills/webapp-testing](https://github.com/evolving-machines-lab/evolve/tree/main/skills/webapp-testing) |
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+
+`browser-use` remains available only as a legacy fallback for now:
+
+```python
+Evolve(browser='browser-use')  # legacy fallback: parse MCP output, no managed replay
+```
 
 ### Agent Plugins
 

--- a/skills/evolve/references/python/03-runtime.md
+++ b/skills/evolve/references/python/03-runtime.md
@@ -82,7 +82,7 @@ evolve.on('lifecycle', lambda event: print(event['reason'], event['sandbox']))
 | `stdout` | `str` | Raw JSONL output |
 | `stderr` | `str` | Error output |
 
-For full type definitions, all event interfaces, browser-use detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 

--- a/skills/evolve/references/python/04-streaming.md
+++ b/skills/evolve/references/python/04-streaming.md
@@ -120,15 +120,15 @@ ToolKind = Literal[
     "think",       # Task (subagent)
     "fetch",       # WebFetch, WebSearch
     "switch_mode", # ExitPlanMode
-    "other",       # MCP tools (including browser-use), unknown
+    "other",       # MCP tools (including `browser-use`), unknown
 ]
 
-# IMPORTANT: Browser-use MCP tools have kind="other", not "browser" or "fetch".
+# IMPORTANT: `browser-use` MCP tools have kind="other", not "browser" or "fetch".
 # To identify browser tools in your UI, check if title starts with "browser-use:"
 # (e.g., "browser-use: browser_task", "browser-use: monitor_task")
 
 def is_browser_use_tool(title: str | None) -> bool:
-    """Helper to detect browser-use tools."""
+    """Helper to detect `browser-use` tools."""
     return "browser-use" in (title or "").lower()
 
 ToolCallStatus = Literal["pending", "in_progress", "completed", "failed"]
@@ -220,15 +220,14 @@ class BrowserUseResponse(TypedDict):
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
-Use remote managed agent-browser for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+Use the recommended managed browser config for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed agent-browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| Remote managed Actionbook | `browser={'provider': 'actionbook', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| browser-use MCP | `browser='browser-use'` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Recommended managed browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
+| Legacy `browser-use` fallback | `browser='browser-use'` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
-### Remote managed Actionbook and agent-browser
+### Managed Browser
 
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
@@ -245,7 +244,6 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 
 ```python
 TraceMetadata = {
-    "browser_provider": "actionbook | agent-browser",
     "browser_session_id": "...",
     "dashboard_session_id": "...",
     "browser_session_tag": "...",
@@ -261,9 +259,9 @@ UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 
 ## BrowserUseResponse Extraction
 
-browser-use is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
+`browser-use` is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
 
-> **Detection:** Browser-use tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
+> **Detection:** `browser-use` tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
 
 **Extraction function** (use regex first for speed and malformed JSON tolerance, then JSON fallback):
 
@@ -273,7 +271,7 @@ import json
 from typing import Optional
 
 def extract_browser_use_urls(text: str) -> dict[str, Optional[str]]:
-    """Extract browser-use URLs from tool response text.
+    """Extract `browser-use` URLs from tool response text.
 
     Returns:
         {"live_url": str | None, "screenshot_url": str | None}
@@ -382,7 +380,7 @@ def handle_event(event: OutputEvent) -> None:
             content=update_data.get("content"),
         )
 
-        # 2. Extract browser-use URLs if present (first-party integration)
+        # 2. Extract `browser-use` URLs if present (first-party integration)
         for c in update_data.get("content") or []:
             if c.get("type") == "content":
                 inner = c.get("content", {})
@@ -412,6 +410,6 @@ evolve.on("content", handle_event)
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
 8. **Use `cast()` for narrowing** — TypedDict unions need explicit casting after checking `sessionUpdate`
-9. **Detect browser-use by title** — Browser-use MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
+9. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
 
 ---

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for the recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available for advanced MCP workflows, but it is inferior for browser automation UX because you must parse MCP tool output and do not get managed replay.
+- **Browser Automation:** Call `.withBrowser()` for the default and recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the recommended managed browser path with live view and replay. `.withBrowser("browser-use")` enables browser-use MCP for advanced MCP workflows, but requires MCP output parsing and does not provide managed replay. | Via skills or MCP |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now. | Via skills or MCP |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/skills/evolve/references/typescript/02-configuration.md
+++ b/skills/evolve/references/typescript/02-configuration.md
@@ -275,40 +275,19 @@ await evolve.run({ prompt: "Browse Hacker News top 5 articles and create a slide
 
 ### Browser Automation
 
-Browser automation is opt-in. `.withBrowser()` defaults to remote managed agent-browser with dashboard live view.
-
-- Use the default agent-browser path for most browser, QA, dogfooding, and website automation tasks.
-- Use remote managed mode for real websites because Evolve provides managed browser infrastructure with extra stealth capabilities.
-- Prefer `.withBrowser()` for browser automation UX. `browser-use` is an advanced MCP option and is inferior because live/screenshot URLs must be parsed from MCP tool output and managed replay is not available.
-- Use the provider string form for local dogfooding or local app testing.
-- Object configs default `remote` to `false` unless you set `remote: true`.
-- browser-use requires Gateway mode because Evolve injects the MCP server.
-
-| Option | Configure | What you get |
-|--------|-----------|--------------|
-| Remote managed agent-browser (default) | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | agent-browser skill, Evolve-managed remote browser transport, dashboard live view |
-| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | Actionbook skills, Evolve-managed remote browser transport, dashboard live view |
-| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; live/screenshot URLs must be parsed from browser-use tool responses, and managed replay is not available |
-
-Use `.withBrowser("actionbook")` or `.withBrowser("agent-browser")` to install only that provider's skills without managed live browser transport.
+Browser automation is opt-in. Use `.withBrowser()` for browser, QA, dogfooding, and website automation tasks.
 
 ```ts
-new Evolve().withBrowser(); // remote managed agent-browser with live view
-new Evolve().withBrowser({ provider: "agent-browser", remote: true }); // explicit default
-new Evolve().withBrowser({ provider: "actionbook", remote: true }); // remote managed Actionbook with live view
-new Evolve().withBrowser("actionbook"); // Actionbook skills only
-new Evolve().withBrowser("agent-browser"); // agent-browser skills only
-new Evolve().withBrowser("browser-use"); // browser-use MCP
+new Evolve().withBrowser(); // managed browser with dashboard live view and replay
 ```
 
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `actionbook` | Browser action engine for web automation | [skills/actionbook](https://github.com/evolving-machines-lab/evolve/tree/main/skills/actionbook) |
-| `active-research` | Browser-enabled research workflows | [skills/active-research](https://github.com/evolving-machines-lab/evolve/tree/main/skills/active-research) |
-| `extract` | Browser data extraction workflows | [skills/extract](https://github.com/evolving-machines-lab/evolve/tree/main/skills/extract) |
-| `agent-browser` | CLI-based headless browser automation for AI agents | [skills/agent-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/agent-browser) |
-| `dev-browser` | Browser automation with persistent page state | [skills/dev-browser](https://github.com/evolving-machines-lab/evolve/tree/main/skills/dev-browser) |
-| `webapp-testing` | Test web applications | [skills/webapp-testing](https://github.com/evolving-machines-lab/evolve/tree/main/skills/webapp-testing) |
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+
+`browser-use` remains available only as a legacy fallback for now:
+
+```ts
+new Evolve().withBrowser("browser-use"); // legacy fallback: parse MCP output, no managed replay
+```
 
 ### Agent Plugins
 

--- a/skills/evolve/references/typescript/03-runtime.md
+++ b/skills/evolve/references/typescript/03-runtime.md
@@ -77,7 +77,7 @@ evolve.on("lifecycle", (event: LifecycleEvent) => {
 | `stdout` | `string` | Raw JSONL output |
 | `stderr` | `string` | Error output |
 
-For full type definitions, all event interfaces, browser-use detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 

--- a/skills/evolve/references/typescript/04-streaming.md
+++ b/skills/evolve/references/typescript/04-streaming.md
@@ -226,13 +226,13 @@ type ToolKind =
   | "think"       // Task (subagent)
   | "fetch"       // WebFetch, WebSearch
   | "switch_mode" // ExitPlanMode
-  | "other";      // MCP tools (including browser-use), unknown
+  | "other";      // MCP tools (including `browser-use`), unknown
 ```
 
-> **Important:** Browser-use MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
+> **Important:** `browser-use` MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
 
 ```typescript
-// Helper to detect browser-use tools
+// Helper to detect `browser-use` tools
 function isBrowserUseTool(title?: string): boolean {
   return title?.toLowerCase().includes('browser-use') ?? false;
 }
@@ -274,15 +274,14 @@ interface DiffContent {
 
 Browser automation URLs are parsed differently depending on which browser option you enable:
 
-Use `.withBrowser()` for browser automation UX. `browser-use` remains supported for advanced MCP workflows, but it requires parsing tool output and does not provide managed replay.
+Use `.withBrowser()` for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
 
 | Option | Enable | Parse from stream |
 |--------|--------|-------------------|
-| Remote managed agent-browser | `.withBrowser()` or `.withBrowser({ provider: "agent-browser", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| Remote managed Actionbook | `.withBrowser({ provider: "actionbook", remote: true })` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| browser-use MCP | `.withBrowser("browser-use")` | Advanced MCP option; parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Recommended managed browser | `.withBrowser()` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
+| Legacy `browser-use` fallback | `.withBrowser("browser-use")` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
 
-### Remote managed Actionbook and agent-browser
+### Managed Browser
 
 Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
@@ -302,7 +301,6 @@ The same URL is also stored in trace metadata for replay or embedding after the 
 
 ```typescript
 type TraceMetadata = {
-  browser_provider?: "actionbook" | "agent-browser";
   browser_session_id?: string;
   dashboard_session_id?: string;
   browser_session_tag?: string;
@@ -318,9 +316,9 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ## BrowserUseResponse
 
-browser-use is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` unless you specifically need browser-use MCP, because browser-use responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
+`browser-use` is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
 
-> **Detection:** Browser-use tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
+> **Detection:** `browser-use` tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
 
 ```typescript
 interface BrowserUseResponse {
@@ -373,7 +371,7 @@ function extractBrowserUseUrls(text: string): { liveUrl?: string; screenshotUrl?
 ```typescript
 import type { OutputEvent } from "@evolvingmachines/sdk";
 
-// Helper to detect browser-use tools (they have kind: "other")
+// Helper to detect `browser-use` tools (they have kind: "other")
 function isBrowserUseTool(title?: string): boolean {
   return title?.toLowerCase().includes('browser-use') ?? false;
 }
@@ -402,16 +400,16 @@ function handleEvent(event: OutputEvent): void {
       break;
 
     case "tool_call":
-      // Store title for browser-use detection on updates
+      // Store title for `browser-use` detection on updates
       toolTitles.set(update.toolCallId, update.title);
 
-      // Determine effective kind for UI (browser-use has kind: "other")
+      // Determine effective kind for UI (`browser-use` has kind: "other")
       const effectiveKind = isBrowserUseTool(update.title) ? "browser" : update.kind;
 
       ui.addTool({
         id: update.toolCallId,
         title: update.title,
-        kind: effectiveKind,  // Use "browser" for browser-use tools
+        kind: effectiveKind,  // Use "browser" for `browser-use` tools
         status: update.status,
         locations: update.locations,
       });
@@ -424,7 +422,7 @@ function handleEvent(event: OutputEvent): void {
         content: update.content,
       });
 
-      // 2. Extract browser-use URLs if this is a browser-use tool
+      // 2. Extract `browser-use` URLs if this is a `browser-use` tool
       const title = toolTitles.get(update.toolCallId);
       if (isBrowserUseTool(title)) {
         for (const c of update.content ?? []) {
@@ -457,6 +455,6 @@ evolve.on("content", handleEvent);
 5. **Support images** — `ContentBlock` includes `ImageContent`
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
-8. **Detect browser-use by title** — Browser-use MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
+8. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
 
 ---


### PR DESCRIPTION
## Summary
- Make .withBrowser() the single recommended browser automation path in docs
- Remove public Actionbook/browser-skill selection guidance from docs
- Keep browser-use only as a legacy fallback and preserve MCP parsing guidance
- Sync Codex and Claude Evolve skill references

## Checks
- git diff --check
- docs/skill reference files compared with cmp
- grep scan for Actionbook/advanced MCP/browser-skill wording in public docs