### PR TITLE
docs: consolidate browser automation guide

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -47,7 +47,7 @@ Read on demand when the user's task requires them:
 
 | When to read | TypeScript | Python |
 |-------------|-----------|--------|
-| Building a UI, handling real-time events, browser live/replay | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
+| Building a UI, handling real-time events | [04-streaming.md](references/typescript/04-streaming.md) | [04-streaming.md](references/python/04-streaming.md) |
 | Parallel agents (map/filter/reduce/bestOf/verify), Pipeline chaining | [05-swarm-pipeline.md](references/typescript/05-swarm-pipeline.md) | [05-swarm-pipeline.md](references/python/05-swarm-pipeline.md) |
 
 ## Topic Index
@@ -71,6 +71,7 @@ Read on demand when the user's task requires them:
 | Sandbox providers (E2B, Modal, Daytona) | [TS](references/typescript/02-configuration.md#sandbox-providers) | [PY](references/python/02-configuration.md#sandbox-providers) |
 | Provider auto-resolution from env | [TS](references/typescript/02-configuration.md#auto-resolution) | [PY](references/python/02-configuration.md#auto-resolution) |
 | Full builder/constructor API | [TS](references/typescript/02-configuration.md#evolve-instance) | [PY](references/python/02-configuration.md#evolve-instance) |
+| Browser automation guide (setup, live view, replay) | [TS](references/typescript/02-configuration.md#browser-automation) | [PY](references/python/02-configuration.md#browser-automation) |
 | Agent skills catalog | [TS](references/typescript/02-configuration.md#agent-skills) | [PY](references/python/02-configuration.md#agent-skills) |
 | Composio (auth paths, tool filtering, types) | [TS](references/typescript/02-configuration.md#composio-tool-router) | [PY](references/python/02-configuration.md#composio-tool-router) |
 | MCP server config (STDIO / HTTP / SSE) | [TS](references/typescript/02-configuration.md#evolve-instance) | [PY](references/python/02-configuration.md#evolve-instance) |
@@ -105,7 +106,7 @@ Read on demand when the user's task requires them:
 | LifecycleEvent & LifecycleReason | [TS](references/typescript/04-streaming.md#lifecycleevent) | [PY](references/python/04-streaming.md#lifecycleevent-typeddict-shape) |
 | OutputEvent & SessionUpdate types | [TS](references/typescript/04-streaming.md#sessionupdate-types) | [PY](references/python/04-streaming.md#event-types-summary) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [TS](references/typescript/04-streaming.md#tool-events) | [PY](references/python/04-streaming.md#toolkind-reference) |
-| Browser automation live URLs and replay URLs | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
+| Browser lifecycle event fields | [TS](references/typescript/04-streaming.md#browser-automation-streaming) | [PY](references/python/04-streaming.md#browser-automation-streaming) |
 | UI integration example | [TS](references/typescript/04-streaming.md#ui-integration-example) | [PY](references/python/04-streaming.md#ui-integration-example) |
 
 ### Swarm & Pipeline

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -277,7 +277,12 @@ Browser automation is opt-in. Use `browser={'provider': 'agent-browser', 'remote
 Evolve(browser={'provider': 'agent-browser', 'remote': True})  # managed browser with dashboard live view and replay
 ```
 
-Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser gives you:
+
+- `event["browser"]["live_url"]` from the `browser_ready` lifecycle event
+- `result.browser["live_url"]` after `run()` returns
+- `result.session_id`, which is the id to use for traces and browser replay
+- `sessions().browser_replay(session_id)`, which returns replay and raw `.mp4` download URLs after cleanup
 
 Use the default managed remote browser unless you have a reason not to:
 
@@ -291,6 +296,54 @@ Evolve(browser={'provider': 'agent-browser', 'remote': False})
 Evolve(browser=None)
 # disable browser automation
 ```
+
+Full browser run with live view and replay:
+
+```python
+from evolve import Evolve, sessions
+
+evolve = Evolve(
+    browser={'provider': 'agent-browser', 'remote': True},
+    session_tag_prefix='checkout-qa',
+)
+
+browser_session = {'id': None}
+session_id = None
+
+def on_lifecycle(event):
+    if event['reason'] == 'browser_ready' and event.get('browser'):
+        show_live_browser(event['browser']['live_url'])
+        browser_session['id'] = event['browser']['session_id']
+
+evolve.on('lifecycle', on_lifecycle)
+
+try:
+    result = await evolve.run(
+        prompt='Open the app, test the checkout flow, and report issues.'
+    )
+
+    session_id = result.session_id or browser_session['id']
+    if result.browser and result.browser.get('live_url'):
+        show_live_browser(result.browser['live_url'])
+finally:
+    await evolve.kill()
+
+if not session_id:
+    raise RuntimeError('Missing dashboard session id')
+
+async with sessions() as session:
+    replay = await session.browser_replay(
+        session_id,
+        timeout_ms=600_000,
+        interval_ms=5_000,
+    )
+
+show_replay(replay.replay_url)
+save_download_link(replay.download_url)
+```
+
+Replay processing starts when the managed browser is cleaned up, usually during `kill()`.
+If replay is not ready before `timeout_ms`, call `browser_replay()` again later with the same `session_id`.
 
 ### Agent Plugins
 

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -777,48 +777,8 @@ replay = await session.browser_replay(
   - Use `download_url` when users need the raw `.mp4` file
   - `suggested_start_seconds`, when present, is already applied to `replay_url`; keep the raw download unchanged
 
-End-to-end managed browser replay flow:
-
-```python
-from evolve import Evolve, sessions
-
-evolve = Evolve(
-    browser={'provider': 'agent-browser', 'remote': True},
-    session_tag_prefix='checkout-qa',
-)
-
-session_id = None
-
-try:
-    result = await evolve.run(
-        prompt='Open the app, test the checkout flow, and report issues.'
-    )
-
-    live_url = result.browser.get('live_url') if result.browser else None
-    session_id = result.session_id
-
-    if live_url:
-        show_live_browser(live_url)
-finally:
-    await evolve.kill()  # starts replay processing
-
-if not session_id:
-    raise RuntimeError('Missing dashboard session id')
-
-async with sessions() as session:
-    replay = await session.browser_replay(
-        session_id,
-        timeout_ms=600_000,
-        interval_ms=5_000,
-    )
-
-show_replay(replay.replay_url)
-save_download_link(replay.download_url)
-```
-
-Replay processing starts when the managed browser is cleaned up, usually during
-`kill()` or session cleanup. If the client times out, processing continues
-server-side; call `browser_replay()` again later to fetch the same replay.
+For the full browser setup, live-view, cleanup, and replay flow, see
+[Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
 This API is **gateway-only**. In BYOK/direct mode, historical traces remain
 available via local JSONL files in `~/.evolve-sdk/observability/sessions/`.

--- a/docs/python/04-streaming.md
+++ b/docs/python/04-streaming.md
@@ -196,14 +196,13 @@ class OutputEvent(TypedDict):
 
 ## Browser Automation Streaming
 
-Use `browser={'provider': 'agent-browser', 'remote': True}` for browser automation. Evolve emits live browser metadata through lifecycle events and returns the same browser metadata on `run()` results.
+The full browser guide is [Configuration → Browser Automation](./02-configuration.md#browser-automation).
+This section only documents the streaming fields for browser live view.
 
 | Need | API | Use |
 |------|-----|-----|
 | Show live browser during a run | `lifecycle` event with `reason == "browser_ready"` | `event["browser"]["live_url"]` |
 | Save the browser/session id | same lifecycle event | `event["browser"]["session_id"]` |
-| Show live browser after `run()` returns | `AgentResponse.browser` | `result.browser["live_url"]` |
-| Fetch replay after cleanup | `sessions().browser_replay(session_id)` | `replay.replay_url`, `replay.download_url` |
 
 ### Managed Browser
 
@@ -211,7 +210,7 @@ Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
 ```python
 def on_lifecycle(event):
-    if event['reason'] == 'browser_ready':
+    if event['reason'] == 'browser_ready' and event.get('browser'):
         open_live_view(event['browser']['live_url'])
         remember_session_id(event['browser']['session_id'])
 
@@ -230,8 +229,9 @@ TraceMetadata = {
 ```
 
 Use `event["browser"]["live_url"]` or `result.browser["live_url"]` for immediate
-UI display. After browser cleanup, pass `event["browser"]["session_id"]` or
-`result.session_id` to `sessions().browser_replay()`.
+UI display. For replay after cleanup, use the `session_id` with
+`sessions().browser_replay()`; the full example lives in
+[Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
 ---
 

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -44,7 +44,7 @@ await evolve.run(prompt='Hello world')
 | `context=` / `files=` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `system_prompt=` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `schema=` (Pydantic / JSON Schema) | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
-| `browser=` | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
+| `browser=` browser guide | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
 | `plugins=` | [Configuration → Agent Plugins](./02-configuration.md#agent-plugins) |
 | `skills=` | [Configuration → Agent Skills](./02-configuration.md#agent-skills) |
 | `composio=` (1000+ integrations) | [Configuration → Composio](./02-configuration.md#composio-tool-router) |
@@ -67,7 +67,7 @@ await evolve.run(prompt='Hello world')
 | OutputEvent / SessionUpdate types | [Streaming → Type Definitions](./04-streaming.md#type-definitions) |
 | LifecycleEvent / LifecycleReason | [Streaming → LifecycleEvent](./04-streaming.md#lifecycleevent-typeddict-shape) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [Streaming → Type Definitions](./04-streaming.md#tool-types) |
-| Browser automation live URLs and replay URLs | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
+| Browser lifecycle event fields | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
 | UI integration example | [Streaming → UI Integration Example](./04-streaming.md#ui-integration-example) |
 | Upload files (`upload_context()`, `upload_files()`) | [Runtime → Upload](./03-runtime.md#upload-local--sandbox) |
 | Download files (`get_output_files()`, `save_local_dir()`) | [Runtime → Download](./03-runtime.md#download-sandbox--local) |

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -281,7 +281,12 @@ Browser automation is opt-in. Use `.withBrowser()` for browser, QA, dogfooding, 
 new Evolve().withBrowser(); // managed browser with dashboard live view and replay
 ```
 
-Evolve automatically configures the browser runtime. In Gateway mode, the managed browser emits a live URL through lifecycle events and provides replay through the sessions API.
+Evolve automatically configures the browser runtime. In Gateway mode, the managed browser gives you:
+
+- `event.browser.liveUrl` from the `browser_ready` lifecycle event
+- `result.browser?.liveUrl` after `run()` returns
+- `result.sessionId`, which is the id to use for traces and browser replay
+- `sessions().browserReplay(sessionId)`, which returns replay and raw `.mp4` download URLs after cleanup
 
 Use the default unless you have a reason not to:
 
@@ -298,6 +303,51 @@ new Evolve().withBrowser({
 new Evolve().withBrowser(false);
 // disable browser automation
 ```
+
+Full browser run with live view and replay:
+
+```ts
+import { Evolve, sessions } from "@evolvingmachines/sdk";
+
+const evolve = new Evolve()
+    .withBrowser()
+    .withSessionTagPrefix("checkout-qa");
+
+let sessionId: string | undefined;
+
+evolve.on("lifecycle", (event) => {
+    if (event.reason === "browser_ready" && event.browser) {
+        showLiveBrowser(event.browser.liveUrl);
+        sessionId = event.browser.sessionId;
+    }
+});
+
+try {
+    const result = await evolve.run({
+        prompt: "Open the app, test the checkout flow, and report issues.",
+    });
+
+    sessionId = result.sessionId ?? sessionId;
+    if (result.browser?.liveUrl) {
+        showLiveBrowser(result.browser.liveUrl);
+    }
+} finally {
+    await evolve.kill();
+}
+
+if (!sessionId) throw new Error("Missing dashboard session id");
+
+const replay = await sessions().browserReplay(sessionId, {
+    timeoutMs: 600_000,
+    intervalMs: 5_000,
+});
+
+showReplay(replay.replayUrl);
+saveDownloadLink(replay.downloadUrl);
+```
+
+Replay processing starts when the managed browser is cleaned up, usually during `kill()`.
+If replay is not ready before `timeoutMs`, call `browserReplay()` again later with the same `sessionId`.
 
 ### Agent Plugins
 

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -739,45 +739,8 @@ const replay = await session.browserReplay(info.id, {
 });
 ```
 
-End-to-end managed browser replay flow:
-
-```ts
-import { Evolve, sessions } from "@evolvingmachines/sdk";
-
-const evolve = new Evolve()
-    .withBrowser()
-    .withSessionTagPrefix("checkout-qa");
-
-let sessionId: string | undefined;
-
-try {
-    const result = await evolve.run({
-        prompt: "Open the app, test the checkout flow, and report issues.",
-    });
-
-    const liveUrl = result.browser?.liveUrl;       // show while the browser is live
-    sessionId = result.sessionId;                  // use later for traces/replay
-
-    if (liveUrl) showLiveBrowser(liveUrl);
-} finally {
-    await evolve.kill();                           // starts replay processing
-}
-
-if (!sessionId) throw new Error("Missing dashboard session id");
-
-const session = sessions();
-const replay = await session.browserReplay(sessionId, {
-    timeoutMs: 600_000,
-    intervalMs: 5_000,
-});
-
-showReplay(replay.replayUrl);                      // embeddable playback URL
-saveDownloadLink(replay.downloadUrl);              // raw .mp4 download URL
-```
-
-Replay processing starts when the managed browser is cleaned up, usually during
-`kill()` or session cleanup. If the client times out, processing continues
-server-side; call `browserReplay()` again later to fetch the same replay.
+For the full browser setup, live-view, cleanup, and replay flow, see
+[Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
 Gateway-only — requires `EVOLVE_API_KEY`. In BYOK/direct mode, traces remain
 available as local JSONL files in `~/.evolve-sdk/observability/sessions/`.

--- a/docs/typescript/04-streaming.md
+++ b/docs/typescript/04-streaming.md
@@ -263,14 +263,13 @@ interface DiffContent {
 
 ## Browser Automation Streaming
 
-Use `.withBrowser()` for browser automation. Evolve emits live browser metadata through lifecycle events and returns the same browser metadata on `run()` results.
+The full browser guide is [Configuration → Browser Automation](./02-configuration.md#browser-automation).
+This section only documents the streaming fields for browser live view.
 
 | Need | API | Use |
 |------|-----|-----|
 | Show live browser during a run | `lifecycle` event with `reason === "browser_ready"` | `event.browser.liveUrl` |
 | Save the browser/session id | same lifecycle event | `event.browser.sessionId` |
-| Show live browser after `run()` returns | `RunResult.browser` | `result.browser?.liveUrl` |
-| Fetch replay after cleanup | `sessions().browserReplay(sessionId)` | `replay.replayUrl`, `replay.downloadUrl` |
 
 ### Managed Browser
 
@@ -278,9 +277,9 @@ Managed browser sessions emit the live-view URL as soon as the browser is ready:
 
 ```typescript
 evolve.on("lifecycle", (event) => {
-  if (event.reason === "browser_ready") {
-    openLiveView(event.browser!.liveUrl);
-    rememberSessionId(event.browser!.sessionId);
+  if (event.reason === "browser_ready" && event.browser) {
+    openLiveView(event.browser.liveUrl);
+    rememberSessionId(event.browser.sessionId);
   }
 });
 
@@ -300,8 +299,8 @@ type TraceMetadata = {
 ```
 
 Use `event.browser.liveUrl` or `result.browser?.liveUrl` for immediate UI display.
-After browser cleanup, pass `event.browser.sessionId` or `result.sessionId` to
-`sessions().browserReplay()`.
+For replay after cleanup, use the `sessionId` with `sessions().browserReplay()`;
+the full example lives in [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
 ---
 

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -44,7 +44,7 @@ await evolve.run({ prompt: "Hello world" });
 | `.withContext()` / `.withFiles()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSystemPrompt()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSchema()` (Zod / JSON Schema) | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
-| `.withBrowser()` | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
+| `.withBrowser()` browser guide | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
 | `.withPlugins()` | [Configuration → Agent Plugins](./02-configuration.md#agent-plugins) |
 | `.withSkills()` | [Configuration → Agent Skills](./02-configuration.md#agent-skills) |
 | `.withComposio()` (1000+ integrations) | [Configuration → Composio](./02-configuration.md#composio-tool-router) |
@@ -67,7 +67,7 @@ await evolve.run({ prompt: "Hello world" });
 | OutputEvent / SessionUpdate types | [Streaming → SessionUpdate Types](./04-streaming.md#sessionupdate-types) |
 | LifecycleEvent / LifecycleReason | [Streaming → LifecycleEvent](./04-streaming.md#lifecycleevent) |
 | Tool events (ToolCall, ToolCallUpdate, ToolKind) | [Streaming → Tool Events](./04-streaming.md#tool-events) |
-| Browser automation live URLs and replay URLs | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
+| Browser lifecycle event fields | [Streaming → Browser Automation Streaming](./04-streaming.md#browser-automation-streaming) |
 | UI integration example | [Streaming → UI Integration Example](./04-streaming.md#ui-integration-example) |
 | Upload files (`uploadContext()`, `uploadFiles()`) | [Runtime → Upload](./03-runtime.md#upload-local--sandbox) |
 | Download files (`getOutputFiles()`, `saveLocalDir()`) | [Runtime → Download](./03-runtime.md#download-sandbox--local) |


### PR DESCRIPTION
## Summary
- Make Configuration → Browser Automation the single full browser guide for TypeScript and Python
- Move the complete live-view + replay API example there
- Keep Runtime and Streaming as short references back to the main browser guide

## Checks
- rg stale browser/internal provider wording across docs/ README.md CHANGELOG.md
- git diff --check