### PR TITLE
Add fast Kimi provider alias

### DIFF
--- a/.claude/skills/evolve/references/python/01-getting-started.md
+++ b/.claude/skills/evolve/references/python/01-getting-started.md
@@ -276,13 +276,21 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.6-plus'` `'qwen3.5-plus'` `'qwen3-max-2026-01-23'` `'qwen3-coder-next'` `'qwen3-coder-plus'` `'qwen3-coder-flash'` `'qwen3-vl-plus'` | `'qwen3.6-plus'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-fast'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `'opencode'` | `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 > **Note:** In Gateway mode (`EVOLVE_API_KEY`), the default claude model is `'opus'`. In BYOK mode, it defaults to `'sonnet'`.
 
 Agent-specific options: `reasoning_effort` (Codex and Droid; valid values vary by model). For 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
+
+#### Evolve-Provided Fast Models
+
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+
+| Agent | Model | Use |
+|-------|-------|-----|
+| `'kimi'` | `'kimi-k2.6-fast'` | Fast Kimi K2.6 for interactive coding and agent runs |
 
 ### Agent Examples
 

--- a/.claude/skills/evolve/references/typescript/01-getting-started.md
+++ b/.claude/skills/evolve/references/typescript/01-getting-started.md
@@ -279,13 +279,21 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.6-plus"` `"qwen3.5-plus"` `"qwen3-max-2026-01-23"` `"qwen3-coder-next"` `"qwen3-coder-plus"` `"qwen3-coder-flash"` `"qwen3-vl-plus"` | `"qwen3.6-plus"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-fast"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `"opencode"` | `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 > **Note:** In Gateway mode (`EVOLVE_API_KEY`), the default claude model is `"opus"`. In BYOK mode, it defaults to `"sonnet"`.
 
 Agent-specific options: `reasoningEffort` (Codex and Droid; valid values vary by model). For 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
+
+#### Evolve-Provided Fast Models
+
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+
+| Agent | Model | Use |
+|-------|-------|-----|
+| `"kimi"` | `"kimi-k2.6-fast"` | Fast Kimi K2.6 for interactive coding and agent runs |
 
 ### Agent Examples
 

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -276,13 +276,21 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.6-plus'` `'qwen3.5-plus'` `'qwen3-max-2026-01-23'` `'qwen3-coder-next'` `'qwen3-coder-plus'` `'qwen3-coder-flash'` `'qwen3-vl-plus'` | `'qwen3.6-plus'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-fast'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `'opencode'` | `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 > **Note:** In Gateway mode (`EVOLVE_API_KEY`), the default claude model is `'opus'`. In BYOK mode, it defaults to `'sonnet'`.
 
 Agent-specific options: `reasoning_effort` (Codex and Droid; valid values vary by model). For 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
+
+#### Evolve-Provided Fast Models
+
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+
+| Agent | Model | Use |
+|-------|-------|-----|
+| `'kimi'` | `'kimi-k2.6-fast'` | Fast Kimi K2.6 for interactive coding and agent runs |
 
 ### Agent Examples
 

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -279,13 +279,21 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.6-plus"` `"qwen3.5-plus"` `"qwen3-max-2026-01-23"` `"qwen3-coder-next"` `"qwen3-coder-plus"` `"qwen3-coder-flash"` `"qwen3-vl-plus"` | `"qwen3.6-plus"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-fast"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `"opencode"` | `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 > **Note:** In Gateway mode (`EVOLVE_API_KEY`), the default claude model is `"opus"`. In BYOK mode, it defaults to `"sonnet"`.
 
 Agent-specific options: `reasoningEffort` (Codex and Droid; valid values vary by model). For 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
+
+#### Evolve-Provided Fast Models
+
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+
+| Agent | Model | Use |
+|-------|-------|-----|
+| `"kimi"` | `"kimi-k2.6-fast"` | Fast Kimi K2.6 for interactive coding and agent runs |
 
 ### Agent Examples
 

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -331,6 +331,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     defaultModel: "kimi-k2.6",
     models: [
       { alias: "kimi-k2.6", modelId: "moonshot/kimi-k2.6", description: "Latest: long-horizon coding, swarm orchestration" },
+      { alias: "kimi-k2.6-fast", modelId: "kimi-k2.6-fast", description: "Evolve-managed fast Kimi K2.6 for latency-sensitive agent runs" },
       { alias: "kimi-k2.5", modelId: "moonshot/kimi-k2.5", description: "Previous multimodal flagship" },
     ],
     systemPromptFile: "AGENTS.md",
@@ -356,6 +357,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     },
     gatewayModelAliases: {
       "kimi-k2.6": "moonshot/kimi-k2.6",
+      "kimi-k2.6-fast": "kimi-k2.6-fast",
       "kimi-k2.5": "moonshot/kimi-k2.5",
     },
     buildCommand: ({ prompt, model, isResume, isDirectMode }) => {

--- a/packages/sdk-ts/tests/unit/cost-api.test.ts
+++ b/packages/sdk-ts/tests/unit/cost-api.test.ts
@@ -778,6 +778,7 @@ async function testKimiBuildCommandIncludesConfigFile(): Promise<void> {
   const kimi = AGENT_REGISTRY.kimi;
   assertEqual(kimi.defaultModel, "kimi-k2.6", "Kimi default is user-facing");
   assertEqual(kimi.gatewayModelAliases?.["kimi-k2.5"], "moonshot/kimi-k2.5", "Kimi gateway maps to Moonshot route");
+  assertEqual(kimi.gatewayModelAliases?.["kimi-k2.6-fast"], "kimi-k2.6-fast", "Kimi fast route stays provider-agnostic");
 
   const gatewayAgent = new Agent({
     type: "kimi",
@@ -790,6 +791,15 @@ async function testKimiBuildCommandIncludesConfigFile(): Promise<void> {
   assert(gatewayCmd.includes("--config-file /home/user/.kimi/evolve-config.toml"), "gateway mode has --config-file");
   assert(gatewayCmd.includes("--print"), "has --print flag");
   assert(gatewayCmd.includes("--yolo"), "has --yolo flag");
+
+  const fastGatewayAgent = new Agent({
+    type: "kimi",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+    model: "kimi-k2.6-fast",
+  } as any, {});
+  const fastGatewayCmd = (fastGatewayAgent as any).buildCommand("hello") as string;
+  assert(fastGatewayCmd.includes("KIMI_MODEL_NAME=kimi-k2.6-fast"), "gateway keeps fast Kimi alias for LiteLLM route");
 
   const directAgent = new Agent({
     type: "kimi",

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -276,13 +276,21 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.6-plus'` `'qwen3.5-plus'` `'qwen3-max-2026-01-23'` `'qwen3-coder-next'` `'qwen3-coder-plus'` `'qwen3-coder-flash'` `'qwen3-vl-plus'` | `'qwen3.6-plus'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-fast'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `'opencode'` | `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 > **Note:** In Gateway mode (`EVOLVE_API_KEY`), the default claude model is `'opus'`. In BYOK mode, it defaults to `'sonnet'`.
 
 Agent-specific options: `reasoning_effort` (Codex and Droid; valid values vary by model). For 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
+
+#### Evolve-Provided Fast Models
+
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+
+| Agent | Model | Use |
+|-------|-------|-----|
+| `'kimi'` | `'kimi-k2.6-fast'` | Fast Kimi K2.6 for interactive coding and agent runs |
 
 ### Agent Examples
 

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -279,13 +279,21 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.6-plus"` `"qwen3.5-plus"` `"qwen3-max-2026-01-23"` `"qwen3-coder-next"` `"qwen3-coder-plus"` `"qwen3-coder-flash"` `"qwen3-vl-plus"` | `"qwen3.6-plus"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-fast"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `"opencode"` | `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 > **Note:** In Gateway mode (`EVOLVE_API_KEY`), the default claude model is `"opus"`. In BYOK mode, it defaults to `"sonnet"`.
 
 Agent-specific options: `reasoningEffort` (Codex and Droid; valid values vary by model). For 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
+
+#### Evolve-Provided Fast Models
+
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+
+| Agent | Model | Use |
+|-------|-------|-----|
+| `"kimi"` | `"kimi-k2.6-fast"` | Fast Kimi K2.6 for interactive coding and agent runs |
 
 ### Agent Examples
 


### PR DESCRIPTION
Adds a provider-agnostic fast Kimi K2.6 model alias for gateway mode.\n\nChanges:\n- Adds `kimi-k2.6-fast` to the Kimi SDK model list.\n- Keeps the public alias provider-agnostic.\n- Adds a focused Kimi command routing test.\n- Updates TypeScript/Python docs and skill references.\n\nVerification:\n- `npm run build:sdk`\n- `npx tsx packages/sdk-ts/tests/unit/cost-api.test.ts`