### PR TITLE
docs: clarify browser remote mode

### DIFF
--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -255,6 +255,11 @@ Evolve automatically configures the browser runtime. In Gateway mode, the manage
 - `result.session_id`, which is the id to use for traces and browser replay
 - `sessions().browser_replay(session_id)`, which returns replay and raw `.mp4` download URLs after cleanup
 
+`remote` controls where the browser session runs:
+
+- `remote: True` creates an Evolve-managed cloud browser session, wires it into the sandbox, and exposes dashboard live view plus replay.
+- `remote: False` runs browser automation locally inside the sandbox. Use it only when you do not need managed live view or replay.
+
 Use the default managed remote browser unless you have a reason not to:
 
 ```python

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -260,6 +260,11 @@ Evolve automatically configures the browser runtime. In Gateway mode, the manage
 - `result.sessionId`, which is the id to use for traces and browser replay
 - `sessions().browserReplay(sessionId)`, which returns replay and raw `.mp4` download URLs after cleanup
 
+`remote` controls where the browser session runs:
+
+- `.withBrowser()` uses `remote: true` by default. Evolve creates and manages a cloud browser session, wires it into the sandbox, and exposes dashboard live view plus replay.
+- `remote: false` runs browser automation locally inside the sandbox. Use it only when you do not need managed live view or replay.
+
 Use the default unless you have a reason not to:
 
 ```ts


### PR DESCRIPTION
## Summary
- Explain what browser remote means in TypeScript and Python browser docs
- Clarify default remote managed browser vs local sandbox browser behavior

## Checks
- rg stale browser/internal-provider wording across docs, README, CHANGELOG, package READMEs
- git diff --check