### PR TITLE
Add browser profile SDK support

### DIFF
--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -271,6 +271,26 @@ Evolve(browser={'provider': 'agent-browser', 'remote': False})
 # local agent-browser, no managed live/replay
 ```
 
+Use a browser profile to reuse logged-in browser state across managed browser sessions:
+
+```python
+evolve = Evolve(
+    browser={'profile': 'ramp-qa'},
+)
+```
+
+Profiles are gateway-only and work only with managed remote browser sessions. Evolve stores and resolves profile state server-side; the SDK never receives raw browser state.
+
+List or delete profiles from the SDK:
+
+```python
+from evolve import browser_profiles
+
+profiles = await browser_profiles().list()
+
+await browser_profiles().delete(profile='ramp-qa')
+```
+
 To disable browser automation, omit the `browser` argument.
 
 Full browser run with live view and replay:
@@ -336,7 +356,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - Use `browser={'provider': 'agent-browser', 'remote': True}`.
-- Not available with `browser-use`, `actionbook`, `remote: False`, direct/BYOK provider mode, or existing sandbox sessions.
+- Not available with local browser mode, direct/BYOK provider mode, or existing sandbox sessions.
 
 Dashboard setup:
 

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -279,6 +279,27 @@ new Evolve().withBrowser({
 // local agent-browser, no managed live/replay
 ```
 
+Use a browser profile to reuse logged-in browser state across managed browser sessions:
+
+```ts
+const evolve = new Evolve()
+    .withBrowser({
+        profile: "ramp-qa",
+    });
+```
+
+Profiles are gateway-only and work only with managed remote browser sessions. Evolve stores and resolves profile state server-side; the SDK never receives raw browser state.
+
+List or delete profiles from the SDK:
+
+```ts
+const profiles = await Evolve.browserProfiles().list();
+
+await Evolve.browserProfiles().delete({
+    profile: "ramp-qa",
+});
+```
+
 To disable browser automation, omit `.withBrowser()`.
 
 Full browser run with live view and replay:
@@ -341,7 +362,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - `.withBrowser()` uses that recommended remote setup by default.
-- Not available with `browser-use`, `actionbook`, `remote: false`, direct/BYOK provider mode, or `.withSession()`.
+- Not available with local browser mode, direct/BYOK provider mode, or `.withSession()`.
 
 Dashboard setup:
 

--- a/packages/sdk-py/bridge/src/types.ts
+++ b/packages/sdk-py/bridge/src/types.ts
@@ -78,7 +78,7 @@ export interface InitializeParams {
   context?: EncodedFileMap;
   files?: EncodedFileMap;
   mcp_servers?: Record<string, any>;
-  browser?: 'browser-use' | 'actionbook' | 'agent-browser' | { provider: 'actionbook' | 'agent-browser'; remote?: boolean };
+  browser?: 'browser-use' | 'actionbook' | 'agent-browser' | { provider?: 'actionbook' | 'agent-browser'; remote?: boolean; profile?: string };
   browser_credentials?: BrowserCredentialsConfig;
   plugins?: AgentPluginConfig[];
   skills?: string[];

--- a/packages/sdk-py/evolve/__init__.py
+++ b/packages/sdk-py/evolve/__init__.py
@@ -14,6 +14,7 @@ from .config import (
     BrowserCredentialScopeEntry,
     BrowserCredentialsConfig,
     BrowserCredentialsClientConfig,
+    BrowserProfilesClientConfig,
     AgentPluginConfig,
     ReasoningEffort,
     ValidationMode,
@@ -41,6 +42,7 @@ from .results import (
 from .storage_client import StorageClient
 from .sessions_client import SessionsClient
 from .browser_credentials import BrowserCredentialsClient, BrowserCredentialMetadata, BrowserCredentialsPage
+from .browser_profiles import BrowserProfilesClient, BrowserProfileMetadata, BrowserProfilesPage
 from .utils import read_local_dir, save_local_dir
 from .bridge import (
     SandboxNotFoundError,
@@ -162,6 +164,14 @@ def browser_credentials(config: Optional[BrowserCredentialsClientConfig] = None)
     return BrowserCredentialsClient(config or BrowserCredentialsClientConfig())
 
 
+def browser_profiles(config: Optional[BrowserProfilesClientConfig] = None) -> BrowserProfilesClient:
+    """Create a standalone browser profiles client.
+
+    Uses EVOLVE_API_KEY unless BrowserProfilesClientConfig(api_key=...) is provided.
+    """
+    return BrowserProfilesClient(config or BrowserProfilesClientConfig())
+
+
 async def list_checkpoints(
     storage: Optional[StorageConfig] = None,
     limit: Optional[int] = None,
@@ -218,6 +228,7 @@ __all__ = [
     'BrowserCredentialScopeEntry',
     'BrowserCredentialsConfig',
     'BrowserCredentialsClientConfig',
+    'BrowserProfilesClientConfig',
     'AgentPluginConfig',
     'ReasoningEffort',
     'ValidationMode',
@@ -231,6 +242,9 @@ __all__ = [
     'BrowserCredentialsClient',
     'BrowserCredentialMetadata',
     'BrowserCredentialsPage',
+    'BrowserProfilesClient',
+    'BrowserProfileMetadata',
+    'BrowserProfilesPage',
 
     # Evolve Results
     'AgentResponse',
@@ -249,6 +263,7 @@ __all__ = [
     'StorageClient',
     'SessionsClient',
     'browser_credentials',
+    'browser_profiles',
 
     # Standalone functions
     'storage',

--- a/packages/sdk-py/evolve/agent.py
+++ b/packages/sdk-py/evolve/agent.py
@@ -183,10 +183,16 @@ class Evolve:
         if browser in ('browser-use', 'actionbook', 'agent-browser'):
             return browser
         if isinstance(browser, dict):
-            provider = browser.get('provider')
+            provider = browser.get('provider', 'agent-browser')
             if provider not in ('actionbook', 'agent-browser'):
                 raise ValueError("browser provider must be 'actionbook' or 'agent-browser'")
-            return dict(browser)
+            normalized = dict(browser)
+            normalized['provider'] = provider
+            if 'profile' in normalized and 'remote' not in normalized and browser.get('provider') is None:
+                normalized['remote'] = True
+            if 'profile' in normalized and normalized.get('remote') is not True:
+                raise ValueError("browser profile requires managed remote browser mode")
+            return normalized
         raise ValueError("browser must be 'browser-use', 'actionbook', 'agent-browser', a managed browser config dict, or None")
 
     @staticmethod

--- a/packages/sdk-py/evolve/browser_profiles.py
+++ b/packages/sdk-py/evolve/browser_profiles.py
@@ -1,0 +1,120 @@
+"""Standalone browser profiles client."""
+
+import asyncio
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .config import BrowserProfilesClientConfig
+
+
+DEFAULT_DASHBOARD_URL = 'https://dashboard.evolvingmachines.ai'
+
+
+@dataclass
+class BrowserProfileMetadata:
+    id: str
+    profile: str
+    created_at: str
+    updated_at: str
+    last_used_at: Optional[str]
+
+
+@dataclass
+class BrowserProfilesPage:
+    profiles: List[BrowserProfileMetadata]
+
+
+def _metadata_from_dict(data: Dict[str, Any]) -> BrowserProfileMetadata:
+    return BrowserProfileMetadata(
+        id=data['id'],
+        profile=data['profile'],
+        created_at=data.get('createdAt') or data.get('created_at') or '',
+        updated_at=data.get('updatedAt') or data.get('updated_at') or '',
+        last_used_at=data.get('lastUsedAt') or data.get('last_used_at'),
+    )
+
+
+class BrowserProfilesClient:
+    """List and delete reusable browser profiles."""
+
+    def __init__(
+        self,
+        config: Optional[BrowserProfilesClientConfig] = None,
+    ):
+        self.config = config or BrowserProfilesClientConfig()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    async def close(self):
+        return None
+
+    async def list(self) -> BrowserProfilesPage:
+        result = await self._request_json('/api/browser-profiles')
+        return BrowserProfilesPage(
+            profiles=[_metadata_from_dict(item) for item in result.get('profiles', [])],
+        )
+
+    async def delete(
+        self,
+        *,
+        profile: str,
+    ) -> Dict[str, bool]:
+        body: Dict[str, Any] = {'profile': profile}
+        return await self._request_json('/api/browser-profiles', method='DELETE', body=body)
+
+    async def _request_json(
+        self,
+        path: str,
+        method: str = 'GET',
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return await asyncio.to_thread(self._request_json_sync, path, method, body)
+
+    def _request_json_sync(
+        self,
+        path: str,
+        method: str,
+        body: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        data = json.dumps(body).encode('utf-8') if body is not None else None
+        headers = {
+            'Authorization': f'Bearer {_resolve_api_key(self.config)}',
+            'Accept': 'application/json',
+        }
+        if data is not None:
+            headers['Content-Type'] = 'application/json'
+        request = urllib.request.Request(
+            f'{_dashboard_base_url(self.config)}{path}',
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = response.read().decode('utf-8')
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode('utf-8', errors='replace')
+            raise RuntimeError(f'Browser profiles request failed ({exc.code}): {detail}') from exc
+        if not payload:
+            return {}
+        return json.loads(payload)
+
+
+def _dashboard_base_url(config: BrowserProfilesClientConfig) -> str:
+    return (config.dashboard_url or os.environ.get('EVOLVE_DASHBOARD_URL') or DEFAULT_DASHBOARD_URL).rstrip('/')
+
+
+def _resolve_api_key(config: BrowserProfilesClientConfig) -> str:
+    api_key = config.api_key or os.environ.get('EVOLVE_API_KEY')
+    if not api_key:
+        raise ValueError('Browser profiles require EVOLVE_API_KEY or BrowserProfilesClientConfig(api_key=...)')
+    return api_key

--- a/packages/sdk-py/evolve/config.py
+++ b/packages/sdk-py/evolve/config.py
@@ -81,6 +81,26 @@ class BrowserCredentialsClientConfig:
 
 
 @dataclass
+class BrowserProfilesClientConfig:
+    """Standalone browser profiles client configuration.
+
+    Args:
+        api_key: Evolve API key override
+        dashboard_url: Dashboard URL override
+    """
+    api_key: Optional[str] = None
+    dashboard_url: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        if self.api_key:
+            result['api_key'] = self.api_key
+        if self.dashboard_url:
+            result['dashboard_url'] = self.dashboard_url
+        return result
+
+
+@dataclass
 class AgentConfig:
     """Agent configuration.
 

--- a/packages/sdk-py/tests/unit/test_auth_config.py
+++ b/packages/sdk-py/tests/unit/test_auth_config.py
@@ -633,6 +633,25 @@ class TestBrowserConfig:
         params = initialize_calls[0][1]
         assert params['browser'] == {'provider': 'agent-browser', 'remote': True}
 
+    @pytest.mark.asyncio
+    async def test_browser_profile_defaults_to_managed_agent_browser(self):
+        mock_bridge = MockBridgeManager()
+        with patch('evolve.agent.BridgeManager', return_value=mock_bridge):
+            kit = Evolve(browser={'profile': 'ramp-qa'})
+            await kit._ensure_initialized()
+
+        initialize_calls = [c for c in mock_bridge.calls if c[0] == 'initialize']
+        params = initialize_calls[0][1]
+        assert params['browser'] == {
+            'provider': 'agent-browser',
+            'remote': True,
+            'profile': 'ramp-qa',
+        }
+
+    def test_browser_profile_requires_managed_remote(self):
+        with pytest.raises(ValueError, match="browser profile requires managed remote browser mode"):
+            Evolve(browser={'provider': 'agent-browser', 'profile': 'ramp-qa'})
+
     def test_invalid_browser_value_rejected(self):
         with pytest.raises(ValueError, match="browser must be 'browser-use', 'actionbook', 'agent-browser', a managed browser config dict, or None"):
             Evolve(browser='invalid')  # type: ignore[arg-type]

--- a/packages/sdk-ts/src/browser-profiles.ts
+++ b/packages/sdk-ts/src/browser-profiles.ts
@@ -1,0 +1,96 @@
+import { DEFAULT_DASHBOARD_URL } from "./constants";
+
+export interface BrowserProfileMetadata {
+  id: string;
+  profile: string;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface BrowserProfilesClientConfig {
+  apiKey?: string;
+  dashboardUrl?: string;
+}
+
+export interface BrowserProfileDeleteInput {
+  profile: string;
+}
+
+type BrowserProfileApiMetadata = Omit<BrowserProfileMetadata, "profile" | "lastUsedAt" | "createdAt" | "updatedAt"> & {
+  profile: string;
+  provider?: string;
+  createdAt?: string;
+  created_at?: string;
+  updatedAt?: string;
+  updated_at?: string;
+  lastUsedAt?: string | null;
+  last_used_at?: string | null;
+};
+
+function dashboardBaseUrl(url?: string): string {
+  return (url || process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL).replace(/\/$/, "");
+}
+
+function resolveApiKey(apiKey?: string): string {
+  const resolved = apiKey || process.env.EVOLVE_API_KEY;
+  if (!resolved) throw new Error("Browser profiles require EVOLVE_API_KEY or an explicit apiKey");
+  return resolved;
+}
+
+async function readError(response: Response): Promise<string> {
+  return await response.text().catch(() => "");
+}
+
+async function requestJson<T>(
+  config: BrowserProfilesClientConfig | undefined,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${dashboardBaseUrl(config?.dashboardUrl)}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${resolveApiKey(config?.apiKey)}`,
+      accept: "application/json",
+      ...(init.body ? { "content-type": "application/json" } : {}),
+      ...(init.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Browser profiles request failed (${response.status}): ${await readError(response)}`);
+  }
+  if (response.status === 204) return {} as T;
+  return await response.json() as T;
+}
+
+export class BrowserProfilesClient {
+  constructor(private readonly config: BrowserProfilesClientConfig = {}) {}
+
+  private toMetadata(profile: BrowserProfileApiMetadata): BrowserProfileMetadata {
+    return {
+      id: profile.id,
+      profile: profile.profile,
+      createdAt: profile.createdAt || profile.created_at || "",
+      updatedAt: profile.updatedAt || profile.updated_at || "",
+      lastUsedAt: profile.lastUsedAt ?? profile.last_used_at ?? null,
+    };
+  }
+
+  async list(): Promise<{ profiles: BrowserProfileMetadata[] }> {
+    const result = await requestJson<{ profiles: BrowserProfileApiMetadata[] }>(this.config, "/api/browser-profiles");
+    return {
+      profiles: result.profiles.map((profile) => this.toMetadata(profile)),
+    };
+  }
+
+  async delete(input: BrowserProfileDeleteInput): Promise<{ ok: boolean }> {
+    return await requestJson(this.config, "/api/browser-profiles", {
+      method: "DELETE",
+      body: JSON.stringify(input),
+    });
+  }
+}
+
+export function browserProfiles(config: BrowserProfilesClientConfig = {}): BrowserProfilesClient {
+  return new BrowserProfilesClient(config);
+}

--- a/packages/sdk-ts/src/browser.ts
+++ b/packages/sdk-ts/src/browser.ts
@@ -24,12 +24,14 @@ const ACTIONBOOK_CONFIG_PATH = `${ACTIONBOOK_CONFIG_DIR}/config.toml`;
 export interface NormalizedBrowserConfig {
   provider: "browser-use" | ManagedBrowserProvider;
   managed: boolean;
+  profile?: string;
 }
 
 export interface ManagedBrowserConfig {
   provider: ManagedBrowserProvider;
   apiKey: string;
   dashboardUrl?: string;
+  profile?: string;
 }
 
 export interface ManagedBrowserSession {
@@ -55,6 +57,14 @@ function usesManagedRemote(browser: ActionbookBrowserConfig | AgentBrowserConfig
   return browser.remote === true;
 }
 
+function normalizeProfile(profile: unknown): string | undefined {
+  if (profile === undefined || profile === null) return undefined;
+  if (typeof profile !== "string") throw new Error("browser profile must be a string");
+  const trimmed = profile.trim();
+  if (!trimmed) throw new Error("browser profile cannot be empty");
+  return trimmed;
+}
+
 export function normalizeBrowserConfig(browser: BrowserConfig): NormalizedBrowserConfig {
   if (typeof browser === "string") {
     if (browser === "browser-use") {
@@ -65,8 +75,19 @@ export function normalizeBrowserConfig(browser: BrowserConfig): NormalizedBrowse
     }
     throw new Error("Unsupported browser configuration");
   }
+  if (browser.provider === undefined) {
+    return {
+      provider: "agent-browser",
+      managed: browser.remote !== false,
+      profile: normalizeProfile(browser.profile),
+    };
+  }
   if (isManagedProvider(browser.provider)) {
-    return { provider: browser.provider, managed: usesManagedRemote(browser) };
+    return {
+      provider: browser.provider,
+      managed: usesManagedRemote(browser),
+      profile: normalizeProfile(browser.profile),
+    };
   }
   throw new Error("Unsupported browser configuration");
 }
@@ -132,6 +153,7 @@ export async function createManagedBrowserSession(
       sessionTag,
       options: { remote: true },
       browserAuth: options.browserCredentials === true,
+      ...(config.profile ? { profile: config.profile } : {}),
     }),
     signal: AbortSignal.timeout(30_000),
   });

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -41,6 +41,7 @@ import type { CheckpointInfo, StorageClient } from "./types";
 import { BROWSER_ACTIONBOOK_PROMPT, BROWSER_AGENT_BROWSER_PROMPT } from "./prompts";
 import { mergeBrowserSkills, normalizeBrowserConfig } from "./browser";
 import { browserCredentials as createBrowserCredentialsClient } from "./browser-credentials";
+import { browserProfiles as createBrowserProfilesClient } from "./browser-profiles";
 
 // =============================================================================
 // TYPES
@@ -396,6 +397,9 @@ export class Evolve extends EventEmitter {
   /** Static browser credential client for listing, creating, and deleting saved browser logins. */
   static browserCredentials = createBrowserCredentialsClient;
 
+  /** Static browser profile client for listing and deleting reusable browser profiles. */
+  static browserProfiles = createBrowserProfilesClient;
+
   // ===========================================================================
   // AGENT INITIALIZATION
   // ===========================================================================
@@ -450,8 +454,13 @@ export class Evolve extends EventEmitter {
             provider: browser.provider,
             apiKey: agentConfig.apiKey,
             dashboardUrl: process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL,
+            ...(browser.profile ? { profile: browser.profile } : {}),
           };
         }
+      }
+
+      if (browser.profile && !browser.managed) {
+        throw new Error("withBrowser({ profile }) requires managed remote browser mode. Use .withBrowser({ profile }) or .withBrowser({ provider: \"agent-browser\", remote: true, profile }).");
       }
     }
 

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -111,6 +111,7 @@ export type {
   BrowserConfig,
   BrowserCredentialScopeEntry,
   BrowserCredentialsConfig,
+  DefaultBrowserConfig,
   ActionbookBrowserConfig,
   AgentBrowserConfig,
   AgentPluginConfig,
@@ -275,6 +276,18 @@ export {
   type BrowserCredentialMetadata,
   type BrowserCredentialsClientConfig,
 } from "./browser-credentials";
+
+// =============================================================================
+// BROWSER PROFILES
+// =============================================================================
+
+export {
+  BrowserProfilesClient,
+  browserProfiles,
+  type BrowserProfileDeleteInput,
+  type BrowserProfileMetadata,
+  type BrowserProfilesClientConfig,
+} from "./browser-profiles";
 
 // =============================================================================
 // SESSIONS

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -149,6 +149,8 @@ export interface ActionbookBrowserConfig {
   provider: "actionbook";
   /** Use Evolve-managed remote browser transport. Defaults to false for object config. */
   remote?: boolean;
+  /** Reusable provider-native browser profile for managed remote browser sessions. */
+  profile?: string;
 }
 
 /** Agent-browser browser configuration. */
@@ -156,10 +158,21 @@ export interface AgentBrowserConfig {
   provider: "agent-browser";
   /** Use Evolve-managed remote browser transport. Defaults to false for object config. */
   remote?: boolean;
+  /** Reusable provider-native browser profile for managed remote browser sessions. */
+  profile?: string;
+}
+
+/** Default managed browser configuration. */
+export interface DefaultBrowserConfig {
+  provider?: undefined;
+  /** Defaults to true for the default managed agent-browser path. */
+  remote?: boolean;
+  /** Reusable provider-native browser profile for managed remote browser sessions. */
+  profile?: string;
 }
 
 /** Browser automation configuration. */
-export type BrowserConfig = BrowserProvider | ActionbookBrowserConfig | AgentBrowserConfig;
+export type BrowserConfig = BrowserProvider | DefaultBrowserConfig | ActionbookBrowserConfig | AgentBrowserConfig;
 
 /** Saved browser login selector exposed to a run. Empty/omitted means all enabled browser logins. */
 export interface BrowserCredentialScopeEntry {
@@ -388,6 +401,7 @@ export interface AgentOptions {
     provider: ManagedBrowserProvider;
     apiKey: string;
     dashboardUrl?: string;
+    profile?: string;
   };
   /** Run-scoped browser login MCP setup. Requires managed remote agent-browser. */
   browserCredentials?: {

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -206,8 +206,41 @@ async function testManagedAgentBrowserDefault(): Promise<void> {
   }
 }
 
+async function testBrowserProfileDefaultsManagedAgentBrowser(): Promise<void> {
+  console.log("\n[9] withBrowser({ profile }): defaults to remote managed agent-browser");
+
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowser({ profile: "ramp-qa" });
+
+  const options = await getInitializedAgentOptions(kit);
+  assertEqual(options.managedBrowser.provider, "agent-browser", "browser profile uses managed agent-browser by default");
+  assertEqual(options.managedBrowser.profile, "ramp-qa", "browser profile name is preserved");
+  assert(options.skills.includes("agent-browser"), "browser profile path adds agent-browser skill");
+}
+
+async function testBrowserProfileRequiresManagedRemote(): Promise<void> {
+  console.log("\n[10] withBrowser({ provider: \"agent-browser\", profile }): requires remote managed browser");
+
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(fakeSandboxProvider)
+    .withBrowser({ provider: "agent-browser", profile: "ramp-qa" });
+
+  try {
+    await getInitializedAgentOptions(kit);
+    assert(false, "browser profile without managed remote browser should throw");
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes("requires managed remote browser"),
+      "browser profile error explains managed remote requirement"
+    );
+  }
+}
+
 async function testActionbookObjectRemoteDefaultsFalse(): Promise<void> {
-  console.log("\n[9] withBrowser({ provider: \"actionbook\" }): remote defaults false");
+  console.log("\n[11] withBrowser({ provider: \"actionbook\" }): remote defaults false");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
@@ -221,7 +254,7 @@ async function testActionbookObjectRemoteDefaultsFalse(): Promise<void> {
 }
 
 async function testManagedActionbookRequiresGatewayMode(): Promise<void> {
-  console.log("\n[10] remote managed Actionbook: direct mode rejected");
+  console.log("\n[12] remote managed Actionbook: direct mode rejected");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", providerApiKey: "provider-key" })
@@ -240,7 +273,7 @@ async function testManagedActionbookRequiresGatewayMode(): Promise<void> {
 }
 
 async function testManagedActionbookConfigUsesProxyOnly(): Promise<void> {
-  console.log("\n[11] remote managed Actionbook config: sandbox sees only Evolve proxy endpoint");
+  console.log("\n[13] remote managed Actionbook config: sandbox sees only Evolve proxy endpoint");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
@@ -279,7 +312,7 @@ async function testManagedActionbookConfigUsesProxyOnly(): Promise<void> {
 }
 
 async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
-  console.log("\n[12] managed agent-browser config: sandbox sees only Evolve proxy endpoint");
+  console.log("\n[14] managed agent-browser config: sandbox sees only Evolve proxy endpoint");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
@@ -331,7 +364,7 @@ async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
 }
 
 async function testBrowserCredentialsRequireManagedAgentBrowser(): Promise<void> {
-  console.log("\n[13] withBrowserCredentials(): requires managed remote agent-browser");
+  console.log("\n[15] withBrowserCredentials(): requires managed remote agent-browser");
 
   const missingBrowser = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
@@ -366,7 +399,7 @@ async function testBrowserCredentialsRequireManagedAgentBrowser(): Promise<void>
 }
 
 async function testBrowserCredentialsRejectDirectMode(): Promise<void> {
-  console.log("\n[14] withBrowserCredentials(): direct mode rejected");
+  console.log("\n[16] withBrowserCredentials(): direct mode rejected");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", providerApiKey: "provider-key" })
@@ -386,7 +419,7 @@ async function testBrowserCredentialsRejectDirectMode(): Promise<void> {
 }
 
 async function testBrowserCredentialsConfigPreserved(): Promise<void> {
-  console.log("\n[15] withBrowserCredentials(): stores allow scope for run-scoped MCP minting");
+  console.log("\n[17] withBrowserCredentials(): stores allow scope for run-scoped MCP minting");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
@@ -403,7 +436,7 @@ async function testBrowserCredentialsConfigPreserved(): Promise<void> {
 }
 
 async function testBrowserCredentialsReserveMcpName(): Promise<void> {
-  console.log("\n[16] withBrowserCredentials(): reserves browser-login MCP name");
+  console.log("\n[18] withBrowserCredentials(): reserves browser-login MCP name");
 
   const kit = new Evolve()
     .withAgent({ type: "claude", apiKey: "evolve-key" })
@@ -438,6 +471,8 @@ async function main(): Promise<void> {
   await testActionbookStringAddsSkillsOnly();
   await testAgentBrowserStringAddsSkillsOnly();
   await testManagedAgentBrowserDefault();
+  await testBrowserProfileDefaultsManagedAgentBrowser();
+  await testBrowserProfileRequiresManagedRemote();
   await testActionbookObjectRemoteDefaultsFalse();
   await testManagedActionbookRequiresGatewayMode();
   await testManagedActionbookConfigUsesProxyOnly();


### PR DESCRIPTION
## Summary
- add browser profile support to existing managed `.withBrowser({ profile })` config
- add standalone browser profile list/delete clients for TypeScript and Python
- document profile usage in the browser automation sections without exposing managed CDP backend details

## Tests
- npm run type-check --workspace=@evolvingmachines/sdk
- npm run test:unit:browser --workspace=@evolvingmachines/sdk
- npm run build --workspace=@evolvingmachines/sdk
- PYTHONPATH=packages/sdk-py python -m pytest packages/sdk-py/tests/unit/test_auth_config.py -q
- npm run build:bridge