### PR TITLE
Add managed browser credentials SDK support

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -72,6 +72,7 @@ Read on demand when the user's task requires them:
 | Provider auto-resolution from env | [TS](references/typescript/02-configuration.md#auto-resolution) | [PY](references/python/02-configuration.md#auto-resolution) |
 | Full builder/constructor API | [TS](references/typescript/02-configuration.md#evolve-instance) | [PY](references/python/02-configuration.md#evolve-instance) |
 | Browser automation guide (setup, live view, replay) | [TS](references/typescript/02-configuration.md#browser-automation) | [PY](references/python/02-configuration.md#browser-automation) |
+| Browser credentials (saved website logins) | [TS](references/typescript/02-configuration.md#browser-credentials) | [PY](references/python/02-configuration.md#browser-credentials) |
 | Agent plugins/extensions | [TS](references/typescript/02-configuration.md#agent-plugins) | [PY](references/python/02-configuration.md#agent-plugins) |
 | Agent skills catalog | [TS](references/typescript/02-configuration.md#agent-skills) | [PY](references/python/02-configuration.md#agent-skills) |
 | Composio (auth paths, tool filtering, types) | [TS](references/typescript/02-configuration.md#composio-tool-router) | [PY](references/python/02-configuration.md#composio-tool-router) |

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -344,7 +344,7 @@ Dashboard setup:
 1. Open the Evolve Dashboard.
 2. Go to **Secrets**.
 3. Add a browser login with `Account label`, `Website`, `Email`, and `Password`.
-4. Use `Website` for the domain, such as `github.com`; use `Account label` as a connected string like `qa-admin`, `work`, or `personal` to distinguish multiple saved accounts for the same website. It is not the website username or email.
+4. Use `Website` for the domain, such as `github.com`; use `Account label` as one word with no spaces, such as `qa-admin`, `work`, or `personal`, to distinguish multiple saved accounts for the same website. It is not the website username or email.
 
 Passwords are encrypted before upload. The dashboard and SDK list only login metadata: account label, website, email, and last-used time.
 

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -343,10 +343,10 @@ Dashboard setup:
 
 1. Open the Evolve Dashboard.
 2. Go to **Secrets**.
-3. Add a browser login with `Website`, `Alias`, `Email`, and `Password`.
-4. Use `Website` for the domain, such as `github.com`; use `Alias` to distinguish multiple accounts for the same website.
+3. Add a browser login with `Account label`, `Website`, `Email`, and `Password`.
+4. Use `Website` for the domain, such as `github.com`; use `Account label` as a connected string like `qa-admin`, `work`, or `personal` to distinguish multiple saved accounts for the same website. It is not the website username or email.
 
-Passwords are encrypted before upload. The dashboard and SDK list only login metadata: website, alias, email, and last-used time.
+Passwords are encrypted before upload. The dashboard and SDK list only login metadata: account label, website, email, and last-used time.
 
 Expose saved logins to a run:
 
@@ -356,7 +356,7 @@ from evolve import Evolve, BrowserCredentialsConfig
 evolve = Evolve(
     browser={'provider': 'agent-browser', 'remote': True},
     browser_credentials=BrowserCredentialsConfig(
-        allow=[{'website': 'github.com', 'alias': 'qa-admin'}],
+        allow=[{'website': 'github.com', 'account_label': 'qa-admin'}],
     ),
 )
 
@@ -380,7 +380,7 @@ evolve = Evolve(
 
 The agent receives a run-scoped `browser-login` MCP server with these tools:
 
-- `browser_list_logins` returns website, alias, and email metadata only.
+- `browser_list_logins` returns website, account_label, and email metadata only.
 - `browser_login` fills and submits a saved login on the current sign-in tab without returning the password.
 - `browser_complete_signup` completes password-based signup after the agent has filled non-secret fields, then saves the generated login for future `browser_login` calls.
 
@@ -394,7 +394,7 @@ credentials = browser_credentials()
 
 await credentials.create(
     website='github.com',
-    alias='qa-admin',
+    account_label='qa-admin',
     email='qualityassurance@example.com',
     password=os.environ['QA_GITHUB_PASSWORD'],
 )
@@ -403,7 +403,7 @@ page = await credentials.list(website='github.com')
 
 await credentials.delete(
     website='github.com',
-    alias='qa-admin',
+    account_label='qa-admin',
 )
 ```
 

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -329,6 +329,84 @@ If replay is not ready before `timeout_ms`, call `browser_replay()` again later 
 The `replay_url` already applies `suggested_start_seconds`; use the field separately only if your UI needs to display or store the recommended start time.
 The `status` is `'ready'` once `browser_replay()` returns.
 
+## Browser Credentials
+
+Browser credentials let managed remote `agent-browser` runs sign in with saved website logins without exposing passwords to the agent.
+
+Availability:
+
+- Requires Gateway mode and managed remote `agent-browser`.
+- Use `browser={'provider': 'agent-browser', 'remote': True}`.
+- Not available with `browser-use`, `actionbook`, `remote: False`, direct/BYOK provider mode, or existing sandbox sessions.
+
+Dashboard setup:
+
+1. Open the Evolve Dashboard.
+2. Go to **Secrets**.
+3. Add a browser login with `Website`, `Alias`, `Email`, and `Password`.
+4. Use `Website` for the domain, such as `github.com`; use `Alias` to distinguish multiple accounts for the same website.
+
+Passwords are encrypted before upload. The dashboard and SDK list only login metadata: website, alias, email, and last-used time.
+
+Expose saved logins to a run:
+
+```python
+from evolve import Evolve, BrowserCredentialsConfig
+
+evolve = Evolve(
+    browser={'provider': 'agent-browser', 'remote': True},
+    browser_credentials=BrowserCredentialsConfig(
+        allow=[{'website': 'github.com', 'alias': 'qa-admin'}],
+    ),
+)
+
+await evolve.run(
+    prompt='Open GitHub, sign in with the saved qa-admin login, and verify the repository settings page.'
+)
+
+await evolve.kill()
+```
+
+If `allow` is omitted, all enabled browser logins for the Evolve account are available to that run:
+
+```python
+from evolve import Evolve, BrowserCredentialsConfig
+
+evolve = Evolve(
+    browser={'provider': 'agent-browser', 'remote': True},
+    browser_credentials=BrowserCredentialsConfig(),
+)
+```
+
+The agent receives a run-scoped `browser-login` MCP server with these tools:
+
+- `browser_list_logins` returns website, alias, and email metadata only.
+- `browser_login` fills and submits a saved login on the current sign-in tab without returning the password.
+- `browser_complete_signup` completes password-based signup after the agent has filled non-secret fields, then saves the generated login for future `browser_login` calls.
+
+Manage browser logins from the SDK:
+
+```python
+import os
+from evolve import browser_credentials
+
+credentials = browser_credentials()
+
+await credentials.create(
+    website='github.com',
+    alias='qa-admin',
+    email='qualityassurance@example.com',
+    password=os.environ['QA_GITHUB_PASSWORD'],
+)
+
+page = await credentials.list(website='github.com')
+
+await credentials.delete(
+    website='github.com',
+    alias='qa-admin',
+)
+```
+
 ## Agent Plugins
 
 `plugins=` installs plugins/extensions into the sandbox user profile before the first agent command. The selected agent determines the accepted shape:

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -45,6 +45,7 @@ await evolve.run(prompt='Hello world')
 | `system_prompt=` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `schema=` (Pydantic / JSON Schema) | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `browser=` browser guide | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
+| `browser_credentials=` browser logins | [Configuration → Browser Credentials](./02-configuration.md#browser-credentials) |
 | `plugins=` | [Configuration → Agent Plugins](./02-configuration.md#agent-plugins) |
 | `skills=` | [Configuration → Agent Skills](./02-configuration.md#agent-skills) |
 | `composio=` (1000+ integrations) | [Configuration → Composio](./02-configuration.md#composio-tool-router) |

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -348,10 +348,10 @@ Dashboard setup:
 
 1. Open the Evolve Dashboard.
 2. Go to **Secrets**.
-3. Add a browser login with `Website`, `Alias`, `Email`, and `Password`.
-4. Use `Website` for the domain, such as `github.com`; use `Alias` to distinguish multiple accounts for the same website.
+3. Add a browser login with `Account label`, `Website`, `Email`, and `Password`.
+4. Use `Website` for the domain, such as `github.com`; use `Account label` as a connected string like `qa-admin`, `work`, or `personal` to distinguish multiple saved accounts for the same website. It is not the website username or email.
 
-Passwords are encrypted before upload. The dashboard and SDK list only login metadata: website, alias, email, and last-used time.
+Passwords are encrypted before upload. The dashboard and SDK list only login metadata: account label, website, email, and last-used time.
 
 Expose saved logins to a run:
 
@@ -361,7 +361,7 @@ import { Evolve } from "@evolvingmachines/sdk";
 const evolve = new Evolve()
     .withBrowser()
     .withBrowserCredentials({
-        allow: [{ website: "github.com", alias: "qa-admin" }],
+        allow: [{ website: "github.com", accountLabel: "qa-admin" }],
     });
 
 await evolve.run({
@@ -381,7 +381,7 @@ const evolve = new Evolve()
 
 The agent receives a run-scoped `browser-login` MCP server with these tools:
 
-- `browser_list_logins` returns website, alias, and email metadata only.
+- `browser_list_logins` returns website, account_label, and email metadata only.
 - `browser_login` fills and submits a saved login on the current sign-in tab without returning the password.
 - `browser_complete_signup` completes password-based signup after the agent has filled non-secret fields, then saves the generated login for future `browser_login` calls.
 
@@ -394,7 +394,7 @@ const credentials = Evolve.browserCredentials();
 
 await credentials.create({
     website: "github.com",
-    alias: "qa-admin",
+    accountLabel: "qa-admin",
     email: "qualityassurance@example.com",
     password: process.env.QA_GITHUB_PASSWORD!,
 });
@@ -403,7 +403,7 @@ const page = await credentials.list({ website: "github.com" });
 
 await credentials.delete({
     website: "github.com",
-    alias: "qa-admin",
+    accountLabel: "qa-admin",
 });
 ```
 

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -349,7 +349,7 @@ Dashboard setup:
 1. Open the Evolve Dashboard.
 2. Go to **Secrets**.
 3. Add a browser login with `Account label`, `Website`, `Email`, and `Password`.
-4. Use `Website` for the domain, such as `github.com`; use `Account label` as a connected string like `qa-admin`, `work`, or `personal` to distinguish multiple saved accounts for the same website. It is not the website username or email.
+4. Use `Website` for the domain, such as `github.com`; use `Account label` as one word with no spaces, such as `qa-admin`, `work`, or `personal`, to distinguish multiple saved accounts for the same website. It is not the website username or email.
 
 Passwords are encrypted before upload. The dashboard and SDK list only login metadata: account label, website, email, and last-used time.
 

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -334,6 +334,79 @@ If replay is not ready before `timeoutMs`, call `browserReplay()` again later wi
 The `replayUrl` already applies `suggestedStartSeconds`; use the field separately only if your UI needs to display or store the recommended start time.
 The `status` is `"ready"` once `browserReplay()` returns.
 
+## Browser Credentials
+
+Browser credentials let managed remote `agent-browser` runs sign in with saved website logins without exposing passwords to the agent.
+
+Availability:
+
+- Requires Gateway mode and managed remote `agent-browser`.
+- `.withBrowser()` uses that recommended remote setup by default.
+- Not available with `browser-use`, `actionbook`, `remote: false`, direct/BYOK provider mode, or `.withSession()`.
+
+Dashboard setup:
+
+1. Open the Evolve Dashboard.
+2. Go to **Secrets**.
+3. Add a browser login with `Website`, `Alias`, `Email`, and `Password`.
+4. Use `Website` for the domain, such as `github.com`; use `Alias` to distinguish multiple accounts for the same website.
+
+Passwords are encrypted before upload. The dashboard and SDK list only login metadata: website, alias, email, and last-used time.
+
+Expose saved logins to a run:
+
+```ts
+import { Evolve } from "@evolvingmachines/sdk";
+
+const evolve = new Evolve()
+    .withBrowser()
+    .withBrowserCredentials({
+        allow: [{ website: "github.com", alias: "qa-admin" }],
+    });
+
+await evolve.run({
+    prompt: "Open GitHub, sign in with the saved qa-admin login, and verify the repository settings page.",
+});
+
+await evolve.kill();
+```
+
+If `allow` is omitted, all enabled browser logins for the Evolve account are available to that run:
+
+```ts
+const evolve = new Evolve()
+    .withBrowser()
+    .withBrowserCredentials();
+```
+
+The agent receives a run-scoped `browser-login` MCP server with these tools:
+
+- `browser_list_logins` returns website, alias, and email metadata only.
+- `browser_login` fills and submits a saved login on the current sign-in tab without returning the password.
+- `browser_complete_signup` completes password-based signup after the agent has filled non-secret fields, then saves the generated login for future `browser_login` calls.
+
+Manage browser logins from the SDK:
+
+```ts
+import { Evolve } from "@evolvingmachines/sdk";
+
+const credentials = Evolve.browserCredentials();
+
+await credentials.create({
+    website: "github.com",
+    alias: "qa-admin",
+    email: "qualityassurance@example.com",
+    password: process.env.QA_GITHUB_PASSWORD!,
+});
+
+const page = await credentials.list({ website: "github.com" });
+
+await credentials.delete({
+    website: "github.com",
+    alias: "qa-admin",
+});
+```
+
 ## Agent Plugins
 
 `.withPlugins()` installs plugins/extensions into the sandbox user profile before the first agent command. The currently selected agent determines the accepted shape:

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -45,6 +45,7 @@ await evolve.run({ prompt: "Hello world" });
 | `.withSystemPrompt()` | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withSchema()` (Zod / JSON Schema) | [Configuration → Evolve Instance](./02-configuration.md#evolve-instance) |
 | `.withBrowser()` browser guide | [Configuration → Browser Automation](./02-configuration.md#browser-automation) |
+| `.withBrowserCredentials()` browser logins | [Configuration → Browser Credentials](./02-configuration.md#browser-credentials) |
 | `.withPlugins()` | [Configuration → Agent Plugins](./02-configuration.md#agent-plugins) |
 | `.withSkills()` | [Configuration → Agent Skills](./02-configuration.md#agent-skills) |
 | `.withComposio()` (1000+ integrations) | [Configuration → Composio](./02-configuration.md#composio-tool-router) |

--- a/packages/sdk-py/bridge/src/adapter.ts
+++ b/packages/sdk-py/bridge/src/adapter.ts
@@ -192,6 +192,9 @@ export class EvolveAdapter {
     if (params.browser) {
       kit.withBrowser(params.browser);
     }
+    if (params.browser_credentials !== undefined) {
+      kit.withBrowserCredentials(params.browser_credentials);
+    }
     if (params.plugins?.length) {
       (kit as Evolve & { withPlugins: (plugins: unknown[]) => Evolve }).withPlugins(params.plugins);
     }

--- a/packages/sdk-py/bridge/src/types.ts
+++ b/packages/sdk-py/bridge/src/types.ts
@@ -79,6 +79,7 @@ export interface InitializeParams {
   files?: EncodedFileMap;
   mcp_servers?: Record<string, any>;
   browser?: 'browser-use' | 'actionbook' | 'agent-browser' | { provider: 'actionbook' | 'agent-browser'; remote?: boolean };
+  browser_credentials?: BrowserCredentialsConfig;
   plugins?: AgentPluginConfig[];
   skills?: string[];
   secrets?: Record<string, string>;
@@ -122,6 +123,15 @@ export interface SetSessionParams {
 
 export interface GetHostParams {
   port: number;
+}
+
+export interface BrowserCredentialScopeEntry {
+  website: string;
+  alias?: string;
+}
+
+export interface BrowserCredentialsConfig {
+  allow?: BrowserCredentialScopeEntry[];
 }
 
 // =============================================================================

--- a/packages/sdk-py/bridge/src/types.ts
+++ b/packages/sdk-py/bridge/src/types.ts
@@ -127,7 +127,7 @@ export interface GetHostParams {
 
 export interface BrowserCredentialScopeEntry {
   website: string;
-  alias?: string;
+  account_label?: string;
 }
 
 export interface BrowserCredentialsConfig {

--- a/packages/sdk-py/evolve/__init__.py
+++ b/packages/sdk-py/evolve/__init__.py
@@ -11,6 +11,9 @@ from .config import (
     WorkspaceMode,
     BrowserProvider,
     BrowserConfig,
+    BrowserCredentialScopeEntry,
+    BrowserCredentialsConfig,
+    BrowserCredentialsClientConfig,
     AgentPluginConfig,
     ReasoningEffort,
     ValidationMode,
@@ -37,6 +40,7 @@ from .results import (
 )
 from .storage_client import StorageClient
 from .sessions_client import SessionsClient
+from .browser_credentials import BrowserCredentialsClient, BrowserCredentialMetadata, BrowserCredentialsPage
 from .utils import read_local_dir, save_local_dir
 from .bridge import (
     SandboxNotFoundError,
@@ -149,6 +153,15 @@ def sessions(config: Optional[SessionsConfig] = None) -> SessionsClient:
     return SessionsClient(bridge, config or SessionsConfig(), _owns_bridge=True)
 
 
+def browser_credentials(config: Optional[BrowserCredentialsClientConfig] = None) -> BrowserCredentialsClient:
+    """Create a standalone browser credentials client.
+
+    Uses EVOLVE_API_KEY unless BrowserCredentialsClientConfig(api_key=...) is provided.
+    Passwords are encrypted locally before they are sent to the dashboard.
+    """
+    return BrowserCredentialsClient(config or BrowserCredentialsClientConfig())
+
+
 async def list_checkpoints(
     storage: Optional[StorageConfig] = None,
     limit: Optional[int] = None,
@@ -202,6 +215,9 @@ __all__ = [
     'WorkspaceMode',
     'BrowserProvider',
     'BrowserConfig',
+    'BrowserCredentialScopeEntry',
+    'BrowserCredentialsConfig',
+    'BrowserCredentialsClientConfig',
     'AgentPluginConfig',
     'ReasoningEffort',
     'ValidationMode',
@@ -212,6 +228,9 @@ __all__ = [
     'StorageConfig',
     'StorageCredentials',
     'SessionsConfig',
+    'BrowserCredentialsClient',
+    'BrowserCredentialMetadata',
+    'BrowserCredentialsPage',
 
     # Evolve Results
     'AgentResponse',
@@ -229,6 +248,7 @@ __all__ = [
     # Standalone clients
     'StorageClient',
     'SessionsClient',
+    'browser_credentials',
 
     # Standalone functions
     'storage',

--- a/packages/sdk-py/evolve/agent.py
+++ b/packages/sdk-py/evolve/agent.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, is_dataclass
 from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
 from .bridge import BridgeManager, SandboxNotFoundError
-from .config import AgentConfig, AgentPluginConfig, BrowserConfig, ComposioSetup, SandboxProvider, SchemaOptions, StorageConfig, WorkspaceMode
+from .config import AgentConfig, AgentPluginConfig, BrowserConfig, BrowserCredentialsConfig, ComposioSetup, SandboxProvider, SchemaOptions, StorageConfig, WorkspaceMode
 from .results import AgentResponse, CheckpointInfo, ExecuteResult, OutputResult, RunCost, SessionCost, SessionStatus
 from .storage_client import StorageClient
 from . import composio as composio_helpers
@@ -66,6 +66,7 @@ class Evolve:
         composio: Optional[ComposioSetup] = None,
         storage: Optional[StorageConfig] = None,
         browser: Optional[BrowserConfig] = None,
+        browser_credentials: Optional[BrowserCredentialsConfig] = None,
         plugins: Optional[Union[AgentPluginConfig, List[AgentPluginConfig]]] = None,
     ):
         """Initialize Evolve.
@@ -93,6 +94,7 @@ class Evolve:
             storage: Storage configuration for checkpoint persistence (BYOK S3 or gateway mode)
             browser: Browser automation provider. Use {'provider': 'agent-browser', 'remote': True}
                 for managed remote browser automation.
+            browser_credentials: Saved browser login MCP setup. Requires managed remote agent-browser.
             plugins: Agent plugins/extensions to install in the sandbox user profile before first run.
         """
         self.config = config
@@ -104,6 +106,7 @@ class Evolve:
         self.files = files
         self.mcp_servers = mcp_servers
         self.browser = self._normalize_browser(browser)
+        self.browser_credentials = browser_credentials
         self.skills = skills
         self.secrets = secrets
         self.sandbox_id = sandbox_id
@@ -150,6 +153,7 @@ class Evolve:
                 'files': _encode_files_for_transport(self.files) if self.files else None,
                 'mcp_servers': self.mcp_servers,
                 'browser': self.browser,
+                'browser_credentials': self.browser_credentials.to_dict() if self.browser_credentials else None,
                 'plugins': self.plugins,
                 'skills': self.skills,
                 'secrets': self.secrets,

--- a/packages/sdk-py/evolve/browser_credentials.py
+++ b/packages/sdk-py/evolve/browser_credentials.py
@@ -1,0 +1,275 @@
+"""Standalone browser credentials client."""
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import secrets
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from .config import BrowserCredentialsClientConfig
+
+
+DEFAULT_DASHBOARD_URL = 'https://dashboard.evolvingmachines.ai'
+BROWSER_AUTH_ALGORITHM = 'RSA-OAEP-256'
+
+
+@dataclass
+class BrowserCredentialMetadata:
+    id: str
+    website: str
+    alias: str
+    email: str
+    enabled: bool
+    created_by: str
+    created_at: str
+    updated_at: str
+    last_used_at: Optional[str]
+
+
+@dataclass
+class BrowserCredentialsPage:
+    credentials: List[BrowserCredentialMetadata]
+    total: int
+    count: int
+    offset: int
+    has_more: bool
+
+
+def _metadata_from_dict(data: Dict[str, Any]) -> BrowserCredentialMetadata:
+    return BrowserCredentialMetadata(
+        id=data['id'],
+        website=data['website'],
+        alias=data['alias'],
+        email=data['email'],
+        enabled=bool(data.get('enabled', True)),
+        created_by=data.get('createdBy') or data.get('created_by') or 'user',
+        created_at=data.get('createdAt') or data.get('created_at') or '',
+        updated_at=data.get('updatedAt') or data.get('updated_at') or '',
+        last_used_at=data.get('lastUsedAt') or data.get('last_used_at'),
+    )
+
+
+class BrowserCredentialsClient:
+    """List, create, and delete saved browser logins without returning passwords."""
+
+    def __init__(
+        self,
+        config: Optional[BrowserCredentialsClientConfig] = None,
+    ):
+        self.config = config or BrowserCredentialsClientConfig()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    async def close(self):
+        return None
+
+    async def list(
+        self,
+        website: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> BrowserCredentialsPage:
+        params = {}
+        if website is not None:
+            params['website'] = website
+        if limit is not None:
+            params['limit'] = str(limit)
+        if offset is not None:
+            params['offset'] = str(offset)
+        query = urllib.parse.urlencode(params)
+        result = await self._request_json(f'/api/browser-credentials{("?" + query) if query else ""}')
+        credentials = [_metadata_from_dict(item) for item in result.get('credentials', [])]
+        return BrowserCredentialsPage(
+            credentials=credentials,
+            total=int(result.get('total', len(credentials))),
+            count=int(result.get('count', len(credentials))),
+            offset=int(result.get('offset', offset or 0)),
+            has_more=bool(result.get('hasMore', result.get('has_more', False))),
+        )
+
+    async def create(
+        self,
+        *,
+        website: str,
+        alias: str,
+        email: str,
+        password: str,
+    ) -> Dict[str, Any]:
+        encrypted_password = await self._encrypt_password(password)
+        result = await self._request_json('/api/browser-credentials', method='POST', body={
+            'website': website,
+            'alias': alias,
+            'email': email,
+            'encryptedPassword': encrypted_password,
+        })
+        return {
+            'status': result['status'],
+            'credential': _metadata_from_dict(result['credential']),
+        }
+
+    async def delete(
+        self,
+        *,
+        id: Optional[str] = None,
+        website: Optional[str] = None,
+        alias: Optional[str] = None,
+    ) -> Dict[str, bool]:
+        if id:
+            body = {'id': id}
+        elif website and alias:
+            body = {'website': website, 'alias': alias}
+        else:
+            raise ValueError('delete requires either id or website and alias')
+        return await self._request_json('/api/browser-credentials', method='DELETE', body=body)
+
+    async def _encrypt_password(self, password: str) -> Dict[str, str]:
+        key = await self._request_json('/api/browser-credentials/public-key')
+        if key.get('algorithm') != BROWSER_AUTH_ALGORITHM:
+            raise ValueError('Unsupported browser credential encryption algorithm')
+        ciphertext = _rsa_oaep_sha256_encrypt(key['publicKey'], password.encode('utf-8'))
+        return {
+            'algorithm': BROWSER_AUTH_ALGORITHM,
+            'keyId': key['id'],
+            'ciphertext': _base64url(ciphertext),
+        }
+
+    async def _request_json(
+        self,
+        path: str,
+        method: str = 'GET',
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return await asyncio.to_thread(self._request_json_sync, path, method, body)
+
+    def _request_json_sync(
+        self,
+        path: str,
+        method: str,
+        body: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        data = json.dumps(body).encode('utf-8') if body is not None else None
+        headers = {
+            'Authorization': f'Bearer {_resolve_api_key(self.config)}',
+            'Accept': 'application/json',
+        }
+        if data is not None:
+            headers['Content-Type'] = 'application/json'
+        request = urllib.request.Request(
+            f'{_dashboard_base_url(self.config)}{path}',
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = response.read().decode('utf-8')
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode('utf-8', errors='replace')
+            raise RuntimeError(f'Browser credentials request failed ({exc.code}): {detail}') from exc
+        if not payload:
+            return {}
+        return json.loads(payload)
+
+
+def _dashboard_base_url(config: BrowserCredentialsClientConfig) -> str:
+    return (config.dashboard_url or os.environ.get('EVOLVE_DASHBOARD_URL') or DEFAULT_DASHBOARD_URL).rstrip('/')
+
+
+def _resolve_api_key(config: BrowserCredentialsClientConfig) -> str:
+    api_key = config.api_key or os.environ.get('EVOLVE_API_KEY')
+    if not api_key:
+        raise ValueError('Browser credentials require EVOLVE_API_KEY or BrowserCredentialsClientConfig(api_key=...)')
+    return api_key
+
+
+def _base64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode('ascii').rstrip('=')
+
+
+def _read_der_length(data: bytes, offset: int) -> Tuple[int, int]:
+    first = data[offset]
+    offset += 1
+    if first < 0x80:
+        return first, offset
+    count = first & 0x7F
+    if count == 0 or count > 4:
+        raise ValueError('Unsupported DER length')
+    length = int.from_bytes(data[offset:offset + count], 'big')
+    return length, offset + count
+
+
+def _read_der_tlv(data: bytes, offset: int, expected_tag: int) -> Tuple[bytes, int]:
+    if offset >= len(data) or data[offset] != expected_tag:
+        raise ValueError('Unexpected public key format')
+    length, value_start = _read_der_length(data, offset + 1)
+    value_end = value_start + length
+    if value_end > len(data):
+        raise ValueError('Invalid public key length')
+    return data[value_start:value_end], value_end
+
+
+def _parse_rsa_public_key(pem: str) -> Tuple[int, int, int]:
+    body = ''.join(
+        line.strip()
+        for line in pem.splitlines()
+        if line and not line.startswith('-----')
+    )
+    der = base64.b64decode(body)
+    spki, offset = _read_der_tlv(der, 0, 0x30)
+    if offset != len(der):
+        raise ValueError('Unexpected trailing public key data')
+    _, offset = _read_der_tlv(spki, 0, 0x30)
+    bit_string, offset = _read_der_tlv(spki, offset, 0x03)
+    if offset != len(spki) or not bit_string or bit_string[0] != 0:
+        raise ValueError('Invalid RSA public key')
+    rsa_key, offset = _read_der_tlv(bit_string[1:], 0, 0x30)
+    if offset != len(bit_string) - 1:
+        raise ValueError('Unexpected RSA key data')
+    modulus_bytes, offset = _read_der_tlv(rsa_key, 0, 0x02)
+    exponent_bytes, offset = _read_der_tlv(rsa_key, offset, 0x02)
+    if offset != len(rsa_key):
+        raise ValueError('Unexpected RSA integer data')
+    n = int.from_bytes(modulus_bytes.lstrip(b'\x00'), 'big')
+    e = int.from_bytes(exponent_bytes, 'big')
+    k = (n.bit_length() + 7) // 8
+    return n, e, k
+
+
+def _mgf1(seed: bytes, length: int) -> bytes:
+    output = bytearray()
+    counter = 0
+    while len(output) < length:
+        output.extend(hashlib.sha256(seed + counter.to_bytes(4, 'big')).digest())
+        counter += 1
+    return bytes(output[:length])
+
+
+def _xor_bytes(left: bytes, right: bytes) -> bytes:
+    return bytes(a ^ b for a, b in zip(left, right))
+
+
+def _rsa_oaep_sha256_encrypt(public_key_pem: str, plaintext: bytes) -> bytes:
+    n, e, k = _parse_rsa_public_key(public_key_pem)
+    h_len = hashlib.sha256().digest_size
+    if len(plaintext) > k - 2 * h_len - 2:
+        raise ValueError('Browser credential password is too long for RSA-OAEP-256')
+
+    label_hash = hashlib.sha256(b'').digest()
+    padding = b'\x00' * (k - len(plaintext) - 2 * h_len - 2)
+    data_block = label_hash + padding + b'\x01' + plaintext
+    seed = secrets.token_bytes(h_len)
+    masked_data_block = _xor_bytes(data_block, _mgf1(seed, k - h_len - 1))
+    masked_seed = _xor_bytes(seed, _mgf1(masked_data_block, h_len))
+    encoded = b'\x00' + masked_seed + masked_data_block
+    cipher_int = pow(int.from_bytes(encoded, 'big'), e, n)
+    return cipher_int.to_bytes(k, 'big')

--- a/packages/sdk-py/evolve/browser_credentials.py
+++ b/packages/sdk-py/evolve/browser_credentials.py
@@ -23,7 +23,7 @@ BROWSER_AUTH_ALGORITHM = 'RSA-OAEP-256'
 class BrowserCredentialMetadata:
     id: str
     website: str
-    alias: str
+    account_label: str
     email: str
     enabled: bool
     created_by: str
@@ -45,7 +45,7 @@ def _metadata_from_dict(data: Dict[str, Any]) -> BrowserCredentialMetadata:
     return BrowserCredentialMetadata(
         id=data['id'],
         website=data['website'],
-        alias=data['alias'],
+        account_label=data['account_label'],
         email=data['email'],
         enabled=bool(data.get('enabled', True)),
         created_by=data.get('createdBy') or data.get('created_by') or 'user',
@@ -101,14 +101,14 @@ class BrowserCredentialsClient:
         self,
         *,
         website: str,
-        alias: str,
+        account_label: str,
         email: str,
         password: str,
     ) -> Dict[str, Any]:
         encrypted_password = await self._encrypt_password(password)
         result = await self._request_json('/api/browser-credentials', method='POST', body={
             'website': website,
-            'alias': alias,
+            'account_label': account_label,
             'email': email,
             'encryptedPassword': encrypted_password,
         })
@@ -122,14 +122,14 @@ class BrowserCredentialsClient:
         *,
         id: Optional[str] = None,
         website: Optional[str] = None,
-        alias: Optional[str] = None,
+        account_label: Optional[str] = None,
     ) -> Dict[str, bool]:
         if id:
             body = {'id': id}
-        elif website and alias:
-            body = {'website': website, 'alias': alias}
+        elif website and account_label:
+            body = {'website': website, 'account_label': account_label}
         else:
-            raise ValueError('delete requires either id or website and alias')
+            raise ValueError('delete requires either id or website and account_label')
         return await self._request_json('/api/browser-credentials', method='DELETE', body=body)
 
     async def _encrypt_password(self, password: str) -> Dict[str, str]:

--- a/packages/sdk-py/evolve/config.py
+++ b/packages/sdk-py/evolve/config.py
@@ -29,7 +29,7 @@ class BrowserCredentialScopeEntry:
 
     Args:
         website: Website/domain, e.g. "github.com"
-        account_label: Optional label for a saved credential, such as "qa-admin" or "work"; not the website username or email
+        account_label: Optional one-word label for a saved credential, such as "qa-admin" or "work"; not the website username or email
     """
     website: str
     account_label: Optional[str] = None

--- a/packages/sdk-py/evolve/config.py
+++ b/packages/sdk-py/evolve/config.py
@@ -29,15 +29,15 @@ class BrowserCredentialScopeEntry:
 
     Args:
         website: Website/domain, e.g. "github.com"
-        alias: Optional account alias for that website
+        account_label: Optional label for a saved credential, such as "qa-admin" or "work"; not the website username or email
     """
     website: str
-    alias: Optional[str] = None
+    account_label: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {'website': self.website}
-        if self.alias:
-            result['alias'] = self.alias
+        if self.account_label:
+            result['account_label'] = self.account_label
         return result
 
 
@@ -46,7 +46,7 @@ class BrowserCredentialsConfig:
     """Browser login MCP configuration for managed remote agent-browser runs.
 
     Args:
-        allow: Optional list of website/alias selectors. None or [] exposes all enabled browser logins.
+        allow: Optional list of website/account_label selectors. None or [] exposes all enabled browser logins.
     """
     allow: Optional[List[Union[BrowserCredentialScopeEntry, Dict[str, Any]]]] = None
 

--- a/packages/sdk-py/evolve/config.py
+++ b/packages/sdk-py/evolve/config.py
@@ -24,6 +24,63 @@ class SchemaOptions:
 
 
 @dataclass
+class BrowserCredentialScopeEntry:
+    """Saved browser login selector for a run.
+
+    Args:
+        website: Website/domain, e.g. "github.com"
+        alias: Optional account alias for that website
+    """
+    website: str
+    alias: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {'website': self.website}
+        if self.alias:
+            result['alias'] = self.alias
+        return result
+
+
+@dataclass
+class BrowserCredentialsConfig:
+    """Browser login MCP configuration for managed remote agent-browser runs.
+
+    Args:
+        allow: Optional list of website/alias selectors. None or [] exposes all enabled browser logins.
+    """
+    allow: Optional[List[Union[BrowserCredentialScopeEntry, Dict[str, Any]]]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        if self.allow:
+            result['allow'] = [
+                entry.to_dict() if isinstance(entry, BrowserCredentialScopeEntry) else dict(entry)
+                for entry in self.allow
+            ]
+        return result
+
+
+@dataclass
+class BrowserCredentialsClientConfig:
+    """Standalone browser credentials client configuration.
+
+    Args:
+        api_key: Evolve API key override
+        dashboard_url: Dashboard URL override
+    """
+    api_key: Optional[str] = None
+    dashboard_url: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        if self.api_key:
+            result['api_key'] = self.api_key
+        if self.dashboard_url:
+            result['dashboard_url'] = self.dashboard_url
+        return result
+
+
+@dataclass
 class AgentConfig:
     """Agent configuration.
 

--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -56,6 +56,7 @@ import {
   stopManagedBrowserSession,
   type ManagedBrowserSession,
 } from "./browser";
+import { BROWSER_LOGIN_MCP_SERVER_NAME, createBrowserLoginMcpServer } from "./browser-credentials";
 
 // Re-export types for external consumers
 export type {
@@ -387,10 +388,11 @@ export class Agent {
           this.options.context ||
           this.options.files ||
           this.options.systemPrompt ||
-          this.options.managedBrowser
+          this.options.managedBrowser ||
+          this.options.browserCredentials
         ) {
           console.warn(
-            "[Evolve] Connecting to existing sandbox - ignoring mcpServers, plugins, context, files, systemPrompt, and managed browser setup"
+            "[Evolve] Connecting to existing sandbox - ignoring mcpServers, plugins, context, files, systemPrompt, managed browser setup, and browser credentials"
           );
         }
         this.sandbox = await provider.connect(this.options.sandboxId);
@@ -526,7 +528,9 @@ export class Agent {
 
   private async ensureManagedBrowserSession(callbacks?: StreamCallbacks): Promise<void> {
     if (this.managedBrowserSession || !this.options.managedBrowser) return;
-    this.managedBrowserSession = await createManagedBrowserSession(this.options.managedBrowser, this.sessionTag);
+    this.managedBrowserSession = await createManagedBrowserSession(this.options.managedBrowser, this.sessionTag, {
+      browserCredentials: this.options.browserCredentials !== undefined,
+    });
     this.emitLifecycle(callbacks, "browser_ready");
   }
 
@@ -801,6 +805,27 @@ export class Agent {
           url: composioMcp.url,
           headers: composioMcp.headers,
         },
+      };
+    }
+
+    if (this.options.browserCredentials) {
+      if (!this.options.managedBrowser || this.options.managedBrowser.provider !== "agent-browser") {
+        throw new Error("Browser credentials require managed remote agent-browser.");
+      }
+      if (!this.managedBrowserSession?.id || !this.managedBrowserSession.sessionTag || !this.managedBrowserSession.browserAuthGrantToken) {
+        throw new Error("Managed browser session is missing browser credential grant data.");
+      }
+      const browserLoginMcp = await createBrowserLoginMcpServer({
+        apiKey: this.options.browserCredentials.apiKey,
+        dashboardUrl: this.options.browserCredentials.dashboardUrl,
+        browserSessionId: this.managedBrowserSession.id,
+        sessionTag: this.managedBrowserSession.sessionTag,
+        grantToken: this.managedBrowserSession.browserAuthGrantToken,
+        config: this.options.browserCredentials.config,
+      });
+      mcpServers = {
+        ...mcpServers,
+        [BROWSER_LOGIN_MCP_SERVER_NAME]: browserLoginMcp,
       };
     }
 

--- a/packages/sdk-ts/src/browser-credentials.ts
+++ b/packages/sdk-ts/src/browser-credentials.ts
@@ -1,0 +1,199 @@
+import { constants, publicEncrypt } from "crypto";
+import type { BrowserCredentialScopeEntry, BrowserCredentialsConfig, McpServerConfig } from "./types";
+import { DEFAULT_DASHBOARD_URL } from "./constants";
+
+const BROWSER_AUTH_ALGORITHM = "RSA-OAEP-256";
+export const BROWSER_LOGIN_MCP_SERVER_NAME = "browser-login";
+
+export interface BrowserCredentialMetadata {
+  id: string;
+  website: string;
+  alias: string;
+  email: string;
+  enabled: boolean;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface BrowserCredentialsClientConfig {
+  apiKey?: string;
+  dashboardUrl?: string;
+}
+
+export interface BrowserCredentialCreateInput {
+  website: string;
+  alias: string;
+  email: string;
+  password: string;
+}
+
+export type BrowserCredentialDeleteInput =
+  | { id: string }
+  | { website: string; alias: string };
+
+export interface BrowserCredentialListOptions {
+  website?: string;
+  limit?: number;
+  offset?: number;
+}
+
+type PublicKeyResponse = {
+  id: string;
+  algorithm: typeof BROWSER_AUTH_ALGORITHM;
+  publicKey: string;
+};
+
+type EncryptedPassword = {
+  algorithm: typeof BROWSER_AUTH_ALGORITHM;
+  keyId: string;
+  ciphertext: string;
+};
+
+function dashboardBaseUrl(url?: string): string {
+  return (url || process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL).replace(/\/$/, "");
+}
+
+function resolveApiKey(apiKey?: string): string {
+  const resolved = apiKey || process.env.EVOLVE_API_KEY;
+  if (!resolved) throw new Error("Browser credentials require EVOLVE_API_KEY or an explicit apiKey");
+  return resolved;
+}
+
+async function readError(response: Response): Promise<string> {
+  return await response.text().catch(() => "");
+}
+
+async function requestJson<T>(
+  config: BrowserCredentialsClientConfig | undefined,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${dashboardBaseUrl(config?.dashboardUrl)}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${resolveApiKey(config?.apiKey)}`,
+      accept: "application/json",
+      ...(init.body ? { "content-type": "application/json" } : {}),
+      ...(init.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Browser credentials request failed (${response.status}): ${await readError(response)}`);
+  }
+  return await response.json() as T;
+}
+
+async function encryptPassword(
+  config: BrowserCredentialsClientConfig | undefined,
+  password: string
+): Promise<EncryptedPassword> {
+  const key = await requestJson<PublicKeyResponse>(config, "/api/browser-credentials/public-key");
+  const ciphertext = publicEncrypt(
+    {
+      key: key.publicKey,
+      padding: constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha256",
+    },
+    Buffer.from(password, "utf8")
+  );
+  return {
+    algorithm: BROWSER_AUTH_ALGORITHM,
+    keyId: key.id,
+    ciphertext: ciphertext.toString("base64url"),
+  };
+}
+
+export class BrowserCredentialsClient {
+  constructor(private readonly config: BrowserCredentialsClientConfig = {}) {}
+
+  async list(options: BrowserCredentialListOptions = {}): Promise<{
+    credentials: BrowserCredentialMetadata[];
+    total: number;
+    count: number;
+    offset: number;
+    hasMore: boolean;
+  }> {
+    const params = new URLSearchParams();
+    if (options.website) params.set("website", options.website);
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.offset !== undefined) params.set("offset", String(options.offset));
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    const result = await requestJson<{
+      credentials: BrowserCredentialMetadata[];
+      total: number;
+      count: number;
+      offset: number;
+      has_more?: boolean;
+    }>(this.config, `/api/browser-credentials${suffix}`);
+    return {
+      credentials: result.credentials,
+      total: result.total,
+      count: result.count,
+      offset: result.offset,
+      hasMore: result.has_more ?? result.offset + result.count < result.total,
+    };
+  }
+
+  async create(input: BrowserCredentialCreateInput): Promise<{
+    status: "created" | "already_exists";
+    credential: BrowserCredentialMetadata;
+  }> {
+    const encryptedPassword = await encryptPassword(this.config, input.password);
+    return await requestJson(this.config, "/api/browser-credentials", {
+      method: "POST",
+      body: JSON.stringify({
+        website: input.website,
+        alias: input.alias,
+        email: input.email,
+        encryptedPassword,
+      }),
+    });
+  }
+
+  async delete(input: BrowserCredentialDeleteInput): Promise<{ ok: boolean }> {
+    return await requestJson(this.config, "/api/browser-credentials", {
+      method: "DELETE",
+      body: JSON.stringify(input),
+    });
+  }
+}
+
+export function browserCredentials(config: BrowserCredentialsClientConfig = {}): BrowserCredentialsClient {
+  return new BrowserCredentialsClient(config);
+}
+
+export async function createBrowserLoginMcpServer(options: {
+  apiKey: string;
+  dashboardUrl?: string;
+  browserSessionId: string;
+  sessionTag: string;
+  grantToken: string;
+  config?: BrowserCredentialsConfig;
+}): Promise<McpServerConfig> {
+  const response = await requestJson<{
+    server: McpServerConfig;
+  }>({
+    apiKey: options.apiKey,
+    dashboardUrl: options.dashboardUrl,
+  }, "/api/browser-login/mcp-config", {
+    method: "POST",
+    body: JSON.stringify({
+      browserSessionId: options.browserSessionId,
+      sessionTag: options.sessionTag,
+      grantToken: options.grantToken,
+      allow: options.config?.allow,
+    }),
+  });
+  return response.server;
+}
+
+export function normalizeBrowserCredentialScope(
+  config?: BrowserCredentialsConfig
+): BrowserCredentialScopeEntry[] | undefined {
+  return config?.allow?.map((entry) => ({
+    website: entry.website,
+    ...(entry.alias ? { alias: entry.alias } : {}),
+  }));
+}

--- a/packages/sdk-ts/src/browser-credentials.ts
+++ b/packages/sdk-ts/src/browser-credentials.ts
@@ -8,7 +8,7 @@ export const BROWSER_LOGIN_MCP_SERVER_NAME = "browser-login";
 export interface BrowserCredentialMetadata {
   id: string;
   website: string;
-  alias: string;
+  accountLabel: string;
   email: string;
   enabled: boolean;
   createdBy: string;
@@ -24,14 +24,14 @@ export interface BrowserCredentialsClientConfig {
 
 export interface BrowserCredentialCreateInput {
   website: string;
-  alias: string;
+  accountLabel: string;
   email: string;
   password: string;
 }
 
 export type BrowserCredentialDeleteInput =
   | { id: string }
-  | { website: string; alias: string };
+  | { website: string; accountLabel: string };
 
 export interface BrowserCredentialListOptions {
   website?: string;
@@ -49,6 +49,10 @@ type EncryptedPassword = {
   algorithm: typeof BROWSER_AUTH_ALGORITHM;
   keyId: string;
   ciphertext: string;
+};
+
+type BrowserCredentialApiMetadata = Omit<BrowserCredentialMetadata, "accountLabel"> & {
+  account_label: string;
 };
 
 function dashboardBaseUrl(url?: string): string {
@@ -108,6 +112,14 @@ async function encryptPassword(
 export class BrowserCredentialsClient {
   constructor(private readonly config: BrowserCredentialsClientConfig = {}) {}
 
+  private toMetadata(credential: BrowserCredentialApiMetadata): BrowserCredentialMetadata {
+    const { account_label: accountLabel, ...rest } = credential;
+    return {
+      ...rest,
+      accountLabel,
+    };
+  }
+
   async list(options: BrowserCredentialListOptions = {}): Promise<{
     credentials: BrowserCredentialMetadata[];
     total: number;
@@ -121,14 +133,14 @@ export class BrowserCredentialsClient {
     if (options.offset !== undefined) params.set("offset", String(options.offset));
     const suffix = params.toString() ? `?${params.toString()}` : "";
     const result = await requestJson<{
-      credentials: BrowserCredentialMetadata[];
+      credentials: BrowserCredentialApiMetadata[];
       total: number;
       count: number;
       offset: number;
       has_more?: boolean;
     }>(this.config, `/api/browser-credentials${suffix}`);
     return {
-      credentials: result.credentials,
+      credentials: result.credentials.map((credential) => this.toMetadata(credential)),
       total: result.total,
       count: result.count,
       offset: result.offset,
@@ -141,21 +153,31 @@ export class BrowserCredentialsClient {
     credential: BrowserCredentialMetadata;
   }> {
     const encryptedPassword = await encryptPassword(this.config, input.password);
-    return await requestJson(this.config, "/api/browser-credentials", {
+    const result = await requestJson<{
+      status: "created" | "already_exists";
+      credential: BrowserCredentialApiMetadata;
+    }>(this.config, "/api/browser-credentials", {
       method: "POST",
       body: JSON.stringify({
         website: input.website,
-        alias: input.alias,
+        account_label: input.accountLabel,
         email: input.email,
         encryptedPassword,
       }),
     });
+    return {
+      status: result.status,
+      credential: this.toMetadata(result.credential),
+    };
   }
 
   async delete(input: BrowserCredentialDeleteInput): Promise<{ ok: boolean }> {
+    const body = "id" in input
+      ? input
+      : { website: input.website, account_label: input.accountLabel };
     return await requestJson(this.config, "/api/browser-credentials", {
       method: "DELETE",
-      body: JSON.stringify(input),
+      body: JSON.stringify(body),
     });
   }
 }
@@ -183,7 +205,7 @@ export async function createBrowserLoginMcpServer(options: {
       browserSessionId: options.browserSessionId,
       sessionTag: options.sessionTag,
       grantToken: options.grantToken,
-      allow: options.config?.allow,
+      allow: normalizeBrowserCredentialScope(options.config),
     }),
   });
   return response.server;
@@ -194,6 +216,6 @@ export function normalizeBrowserCredentialScope(
 ): BrowserCredentialScopeEntry[] | undefined {
   return config?.allow?.map((entry) => ({
     website: entry.website,
-    ...(entry.alias ? { alias: entry.alias } : {}),
+    ...((entry.accountLabel || entry.account_label) ? { account_label: entry.accountLabel || entry.account_label } : {}),
   }));
 }

--- a/packages/sdk-ts/src/browser.ts
+++ b/packages/sdk-ts/src/browser.ts
@@ -38,6 +38,7 @@ export interface ManagedBrowserSession {
   sessionTag?: string;
   cdpUrl: string;
   liveUrl: string;
+  browserAuthGrantToken?: string;
 }
 
 export interface ManagedBrowserSandboxSetup {
@@ -117,7 +118,8 @@ async function readError(response: Response): Promise<string> {
 
 export async function createManagedBrowserSession(
   config: ManagedBrowserConfig,
-  sessionTag: string
+  sessionTag: string,
+  options: { browserCredentials?: boolean } = {}
 ): Promise<ManagedBrowserSession> {
   const response = await fetch(`${dashboardBaseUrl(config)}/api/browser-sessions`, {
     method: "POST",
@@ -129,6 +131,7 @@ export async function createManagedBrowserSession(
     body: JSON.stringify({
       sessionTag,
       options: { remote: true },
+      browserAuth: options.browserCredentials === true,
     }),
     signal: AbortSignal.timeout(30_000),
   });
@@ -148,6 +151,7 @@ export async function createManagedBrowserSession(
     sessionTag: data.sessionTag,
     cdpUrl: data.cdpUrl,
     liveUrl: data.liveUrl,
+    browserAuthGrantToken: data.browserAuthGrantToken,
   };
 }
 

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -29,6 +29,7 @@ import type {
   RunCost,
   SessionCost,
   BrowserConfig,
+  BrowserCredentialsConfig,
   AgentPluginConfig,
 } from "./types";
 import { Agent, type AgentConfig, type AgentOptions, type AgentResponse } from "./agent";
@@ -40,6 +41,7 @@ import { resolveStorageConfig, createBoundStorageClient } from "./storage";
 import type { CheckpointInfo, StorageClient } from "./types";
 import { BROWSER_ACTIONBOOK_PROMPT, BROWSER_AGENT_BROWSER_PROMPT } from "./prompts";
 import { mergeBrowserSkills, normalizeBrowserConfig } from "./browser";
+import { browserCredentials as createBrowserCredentialsClient } from "./browser-credentials";
 
 // =============================================================================
 // TYPES
@@ -74,6 +76,8 @@ export interface EvolveConfig {
   mcpServers?: Record<string, McpServerConfig>;
   /** Browser automation provider to enable explicitly */
   browser?: BrowserConfig;
+  /** Browser login MCP setup for managed remote agent-browser runs */
+  browserCredentials?: BrowserCredentialsConfig;
   /** Agent plugins/extensions to install before first run */
   plugins?: AgentPluginConfig[];
   /** Skills to enable (e.g., ["pdf", "dev-browser"]) */
@@ -256,6 +260,17 @@ export class Evolve extends EventEmitter {
   }
 
   /**
+   * Enable saved browser logins for managed remote agent-browser runs.
+   *
+   * Empty config exposes all enabled browser logins for this Evolve account.
+   * Use allow to restrict a run to specific websites and optional aliases.
+   */
+  withBrowserCredentials(config: BrowserCredentialsConfig = {}): this {
+    this.config.browserCredentials = config;
+    return this;
+  }
+
+  /**
    * Install agent plugins/extensions in the sandbox user profile.
    *
    * The selected agent determines the installer:
@@ -422,6 +437,9 @@ export class Evolve extends EventEmitter {
    */
   static composio = composioHelpers;
 
+  /** Static browser credential client for listing, creating, and deleting saved browser logins. */
+  static browserCredentials = createBrowserCredentialsClient;
+
   // ===========================================================================
   // AGENT INITIALIZATION
   // ===========================================================================
@@ -442,8 +460,11 @@ export class Evolve extends EventEmitter {
     let managedBrowser: AgentOptions["managedBrowser"] | undefined;
     let skills = this.config.skills;
 
+    let normalizedBrowser: ReturnType<typeof normalizeBrowserConfig> | undefined;
+
     if (this.config.browser) {
       const browser = normalizeBrowserConfig(this.config.browser);
+      normalizedBrowser = browser;
 
       if (browser.provider === "browser-use") {
         if (agentConfig.isDirectMode) {
@@ -474,6 +495,21 @@ export class Evolve extends EventEmitter {
       }
     }
 
+    if (this.config.browserCredentials !== undefined) {
+      if (this.config.sandboxId) {
+        throw new Error("withBrowserCredentials() cannot be used with withSession(); browser login tokens are run-scoped.");
+      }
+      if (agentConfig.isDirectMode) {
+        throw new Error("withBrowserCredentials() requires gateway mode. Use apiKey/EVOLVE_API_KEY instead of providerApiKey/direct mode.");
+      }
+      if (!normalizedBrowser || normalizedBrowser.provider !== "agent-browser" || !normalizedBrowser.managed) {
+        throw new Error('withBrowserCredentials() requires .withBrowser() or .withBrowser({ provider: "agent-browser", remote: true }).');
+      }
+      if (this.config.mcpServers?.["browser-login"]) {
+        throw new Error('withBrowserCredentials() reserves the "browser-login" MCP server name.');
+      }
+    }
+
     // Resolve storage config if .withStorage() was called
     const resolvedStorage = this.config.storage !== undefined
       ? resolveStorageConfig(
@@ -496,6 +532,13 @@ export class Evolve extends EventEmitter {
       mcpServers: { ...browserMcpServers, ...this.config.mcpServers },
       browserPrompt,
       managedBrowser,
+      browserCredentials: this.config.browserCredentials !== undefined
+        ? {
+            apiKey: agentConfig.apiKey,
+            dashboardUrl: process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL,
+            config: this.config.browserCredentials,
+          }
+        : undefined,
       plugins: this.config.plugins,
       skills,
       schema: this.config.schema,

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -263,7 +263,7 @@ export class Evolve extends EventEmitter {
    * Enable saved browser logins for managed remote agent-browser runs.
    *
    * Empty config exposes all enabled browser logins for this Evolve account.
-   * Use allow to restrict a run to specific websites and optional aliases.
+   * Use allow to restrict a run to specific websites and optional account labels.
    */
   withBrowserCredentials(config: BrowserCredentialsConfig = {}): this {
     this.config.browserCredentials = config;

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -109,6 +109,8 @@ export type {
   BrowserProvider,
   ManagedBrowserProvider,
   BrowserConfig,
+  BrowserCredentialScopeEntry,
+  BrowserCredentialsConfig,
   ActionbookBrowserConfig,
   AgentBrowserConfig,
   AgentPluginConfig,
@@ -252,6 +254,21 @@ export {
 // =============================================================================
 
 export { resolveStorageConfig, storage } from "./storage";
+
+// =============================================================================
+// BROWSER CREDENTIALS
+// =============================================================================
+
+export {
+  BrowserCredentialsClient,
+  browserCredentials,
+  BROWSER_LOGIN_MCP_SERVER_NAME,
+  type BrowserCredentialCreateInput,
+  type BrowserCredentialDeleteInput,
+  type BrowserCredentialListOptions,
+  type BrowserCredentialMetadata,
+  type BrowserCredentialsClientConfig,
+} from "./browser-credentials";
 
 // =============================================================================
 // SESSIONS

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -164,7 +164,10 @@ export type BrowserConfig = BrowserProvider | ActionbookBrowserConfig | AgentBro
 /** Saved browser login selector exposed to a run. Empty/omitted means all enabled browser logins. */
 export interface BrowserCredentialScopeEntry {
   website: string;
-  alias?: string;
+  /** Label for the saved credential, such as "qa-admin" or "work"; not the website username or email. */
+  accountLabel?: string;
+  /** Python bridge wire shape. Prefer accountLabel in TypeScript. */
+  account_label?: string;
 }
 
 /** Browser login MCP configuration for managed remote agent-browser runs. */

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -164,7 +164,7 @@ export type BrowserConfig = BrowserProvider | ActionbookBrowserConfig | AgentBro
 /** Saved browser login selector exposed to a run. Empty/omitted means all enabled browser logins. */
 export interface BrowserCredentialScopeEntry {
   website: string;
-  /** Label for the saved credential, such as "qa-admin" or "work"; not the website username or email. */
+  /** One-word label for the saved credential, such as "qa-admin" or "work"; not the website username or email. */
   accountLabel?: string;
   /** Python bridge wire shape. Prefer accountLabel in TypeScript. */
   account_label?: string;

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -161,6 +161,17 @@ export interface AgentBrowserConfig {
 /** Browser automation configuration. */
 export type BrowserConfig = BrowserProvider | ActionbookBrowserConfig | AgentBrowserConfig;
 
+/** Saved browser login selector exposed to a run. Empty/omitted means all enabled browser logins. */
+export interface BrowserCredentialScopeEntry {
+  website: string;
+  alias?: string;
+}
+
+/** Browser login MCP configuration for managed remote agent-browser runs. */
+export interface BrowserCredentialsConfig {
+  allow?: BrowserCredentialScopeEntry[];
+}
+
 /** Marketplace plugin shape for CLIs with explicit plugin install commands. */
 export interface MarketplaceAgentPluginConfig {
   /** Marketplace URL/source to register in the sandbox user profile */
@@ -373,6 +384,12 @@ export interface AgentOptions {
     provider: ManagedBrowserProvider;
     apiKey: string;
     dashboardUrl?: string;
+  };
+  /** Run-scoped browser login MCP setup. Requires managed remote agent-browser. */
+  browserCredentials?: {
+    apiKey: string;
+    dashboardUrl?: string;
+    config?: BrowserCredentialsConfig;
   };
   /** Plugins/extensions to install in the sandbox user profile before first run */
   plugins?: AgentPluginConfig[];

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -393,13 +393,13 @@ async function testBrowserCredentialsConfigPreserved(): Promise<void> {
     .withSandbox(fakeSandboxProvider)
     .withBrowser()
     .withBrowserCredentials({
-      allow: [{ website: "github.com", alias: "qa" }],
+      allow: [{ website: "github.com", accountLabel: "qa" }],
     });
 
   const options = await getInitializedAgentOptions(kit);
   assertEqual(options.browserCredentials.apiKey, "evolve-key", "browser credentials use Evolve API key");
   assertEqual(options.browserCredentials.config.allow[0].website, "github.com", "browser credential website scope preserved");
-  assertEqual(options.browserCredentials.config.allow[0].alias, "qa", "browser credential alias scope preserved");
+  assertEqual(options.browserCredentials.config.allow[0].accountLabel, "qa", "browser credential account label scope preserved");
 }
 
 async function testBrowserCredentialsReserveMcpName(): Promise<void> {

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -330,6 +330,101 @@ async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
   assert(!config?.includes("_managedTransport"), "agent-browser config does not expose transport selector");
 }
 
+async function testBrowserCredentialsRequireManagedAgentBrowser(): Promise<void> {
+  console.log("\n[13] withBrowserCredentials(): requires managed remote agent-browser");
+
+  const missingBrowser = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowserCredentials();
+
+  try {
+    await getInitializedAgentOptions(missingBrowser);
+    assert(false, "browser credentials without browser should throw");
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes("requires .withBrowser()"),
+      "missing browser error explains managed agent-browser requirement"
+    );
+  }
+
+  const localBrowser = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowser("agent-browser")
+    .withBrowserCredentials();
+
+  try {
+    await getInitializedAgentOptions(localBrowser);
+    assert(false, "browser credentials with local browser should throw");
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes("requires .withBrowser()"),
+      "local browser error explains managed agent-browser requirement"
+    );
+  }
+}
+
+async function testBrowserCredentialsRejectDirectMode(): Promise<void> {
+  console.log("\n[14] withBrowserCredentials(): direct mode rejected");
+
+  const kit = new Evolve()
+    .withAgent({ type: "claude", providerApiKey: "provider-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowser()
+    .withBrowserCredentials();
+
+  try {
+    await getInitializedAgentOptions(kit);
+    assert(false, "browser credentials direct mode should throw");
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes("requires gateway mode"),
+      "direct mode error explains gateway requirement"
+    );
+  }
+}
+
+async function testBrowserCredentialsConfigPreserved(): Promise<void> {
+  console.log("\n[15] withBrowserCredentials(): stores allow scope for run-scoped MCP minting");
+
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowser()
+    .withBrowserCredentials({
+      allow: [{ website: "github.com", alias: "qa" }],
+    });
+
+  const options = await getInitializedAgentOptions(kit);
+  assertEqual(options.browserCredentials.apiKey, "evolve-key", "browser credentials use Evolve API key");
+  assertEqual(options.browserCredentials.config.allow[0].website, "github.com", "browser credential website scope preserved");
+  assertEqual(options.browserCredentials.config.allow[0].alias, "qa", "browser credential alias scope preserved");
+}
+
+async function testBrowserCredentialsReserveMcpName(): Promise<void> {
+  console.log("\n[16] withBrowserCredentials(): reserves browser-login MCP name");
+
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowser()
+    .withBrowserCredentials()
+    .withMcpServers({
+      "browser-login": { type: "http", url: "https://custom.example/mcp" },
+    });
+
+  try {
+    await getInitializedAgentOptions(kit);
+    assert(false, "browser-login MCP collision should throw");
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes("reserves"),
+      "reserved MCP name error is explicit"
+    );
+  }
+}
+
 async function main(): Promise<void> {
   console.log("=".repeat(70));
   console.log("Browser Config Tests");
@@ -347,6 +442,10 @@ async function main(): Promise<void> {
   await testManagedActionbookRequiresGatewayMode();
   await testManagedActionbookConfigUsesProxyOnly();
   await testManagedAgentBrowserConfigUsesProxyOnly();
+  await testBrowserCredentialsRequireManagedAgentBrowser();
+  await testBrowserCredentialsRejectDirectMode();
+  await testBrowserCredentialsConfigPreserved();
+  await testBrowserCredentialsReserveMcpName();
 
   console.log("\n" + "=".repeat(70));
   console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -368,6 +368,7 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
     assertEqual(result.exitCode, 0, "run() with managed agent-browser returns success");
     assert(!("provider" in createBody), "managed browser create does not expose automation provider");
     assertEqual(createBody.options?.remote, true, "managed browser create uses remote option");
+    assertEqual(createBody.browserAuth, false, "managed browser create does not request browser auth by default");
     assert(!("_managedTransport" in createBody.options), "managed browser create does not expose transport selector");
     assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed agent-browser live URL");
     assertEqual(

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -72,6 +72,7 @@ Read on demand when the user's task requires them:
 | Provider auto-resolution from env | [TS](references/typescript/02-configuration.md#auto-resolution) | [PY](references/python/02-configuration.md#auto-resolution) |
 | Full builder/constructor API | [TS](references/typescript/02-configuration.md#evolve-instance) | [PY](references/python/02-configuration.md#evolve-instance) |
 | Browser automation guide (setup, live view, replay) | [TS](references/typescript/02-configuration.md#browser-automation) | [PY](references/python/02-configuration.md#browser-automation) |
+| Browser credentials (saved website logins) | [TS](references/typescript/02-configuration.md#browser-credentials) | [PY](references/python/02-configuration.md#browser-credentials) |
 | Agent plugins/extensions | [TS](references/typescript/02-configuration.md#agent-plugins) | [PY](references/python/02-configuration.md#agent-plugins) |
 | Agent skills catalog | [TS](references/typescript/02-configuration.md#agent-skills) | [PY](references/python/02-configuration.md#agent-skills) |
 | Composio (auth paths, tool filtering, types) | [TS](references/typescript/02-configuration.md#composio-tool-router) | [PY](references/python/02-configuration.md#composio-tool-router) |

--- a/skills/evolve/references/python/02-configuration.md
+++ b/skills/evolve/references/python/02-configuration.md
@@ -329,6 +329,84 @@ If replay is not ready before `timeout_ms`, call `browser_replay()` again later 
 The `replay_url` already applies `suggested_start_seconds`; use the field separately only if your UI needs to display or store the recommended start time.
 The `status` is `'ready'` once `browser_replay()` returns.
 
+## Browser Credentials
+
+Browser credentials let managed remote `agent-browser` runs sign in with saved website logins without exposing passwords to the agent.
+
+Availability:
+
+- Requires Gateway mode and managed remote `agent-browser`.
+- Use `browser={'provider': 'agent-browser', 'remote': True}`.
+- Not available with `browser-use`, `actionbook`, `remote: False`, direct/BYOK provider mode, or existing sandbox sessions.
+
+Dashboard setup:
+
+1. Open the Evolve Dashboard.
+2. Go to **Secrets**.
+3. Add a browser login with `Website`, `Alias`, `Email`, and `Password`.
+4. Use `Website` for the domain, such as `github.com`; use `Alias` to distinguish multiple accounts for the same website.
+
+Passwords are encrypted before upload. The dashboard and SDK list only login metadata: website, alias, email, and last-used time.
+
+Expose saved logins to a run:
+
+```python
+from evolve import Evolve, BrowserCredentialsConfig
+
+evolve = Evolve(
+    browser={'provider': 'agent-browser', 'remote': True},
+    browser_credentials=BrowserCredentialsConfig(
+        allow=[{'website': 'github.com', 'alias': 'qa-admin'}],
+    ),
+)
+
+await evolve.run(
+    prompt='Open GitHub, sign in with the saved qa-admin login, and verify the repository settings page.'
+)
+
+await evolve.kill()
+```
+
+If `allow` is omitted, all enabled browser logins for the Evolve account are available to that run:
+
+```python
+from evolve import Evolve, BrowserCredentialsConfig
+
+evolve = Evolve(
+    browser={'provider': 'agent-browser', 'remote': True},
+    browser_credentials=BrowserCredentialsConfig(),
+)
+```
+
+The agent receives a run-scoped `browser-login` MCP server with these tools:
+
+- `browser_list_logins` returns website, alias, and email metadata only.
+- `browser_login` fills and submits a saved login on the current sign-in tab without returning the password.
+- `browser_complete_signup` completes password-based signup after the agent has filled non-secret fields, then saves the generated login for future `browser_login` calls.
+
+Manage browser logins from the SDK:
+
+```python
+import os
+from evolve import browser_credentials
+
+credentials = browser_credentials()
+
+await credentials.create(
+    website='github.com',
+    alias='qa-admin',
+    email='qualityassurance@example.com',
+    password=os.environ['QA_GITHUB_PASSWORD'],
+)
+
+page = await credentials.list(website='github.com')
+
+await credentials.delete(
+    website='github.com',
+    alias='qa-admin',
+)
+```
+
 ## Agent Plugins
 
 `plugins=` installs plugins/extensions into the sandbox user profile before the first agent command. The selected agent determines the accepted shape:

--- a/skills/evolve/references/typescript/02-configuration.md
+++ b/skills/evolve/references/typescript/02-configuration.md
@@ -334,6 +334,79 @@ If replay is not ready before `timeoutMs`, call `browserReplay()` again later wi
 The `replayUrl` already applies `suggestedStartSeconds`; use the field separately only if your UI needs to display or store the recommended start time.
 The `status` is `"ready"` once `browserReplay()` returns.
 
+## Browser Credentials
+
+Browser credentials let managed remote `agent-browser` runs sign in with saved website logins without exposing passwords to the agent.
+
+Availability:
+
+- Requires Gateway mode and managed remote `agent-browser`.
+- `.withBrowser()` uses that recommended remote setup by default.
+- Not available with `browser-use`, `actionbook`, `remote: false`, direct/BYOK provider mode, or `.withSession()`.
+
+Dashboard setup:
+
+1. Open the Evolve Dashboard.
+2. Go to **Secrets**.
+3. Add a browser login with `Website`, `Alias`, `Email`, and `Password`.
+4. Use `Website` for the domain, such as `github.com`; use `Alias` to distinguish multiple accounts for the same website.
+
+Passwords are encrypted before upload. The dashboard and SDK list only login metadata: website, alias, email, and last-used time.
+
+Expose saved logins to a run:
+
+```ts
+import { Evolve } from "@evolvingmachines/sdk";
+
+const evolve = new Evolve()
+    .withBrowser()
+    .withBrowserCredentials({
+        allow: [{ website: "github.com", alias: "qa-admin" }],
+    });
+
+await evolve.run({
+    prompt: "Open GitHub, sign in with the saved qa-admin login, and verify the repository settings page.",
+});
+
+await evolve.kill();
+```
+
+If `allow` is omitted, all enabled browser logins for the Evolve account are available to that run:
+
+```ts
+const evolve = new Evolve()
+    .withBrowser()
+    .withBrowserCredentials();
+```
+
+The agent receives a run-scoped `browser-login` MCP server with these tools:
+
+- `browser_list_logins` returns website, alias, and email metadata only.
+- `browser_login` fills and submits a saved login on the current sign-in tab without returning the password.
+- `browser_complete_signup` completes password-based signup after the agent has filled non-secret fields, then saves the generated login for future `browser_login` calls.
+
+Manage browser logins from the SDK:
+
+```ts
+import { Evolve } from "@evolvingmachines/sdk";
+
+const credentials = Evolve.browserCredentials();
+
+await credentials.create({
+    website: "github.com",
+    alias: "qa-admin",
+    email: "qualityassurance@example.com",
+    password: process.env.QA_GITHUB_PASSWORD!,
+});
+
+const page = await credentials.list({ website: "github.com" });
+
+await credentials.delete({
+    website: "github.com",
+    alias: "qa-admin",
+});
+```
+
 ## Agent Plugins
 
 `.withPlugins()` installs plugins/extensions into the sandbox user profile before the first agent command. The currently selected agent determines the accepted shape:


### PR DESCRIPTION
## Summary
- add .withBrowserCredentials() for run-scoped browser-login MCP setup
- add TypeScript and Python browser credentials clients for list/create/delete
- document browser credentials immediately after browser automation docs

## Verification
- npm run test:ts:unit
- npm run test:py:unit
- npm run build
