### PR TITLE
docs: organize browser and plugin sections

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -72,6 +72,7 @@ Read on demand when the user's task requires them:
 | Provider auto-resolution from env | [TS](references/typescript/02-configuration.md#auto-resolution) | [PY](references/python/02-configuration.md#auto-resolution) |
 | Full builder/constructor API | [TS](references/typescript/02-configuration.md#evolve-instance) | [PY](references/python/02-configuration.md#evolve-instance) |
 | Browser automation guide (setup, live view, replay) | [TS](references/typescript/02-configuration.md#browser-automation) | [PY](references/python/02-configuration.md#browser-automation) |
+| Agent plugins/extensions | [TS](references/typescript/02-configuration.md#agent-plugins) | [PY](references/python/02-configuration.md#agent-plugins) |
 | Agent skills catalog | [TS](references/typescript/02-configuration.md#agent-skills) | [PY](references/python/02-configuration.md#agent-skills) |
 | Composio (auth paths, tool filtering, types) | [TS](references/typescript/02-configuration.md#composio-tool-router) | [PY](references/python/02-configuration.md#composio-tool-router) |
 | MCP server config (STDIO / HTTP / SSE) | [TS](references/typescript/02-configuration.md#evolve-instance) | [PY](references/python/02-configuration.md#evolve-instance) |

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -240,36 +240,7 @@ McpServerConfig = {
 }
 ```
 
-## Agent Skills
-
-Skills extend agent capabilities with specialized tools and workflows. See [agentskills.io](https://agentskills.io/home) for the open standard.
-
-```bash
-# .env
-EVOLVE_API_KEY=sk-...
-COMPOSIO_API_KEY=...
-```
-
-```python
-from evolve import Evolve
-
-evolve = Evolve(
-    browser={'provider': 'agent-browser', 'remote': True},
-    skills=['pptx'],
-)
-
-await evolve.run(prompt='Browse Hacker News top 5 articles and create a slide deck summarizing each')
-```
-
-### Documents
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `pdf` | Read, extract, and analyze PDF documents | [skills/pdf](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pdf) |
-| `docx` | Create and edit Word documents | [skills/docx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/docx) |
-| `pptx` | Create and edit PowerPoint presentations | [skills/pptx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pptx) |
-| `xlsx` | Create and edit Excel spreadsheets | [skills/xlsx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/xlsx) |
-
-### Browser Automation
+## Browser Automation
 
 Browser automation is opt-in. Use `browser={'provider': 'agent-browser', 'remote': True}` for browser, QA, dogfooding, and website automation tasks.
 
@@ -292,10 +263,9 @@ Evolve(browser={'provider': 'agent-browser', 'remote': True})
 
 Evolve(browser={'provider': 'agent-browser', 'remote': False})
 # local agent-browser, no managed live/replay
-
-Evolve(browser=None)
-# disable browser automation
 ```
+
+To disable browser automation, omit the `browser` argument.
 
 Full browser run with live view and replay:
 
@@ -345,7 +315,7 @@ save_download_link(replay.download_url)
 Replay processing starts when the managed browser is cleaned up, usually during `kill()`.
 If replay is not ready before `timeout_ms`, call `browser_replay()` again later with the same `session_id`.
 
-### Agent Plugins
+## Agent Plugins
 
 `plugins=` installs plugins/extensions into the sandbox user profile before the first agent command. The selected agent determines the accepted shape:
 
@@ -376,6 +346,33 @@ plugins={
 ```
 
 If `config=AgentConfig(...)` is omitted, plugins target the default agent (`claude`).
+
+## Agent Skills
+
+Skills extend agent capabilities with specialized tools and workflows. See [agentskills.io](https://agentskills.io/home) for the open standard.
+
+```bash
+# .env
+EVOLVE_API_KEY=sk-...
+```
+
+```python
+from evolve import Evolve
+
+evolve = Evolve(
+    skills=['pptx'],
+)
+
+await evolve.run(prompt='Create a slide deck summarizing the uploaded notes.')
+```
+
+### Documents
+| Skill | Description | Source |
+|-------|-------------|--------|
+| `pdf` | Read, extract, and analyze PDF documents | [skills/pdf](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pdf) |
+| `docx` | Create and edit Word documents | [skills/docx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/docx) |
+| `pptx` | Create and edit PowerPoint presentations | [skills/pptx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pptx) |
+| `xlsx` | Create and edit Excel spreadsheets | [skills/xlsx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/xlsx) |
 
 ### Research & Analysis
 | Skill | Description | Source |

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -245,35 +245,7 @@ interface McpServerConfig {
 }
 ```
 
-## Agent Skills
-
-Skills extend agent capabilities with specialized tools and workflows. See [agentskills.io](https://agentskills.io/home) for the open standard.
-
-```bash
-# .env
-EVOLVE_API_KEY=sk-...
-COMPOSIO_API_KEY=...
-```
-
-```ts
-import { Evolve } from "@evolvingmachines/sdk";
-
-const evolve = new Evolve()
-    .withBrowser()
-    .withSkills(["pptx"]);
-
-await evolve.run({ prompt: "Browse Hacker News top 5 articles and create a slide deck summarizing each" });
-```
-
-### Documents
-| Skill | Description | Source |
-|-------|-------------|--------|
-| `pdf` | Read, extract, and analyze PDF documents | [skills/pdf](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pdf) |
-| `docx` | Create and edit Word documents | [skills/docx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/docx) |
-| `pptx` | Create and edit PowerPoint presentations | [skills/pptx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pptx) |
-| `xlsx` | Create and edit Excel spreadsheets | [skills/xlsx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/xlsx) |
-
-### Browser Automation
+## Browser Automation
 
 Browser automation is opt-in. Use `.withBrowser()` for browser, QA, dogfooding, and website automation tasks.
 
@@ -299,10 +271,9 @@ new Evolve().withBrowser({
     remote: false,
 });
 // local agent-browser, no managed live/replay
-
-new Evolve().withBrowser(false);
-// disable browser automation
 ```
+
+To disable browser automation, omit `.withBrowser()`.
 
 Full browser run with live view and replay:
 
@@ -349,7 +320,7 @@ saveDownloadLink(replay.downloadUrl);
 Replay processing starts when the managed browser is cleaned up, usually during `kill()`.
 If replay is not ready before `timeoutMs`, call `browserReplay()` again later with the same `sessionId`.
 
-### Agent Plugins
+## Agent Plugins
 
 `.withPlugins()` installs plugins/extensions into the sandbox user profile before the first agent command. The currently selected agent determines the accepted shape:
 
@@ -380,6 +351,32 @@ If replay is not ready before `timeoutMs`, call `browserReplay()` again later wi
 ```
 
 If `.withAgent()` is omitted, plugins target the default agent (`claude`).
+
+## Agent Skills
+
+Skills extend agent capabilities with specialized tools and workflows. See [agentskills.io](https://agentskills.io/home) for the open standard.
+
+```bash
+# .env
+EVOLVE_API_KEY=sk-...
+```
+
+```ts
+import { Evolve } from "@evolvingmachines/sdk";
+
+const evolve = new Evolve()
+    .withSkills(["pptx"]);
+
+await evolve.run({ prompt: "Create a slide deck summarizing the uploaded notes." });
+```
+
+### Documents
+| Skill | Description | Source |
+|-------|-------------|--------|
+| `pdf` | Read, extract, and analyze PDF documents | [skills/pdf](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pdf) |
+| `docx` | Create and edit Word documents | [skills/docx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/docx) |
+| `pptx` | Create and edit PowerPoint presentations | [skills/pptx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/pptx) |
+| `xlsx` | Create and edit Excel spreadsheets | [skills/xlsx](https://github.com/evolving-machines-lab/evolve/tree/main/skills/xlsx) |
 
 ### Research & Analysis
 | Skill | Description | Source |


### PR DESCRIPTION
## Summary
- Move Browser Automation and Agent Plugins out of Agent Skills into top-level configuration sections
- Remove documented .withBrowser(false) / browser=None disable examples; docs now say to omit browser config
- Keep Agent Skills focused only on .withSkills()/skills=

## Checks
- rg stale browser/internal-provider wording across docs, README, CHANGELOG, package READMEs
- rg section headings for configuration docs
- git diff --check