### PR TITLE
docs: simplify browser automation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,19 +27,19 @@
 
 ### Highlights
 
-- Added remote managed `agent-browser` as a browser automation option alongside Actionbook.
-- Updated browser automation config around `remote: true`, with `.withBrowser()` still defaulting to remote managed Actionbook in TypeScript.
-- Added immediate browser live-view metadata for remote managed Actionbook and agent-browser runs.
+- Added remote managed `agent-browser` as the recommended browser automation path.
+- Updated browser automation config around `remote: true`, with `.withBrowser()` defaulting to remote managed browser automation in TypeScript.
+- Added immediate browser live-view metadata for remote managed browser runs.
 - Routed managed E2B sandbox operations through Dashboard-managed APIs in Gateway mode.
 - Added E2B `apiUrl` support for managed gateway routing.
 - Added Gemini 3.5 Flash models and fixed Gemini gateway passthrough routing.
-- Improved sandbox/browser reliability by detaching the Actionbook daemon in Docker and E2B assets.
+- Improved sandbox/browser reliability by detaching the browser daemon in Docker and E2B assets.
 
 ### Documentation And Skills
 
 - Refreshed browser automation docs for TypeScript, Python, streaming, and skill references.
 - Refreshed the `agent-browser` skill.
-- Clarified browser-use MCP parsing separately from remote managed browser lifecycle events.
+- Clarified remote managed browser lifecycle events.
 
 ### Tests
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, browser live/replay, parsing tool calls, legacy `browser-use` fallback | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events, browser live/replay | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -105,7 +105,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser automation live URLs, replay URLs, and legacy `browser-use` URL extraction | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
+| Browser automation live URLs and replay URLs | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -101,7 +101,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `session_tag_prefix` to label sessions for easy filtering.
-- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the default and recommended managed browser path with dashboard live view and replay. `browser='browser-use'` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
+- **Browser Automation:** Use `browser={'provider': 'agent-browser', 'remote': True}` for the default and recommended managed browser path with dashboard live view and replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `storage=StorageConfig()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -112,7 +112,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. `browser='browser-use'` remains available as a legacy fallback for now. | Via skills or MCP |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -279,10 +279,17 @@ Evolve(browser={'provider': 'agent-browser', 'remote': True})  # managed browser
 
 Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
 
-`browser-use` remains available only as a legacy fallback for now:
+Use the default managed remote browser unless you have a reason not to:
 
 ```python
-Evolve(browser='browser-use')  # legacy fallback: parse MCP output, no managed replay
+Evolve(browser={'provider': 'agent-browser', 'remote': True})
+# recommended: managed remote browser
+
+Evolve(browser={'provider': 'agent-browser', 'remote': False})
+# local agent-browser, no managed live/replay
+
+Evolve(browser=None)
+# disable browser automation
 ```
 
 ### Agent Plugins

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -82,7 +82,7 @@ evolve.on('lifecycle', lambda event: print(event['reason'], event['sandbox']))
 | `stdout` | `str` | Raw JSONL output |
 | `stderr` | `str` | Error output |
 
-For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, browser live view, replay, and UI integration example, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 
@@ -776,6 +776,45 @@ replay = await session.browser_replay(
   - Use `replay_url` in your UI for browser playback
   - Use `download_url` when users need the raw `.mp4` file
   - `suggested_start_seconds`, when present, is already applied to `replay_url`; keep the raw download unchanged
+
+End-to-end managed browser replay flow:
+
+```python
+from evolve import Evolve, sessions
+
+evolve = Evolve(
+    browser={'provider': 'agent-browser', 'remote': True},
+    session_tag_prefix='checkout-qa',
+)
+
+session_id = None
+
+try:
+    result = await evolve.run(
+        prompt='Open the app, test the checkout flow, and report issues.'
+    )
+
+    live_url = result.browser.get('live_url') if result.browser else None
+    session_id = result.session_id
+
+    if live_url:
+        show_live_browser(live_url)
+finally:
+    await evolve.kill()  # starts replay processing
+
+if not session_id:
+    raise RuntimeError('Missing dashboard session id')
+
+async with sessions() as session:
+    replay = await session.browser_replay(
+        session_id,
+        timeout_ms=600_000,
+        interval_ms=5_000,
+    )
+
+show_replay(replay.replay_url)
+save_download_link(replay.download_url)
+```
 
 Replay processing starts when the managed browser is cleaned up, usually during
 `kill()` or session cleanup. If the client times out, processing continues

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -120,16 +120,8 @@ ToolKind = Literal[
     "think",       # Task (subagent)
     "fetch",       # WebFetch, WebSearch
     "switch_mode", # ExitPlanMode
-    "other",       # MCP tools (including `browser-use`), unknown
+    "other",       # Unknown or third-party MCP tools
 ]
-
-# IMPORTANT: `browser-use` MCP tools have kind="other", not "browser" or "fetch".
-# To identify browser tools in your UI, check if title starts with "browser-use:"
-# (e.g., "browser-use: browser_task", "browser-use: monitor_task")
-
-def is_browser_use_tool(title: str | None) -> bool:
-    """Helper to detect `browser-use` tools."""
-    return "browser-use" in (title or "").lower()
 
 ToolCallStatus = Literal["pending", "in_progress", "completed", "failed"]
 
@@ -198,34 +190,20 @@ SessionUpdate = Union[
 class OutputEvent(TypedDict):
     sessionId: NotRequired[str]
     update: SessionUpdate
-
-# =============================================================================
-# Browser-Use Response (First-Party Integration)
-# =============================================================================
-
-class BrowserUseResponse(TypedDict):
-    """Browser automation response embedded in ToolCallUpdate.content[].content.text as JSON string."""
-    task_id: NotRequired[str]         # Task ID for monitoring
-    session_id: NotRequired[str]      # Browser session ID
-    live_url: NotRequired[str]        # VNC live view URL
-    screenshot_url: NotRequired[str]  # Final screenshot URL
-    steps: NotRequired[list[dict]]    # Per-step screenshots with url, memory, screenshot_url
-    is_success: NotRequired[bool]     # Task completion status
-    task_output: NotRequired[str]     # Final task result
 ```
 
 ---
 
 ## Browser Automation Streaming
 
-Browser automation URLs are parsed differently depending on which browser option you enable:
+Use `browser={'provider': 'agent-browser', 'remote': True}` for browser automation. Evolve emits live browser metadata through lifecycle events and returns the same browser metadata on `run()` results.
 
-Use the recommended managed browser config for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
-
-| Option | Enable | Parse from stream |
-|--------|--------|-------------------|
-| Recommended managed browser | `browser={'provider': 'agent-browser', 'remote': True}` | `lifecycle` event with `reason == "browser_ready"`; read `event["browser"]["live_url"]` and `event["browser"]["session_id"]` |
-| Legacy `browser-use` fallback | `browser='browser-use'` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Need | API | Use |
+|------|-----|-----|
+| Show live browser during a run | `lifecycle` event with `reason == "browser_ready"` | `event["browser"]["live_url"]` |
+| Save the browser/session id | same lifecycle event | `event["browser"]["session_id"]` |
+| Show live browser after `run()` returns | `AgentResponse.browser` | `result.browser["live_url"]` |
+| Fetch replay after cleanup | `sessions().browser_replay(session_id)` | `replay.replay_url`, `replay.download_url` |
 
 ### Managed Browser
 
@@ -254,56 +232,6 @@ TraceMetadata = {
 Use `event["browser"]["live_url"]` or `result.browser["live_url"]` for immediate
 UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
 `result.session_id` to `sessions().browser_replay()`.
-
----
-
-## BrowserUseResponse Extraction
-
-`browser-use` is available when enabled with `browser='browser-use'` in Gateway mode. Prefer remote managed agent-browser for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate["content"][].content.text`. You must extract and parse it.
-
-> **Detection:** `browser-use` tools arrive with `kind="other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use `is_browser_use_tool(title)` to identify them, then extract URLs from the tool output.
-
-**Extraction function** (use regex first for speed and malformed JSON tolerance, then JSON fallback):
-
-```python
-import re
-import json
-from typing import Optional
-
-def extract_browser_use_urls(text: str) -> dict[str, Optional[str]]:
-    """Extract `browser-use` URLs from tool response text.
-
-    Returns:
-        {"live_url": str | None, "screenshot_url": str | None}
-    """
-    live_url: Optional[str] = None
-    screenshot_url: Optional[str] = None
-
-    # 1. Regex extraction (fast, handles malformed JSON)
-    live_match = re.search(r'"live_url"\s*:\s*"([^"]+)"', text)
-    if live_match:
-        live_url = live_match.group(1)
-
-    screenshot_match = re.search(r'"screenshot_url"\s*:\s*"([^"]+)"', text)
-    if screenshot_match:
-        screenshot_url = screenshot_match.group(1)
-
-    # 2. JSON fallback (for steps[].screenshot_url)
-    if not live_url or not screenshot_url:
-        try:
-            parsed: BrowserUseResponse = json.loads(text)
-            if not live_url:
-                live_url = parsed.get("live_url")
-            if not screenshot_url:
-                steps = parsed.get("steps", [])
-                screenshot_url = parsed.get("screenshot_url") or (
-                    steps[-1].get("screenshot_url") if steps else None
-                )
-        except (json.JSONDecodeError, IndexError, KeyError):
-            pass
-
-    return {"live_url": live_url, "screenshot_url": screenshot_url}
-```
 
 ---
 
@@ -372,24 +300,11 @@ def handle_event(event: OutputEvent) -> None:
 
     elif event_type == "tool_call_update":
         update_data = cast(ToolCallUpdate, update)
-
-        # 1. Always update tool card with result
         ui.update_tool(
             update_data["toolCallId"],
             status=update_data.get("status"),
             content=update_data.get("content"),
         )
-
-        # 2. Extract `browser-use` URLs if present (first-party integration)
-        for c in update_data.get("content") or []:
-            if c.get("type") == "content":
-                inner = c.get("content", {})
-                if inner.get("type") == "text":
-                    urls = extract_browser_use_urls(inner["text"])
-                    if urls["live_url"]:
-                        ui.show_live_view_button(urls["live_url"])
-                    if urls["screenshot_url"]:
-                        ui.show_screenshot(urls["screenshot_url"])
 
     elif event_type == "plan":
         plan = cast(Plan, update)
@@ -410,6 +325,5 @@ evolve.on("content", handle_event)
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
 8. **Use `cast()` for narrowing** — TypedDict unions need explicit casting after checking `sessionUpdate`
-9. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind="other"`, check `"browser-use" in title.lower()` to identify them
 
 ---

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -67,7 +67,7 @@ await evolve.run(prompt='Hello world')
 | OutputEvent / SessionUpdate types | [Streaming → Type Definitions](./04-streaming.md#type-definitions) |
 | LifecycleEvent / LifecycleReason | [Streaming → LifecycleEvent](./04-streaming.md#lifecycleevent-typeddict-shape) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [Streaming → Type Definitions](./04-streaming.md#tool-types) |
-| Browser automation streaming & URL extraction | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
+| Browser automation live URLs and replay URLs | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
 | UI integration example | [Streaming → UI Integration Example](./04-streaming.md#ui-integration-example) |
 | Upload files (`upload_context()`, `upload_files()`) | [Runtime → Upload](./03-runtime.md#upload-local--sandbox) |
 | Download files (`get_output_files()`, `save_local_dir()`) | [Runtime → Download](./03-runtime.md#download-sandbox--local) |

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -114,7 +114,7 @@ See [Streaming Events](./04-streaming.md) for all event types, type definitions,
 When using `EVOLVE_API_KEY`:
 
 - **Tracing:** Automatic tracing and agent analytics at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) for observability and replay — no extra setup needed. Use `withSessionTagPrefix()` to label sessions for easy filtering.
-- **Browser Automation:** Call `.withBrowser()` for the default and recommended managed browser path with dashboard live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now, but it is not needed for new browser automation and may be removed as the default browser path gets stronger.
+- **Browser Automation:** Call `.withBrowser()` for the default and recommended managed browser path with dashboard live view and replay.
 - **Checkpointing:** Snapshot sandbox state to Evolve-managed storage with `.withStorage()` — no S3 credentials needed. See [Storage & Checkpointing](./03-runtime.md#storage--checkpointing).
 
 ---
@@ -125,7 +125,7 @@ When using `EVOLVE_API_KEY`:
 |---|---------|---------------|
 | Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
 | Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. `.withBrowser("browser-use")` remains available as a legacy fallback for now. | Via skills or MCP |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
 | Billing | Evolving Machines | Your provider accounts |
 
 ---

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -283,10 +283,20 @@ new Evolve().withBrowser(); // managed browser with dashboard live view and repl
 
 Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
 
-`browser-use` remains available only as a legacy fallback for now:
+Use the default unless you have a reason not to:
 
 ```ts
-new Evolve().withBrowser("browser-use"); // legacy fallback: parse MCP output, no managed replay
+new Evolve().withBrowser();
+// recommended: managed remote browser
+
+new Evolve().withBrowser({
+    provider: "agent-browser",
+    remote: false,
+});
+// local agent-browser, no managed live/replay
+
+new Evolve().withBrowser(false);
+// disable browser automation
 ```
 
 ### Agent Plugins

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -77,7 +77,7 @@ evolve.on("lifecycle", (event: LifecycleEvent) => {
 | `stdout` | `string` | Raw JSONL output |
 | `stderr` | `string` | Error output |
 
-For full type definitions, all event interfaces, legacy `browser-use` detection, and UI integration example, see [Streaming Events](./04-streaming.md).
+For full type definitions, all event interfaces, browser live view, replay, and UI integration examples, see [Streaming Events](./04-streaming.md).
 
 ### Upload: Local → Sandbox
 
@@ -737,6 +737,42 @@ const replay = await session.browserReplay(info.id, {
   timeoutMs: 600_000, // optional; default 10 minutes
   intervalMs: 5_000,  // optional; default 5 seconds
 });
+```
+
+End-to-end managed browser replay flow:
+
+```ts
+import { Evolve, sessions } from "@evolvingmachines/sdk";
+
+const evolve = new Evolve()
+    .withBrowser()
+    .withSessionTagPrefix("checkout-qa");
+
+let sessionId: string | undefined;
+
+try {
+    const result = await evolve.run({
+        prompt: "Open the app, test the checkout flow, and report issues.",
+    });
+
+    const liveUrl = result.browser?.liveUrl;       // show while the browser is live
+    sessionId = result.sessionId;                  // use later for traces/replay
+
+    if (liveUrl) showLiveBrowser(liveUrl);
+} finally {
+    await evolve.kill();                           // starts replay processing
+}
+
+if (!sessionId) throw new Error("Missing dashboard session id");
+
+const session = sessions();
+const replay = await session.browserReplay(sessionId, {
+    timeoutMs: 600_000,
+    intervalMs: 5_000,
+});
+
+showReplay(replay.replayUrl);                      // embeddable playback URL
+saveDownloadLink(replay.downloadUrl);              // raw .mp4 download URL
 ```
 
 Replay processing starts when the managed browser is cleaned up, usually during

--- a/docs/typescript/04-streaming.md
+++ b/docs/typescript/04-streaming.md
@@ -226,16 +226,7 @@ type ToolKind =
   | "think"       // Task (subagent)
   | "fetch"       // WebFetch, WebSearch
   | "switch_mode" // ExitPlanMode
-  | "other";      // MCP tools (including `browser-use`), unknown
-```
-
-> **Important:** `browser-use` MCP tools have `kind: "other"`, not `"browser"` or `"fetch"`. To identify browser tools in your UI, check if `title` starts with `"browser-use:"` (e.g., `"browser-use: browser_task"`, `"browser-use: monitor_task"`).
-
-```typescript
-// Helper to detect `browser-use` tools
-function isBrowserUseTool(title?: string): boolean {
-  return title?.toLowerCase().includes('browser-use') ?? false;
-}
+  | "other";      // Unknown or third-party MCP tools
 ```
 
 ### ToolCallStatus
@@ -272,14 +263,14 @@ interface DiffContent {
 
 ## Browser Automation Streaming
 
-Browser automation URLs are parsed differently depending on which browser option you enable:
+Use `.withBrowser()` for browser automation. Evolve emits live browser metadata through lifecycle events and returns the same browser metadata on `run()` results.
 
-Use `.withBrowser()` for browser automation UX. `browser-use` remains supported as a legacy fallback for now, but it requires parsing tool output and does not provide managed replay.
-
-| Option | Enable | Parse from stream |
-|--------|--------|-------------------|
-| Recommended managed browser | `.withBrowser()` | `lifecycle` event with `reason === "browser_ready"`; read `event.browser.liveUrl` and `event.browser.sessionId` |
-| Legacy `browser-use` fallback | `.withBrowser("browser-use")` | Parse embedded `live_url` and `screenshot_url` JSON fields from `tool_call_update` content |
+| Need | API | Use |
+|------|-----|-----|
+| Show live browser during a run | `lifecycle` event with `reason === "browser_ready"` | `event.browser.liveUrl` |
+| Save the browser/session id | same lifecycle event | `event.browser.sessionId` |
+| Show live browser after `run()` returns | `RunResult.browser` | `result.browser?.liveUrl` |
+| Fetch replay after cleanup | `sessions().browserReplay(sessionId)` | `replay.replayUrl`, `replay.downloadUrl` |
 
 ### Managed Browser
 
@@ -314,70 +305,10 @@ After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
 
 ---
 
-## BrowserUseResponse
-
-`browser-use` is available when enabled with `.withBrowser("browser-use")` in Gateway mode. Prefer `.withBrowser()` for new browser automation; use `browser-use` only as a legacy fallback, because `browser-use` responses embed a **JSON string** inside `ToolCallUpdate.content[].content.text`. You must extract and parse it.
-
-> **Detection:** `browser-use` tools arrive with `kind: "other"` and `title` like `"browser-use: browser_task"` or `"browser-use: monitor_task"`. Use the `isBrowserUseTool(title)` helper above to identify them, then extract URLs from the tool output.
-
-```typescript
-interface BrowserUseResponse {
-  task_id?: string;                           // Task ID for monitoring
-  session_id?: string;                        // Browser session ID
-  live_url?: string;                          // VNC live view URL
-  screenshot_url?: string;                    // Final screenshot URL
-  steps?: Array<{                             // Per-step screenshots
-    step_number: number;
-    screenshot_url?: string;
-    url?: string;                             // Page URL at this step
-    memory?: string;                          // Agent's reasoning
-  }>;
-  is_success?: boolean | null;                // Task completion status
-  task_output?: string | null;                // Final task result
-}
-```
-
-**Extraction function** (use regex first for speed and malformed JSON tolerance, then JSON.parse fallback for nested access):
-
-```typescript
-function extractBrowserUseUrls(text: string): { liveUrl?: string; screenshotUrl?: string } {
-  let liveUrl: string | undefined;
-  let screenshotUrl: string | undefined;
-
-  // 1. Regex extraction (fast, handles malformed JSON)
-  const liveMatch = text.match(/"live_url"\s*:\s*"([^"]+)"/);
-  if (liveMatch) liveUrl = liveMatch[1];
-
-  const screenshotMatch = text.match(/"screenshot_url"\s*:\s*"([^"]+)"/);
-  if (screenshotMatch) screenshotUrl = screenshotMatch[1];
-
-  // 2. JSON.parse fallback (for steps[].screenshot_url)
-  if (!liveUrl || !screenshotUrl) {
-    try {
-      const parsed = JSON.parse(text) as BrowserUseResponse;
-      if (!liveUrl) liveUrl = parsed.live_url;
-      if (!screenshotUrl) screenshotUrl = parsed.screenshot_url ?? parsed.steps?.[parsed.steps.length - 1]?.screenshot_url;
-    } catch {}
-  }
-
-  return { liveUrl, screenshotUrl };
-}
-```
-
----
-
 ## UI Integration Example
 
 ```typescript
 import type { OutputEvent } from "@evolvingmachines/sdk";
-
-// Helper to detect `browser-use` tools (they have kind: "other")
-function isBrowserUseTool(title?: string): boolean {
-  return title?.toLowerCase().includes('browser-use') ?? false;
-}
-
-// Track tool titles for browser detection
-const toolTitles = new Map<string, string>();
 
 function handleEvent(event: OutputEvent): void {
   const { update } = event;
@@ -400,39 +331,20 @@ function handleEvent(event: OutputEvent): void {
       break;
 
     case "tool_call":
-      // Store title for `browser-use` detection on updates
-      toolTitles.set(update.toolCallId, update.title);
-
-      // Determine effective kind for UI (`browser-use` has kind: "other")
-      const effectiveKind = isBrowserUseTool(update.title) ? "browser" : update.kind;
-
       ui.addTool({
         id: update.toolCallId,
         title: update.title,
-        kind: effectiveKind,  // Use "browser" for `browser-use` tools
+        kind: update.kind,
         status: update.status,
         locations: update.locations,
       });
       break;
 
     case "tool_call_update":
-      // 1. Always update tool card with result
       ui.updateTool(update.toolCallId, {
         status: update.status,
         content: update.content,
       });
-
-      // 2. Extract `browser-use` URLs if this is a `browser-use` tool
-      const title = toolTitles.get(update.toolCallId);
-      if (isBrowserUseTool(title)) {
-        for (const c of update.content ?? []) {
-          if (c.type === "content" && c.content?.type === "text") {
-            const urls = extractBrowserUseUrls(c.content.text);
-            if (urls.liveUrl) ui.showLiveViewButton(urls.liveUrl);
-            if (urls.screenshotUrl) ui.showScreenshot(urls.screenshotUrl);
-          }
-        }
-      }
       break;
 
     case "plan":
@@ -455,6 +367,5 @@ evolve.on("content", handleEvent);
 5. **Support images** — `ContentBlock` includes `ImageContent`
 6. **Use `kind` for icons** — Categorize tools visually (read, edit, execute, etc.)
 7. **Track `locations`** — Show affected file paths in UI
-8. **Detect `browser-use` by title** — `browser-use` MCP tools have `kind: "other"`, check `title.includes("browser-use")` to identify them
 
 ---

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -44,7 +44,7 @@ await evolve.run({ prompt: "Hello world" });
 | `.withContext()` / `.withFiles()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSystemPrompt()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSchema()` (Zod / JSON Schema) | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
-| `.withBrowser()` / legacy `.withBrowser("browser-use")` | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
+| `.withBrowser()` | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
 | `.withPlugins()` | [Configuration → Agent Plugins](./02-configuration.md#agent-plugins) |
 | `.withSkills()` | [Configuration → Agent Skills](./02-configuration.md#agent-skills) |
 | `.withComposio()` (1000+ integrations) | [Configuration → Composio](./02-configuration.md#composio-tool-router) |
@@ -67,7 +67,7 @@ await evolve.run({ prompt: "Hello world" });
 | OutputEvent / SessionUpdate types | [Streaming → SessionUpdate Types](./04-streaming.md#sessionupdate-types) |
 | LifecycleEvent / LifecycleReason | [Streaming → LifecycleEvent](./04-streaming.md#lifecycleevent) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [Streaming → Tool Events](./04-streaming.md#tool-events) |
-| Browser automation streaming & URL extraction | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
+| Browser automation live URLs and replay URLs | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
 | UI integration example | [Streaming → UI Integration Example](./04-streaming.md#ui-integration-example) |
 | Upload files (`uploadContext()`, `uploadFiles()`) | [Runtime → Upload](./03-runtime.md#upload-local--sandbox) |
 | Download files (`getOutputFiles()`, `saveLocalDir()`) | [Runtime → Download](./03-runtime.md#download-sandbox--local) |

--- a/packages/sdk-py/evolve/agent.py
+++ b/packages/sdk-py/evolve/agent.py
@@ -92,8 +92,7 @@ class Evolve:
             composio: Composio Tool Router setup for 500+ external service integrations
             storage: Storage configuration for checkpoint persistence (BYOK S3 or gateway mode)
             browser: Browser automation provider. Use {'provider': 'agent-browser', 'remote': True}
-                for managed remote browser automation, or 'browser-use' as a legacy
-                `browser-use` MCP fallback.
+                for managed remote browser automation.
             plugins: Agent plugins/extensions to install in the sandbox user profile before first run.
         """
         self.config = config

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -238,11 +238,7 @@ export class Evolve extends EventEmitter {
    * Enable browser automation.
    *
    * .withBrowser() defaults to agent-browser with Evolve-managed remote browser
-   * transport in gateway mode. Pass "browser-use" only as a legacy `browser-use`
-   * MCP fallback.
-   *
-   * @example
-   * kit.withBrowser("browser-use") // legacy `browser-use` MCP fallback
+   * transport in gateway mode.
    *
    * @example
    * kit.withBrowser() // defaults to remote managed agent-browser


### PR DESCRIPTION
## Summary
- Remove legacy browser-use and MCP parsing guidance from public docs
- Make .withBrowser() / managed agent-browser the single documented browser path
- Add compact live URL and replay examples for TypeScript and Python

## Checks
- rg stale browser wording across docs/ README.md CHANGELOG.md
- git diff --check