### PR TITLE
docs: explain browser replay start time

### DIFF
--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -254,6 +254,7 @@ Evolve automatically configures the browser runtime. In Gateway mode, the manage
 - `result.browser["live_url"]` after `run()` returns
 - `result.session_id`, which is the id to use for traces and browser replay
 - `sessions().browser_replay(session_id)`, which returns replay and raw `.mp4` download URLs after cleanup
+- `replay.suggested_start_seconds`, when present, which is the recommended replay start time in seconds
 
 `remote` controls where the browser session runs:
 
@@ -315,10 +316,12 @@ async with sessions() as session:
 
 show_replay(replay.replay_url)
 save_download_link(replay.download_url)
+set_replay_start_time(replay.suggested_start_seconds or 0)
 ```
 
 Replay processing starts when the managed browser is cleaned up, usually during `kill()`.
 If replay is not ready before `timeout_ms`, call `browser_replay()` again later with the same `session_id`.
+The `replay_url` already applies `suggested_start_seconds`; use the field separately only if your UI needs to display or store the recommended start time.
 
 ## Agent Plugins
 

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -775,7 +775,7 @@ replay = await session.browser_replay(
   `replay_url` plus `download_url`
   - Use `replay_url` in your UI for browser playback
   - Use `download_url` when users need the raw `.mp4` file
-  - `suggested_start_seconds`, when present, is already applied to `replay_url`; keep the raw download unchanged
+  - `suggested_start_seconds`, when present, is the recommended replay start time in seconds and is already applied to `replay_url`; keep the raw download unchanged
 
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -259,6 +259,7 @@ Evolve automatically configures the browser runtime. In Gateway mode, the manage
 - `result.browser?.liveUrl` after `run()` returns
 - `result.sessionId`, which is the id to use for traces and browser replay
 - `sessions().browserReplay(sessionId)`, which returns replay and raw `.mp4` download URLs after cleanup
+- `replay.suggestedStartSeconds`, when present, which is the recommended replay start time in seconds
 
 `remote` controls where the browser session runs:
 
@@ -320,10 +321,12 @@ const replay = await sessions().browserReplay(sessionId, {
 
 showReplay(replay.replayUrl);
 saveDownloadLink(replay.downloadUrl);
+setReplayStartTime(replay.suggestedStartSeconds ?? 0);
 ```
 
 Replay processing starts when the managed browser is cleaned up, usually during `kill()`.
 If replay is not ready before `timeoutMs`, call `browserReplay()` again later with the same `sessionId`.
+The `replayUrl` already applies `suggestedStartSeconds`; use the field separately only if your UI needs to display or store the recommended start time.
 
 ## Agent Plugins
 

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -730,7 +730,7 @@ const replay = await session.browserReplay(info.id);
 - `browserReplay()` waits for the managed browser replay and returns `replayUrl` plus `downloadUrl`
   - Use `replayUrl` in your UI for browser playback
   - Use `downloadUrl` when users need the raw `.mp4` file
-  - `suggestedStartSeconds`, when present, is already applied to `replayUrl`; keep the raw download unchanged
+  - `suggestedStartSeconds`, when present, is the recommended replay start time in seconds and is already applied to `replayUrl`; keep the raw download unchanged
 
 ```ts
 const replay = await session.browserReplay(info.id, {


### PR DESCRIPTION
## Summary
- Document replay.suggestedStartSeconds / suggested_start_seconds in the main Browser Automation guide
- Clarify that the replay URL already applies the recommended start time
- Clarify the field meaning in the runtime replay reference

## Checks
- rg suggested start-time wording in browser docs
- git diff --check