### PR TITLE
Add Claude Fable model aliases

### DIFF
--- a/.claude/skills/evolve/references/python/01-getting-started.md
+++ b/.claude/skills/evolve/references/python/01-getting-started.md
@@ -272,12 +272,12 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 | type | models | default | Gateway | BYOK |
 |------|--------|---------|---------|------|
-| `'claude'` | `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
+| `'claude'` | `'fable'` `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.7-max'` `'qwen3.7-plus'` `'qwen3.6-flash'` `'qwen3.6-plus'` | `'qwen3.7-max'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
 | `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-turbo'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
-| `'opencode'` | `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
+| `'opencode'` | `'openrouter/anthropic/claude-fable-5'` `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 Agent-specific option: `reasoning_effort` controls how much reasoning/thinking the selected agent uses when that agent supports it.
@@ -292,7 +292,7 @@ Agent-specific option: `reasoning_effort` controls how much reasoning/thinking t
 | `'opencode'` | `'thinking'` + `'medium'` | `'thinking'` `'no-thinking'` `'minimal'` `'low'` `'medium'` `'high'` `'xhigh'` `'max'` |
 | `'droid'` | Droid/model default | `'off'` `'minimal'` `'low'` `'medium'` `'high'` `'xhigh'` `'max'`; exact values depend on the Droid model |
 
-For Claude 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
+For Claude Fable 5, use `model='fable'`. For OpenCode via OpenRouter, use `model='openrouter/anthropic/claude-fable-5'`. For Claude 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
 
 #### Evolve-Provided Gateway Models
 
@@ -323,6 +323,10 @@ evolve = Evolve(
 
 evolve = Evolve(
     config=AgentConfig(type='claude', model='opus'),
+)
+
+evolve = Evolve(
+    config=AgentConfig(type='claude', model='fable'),
 )
 
 evolve = Evolve(
@@ -405,6 +409,10 @@ evolve = Evolve(
 
 evolve = Evolve(
     config=AgentConfig(type='opencode', model='openrouter/openai/gpt-5.2'),
+)
+
+evolve = Evolve(
+    config=AgentConfig(type='opencode', model='openrouter/anthropic/claude-fable-5'),
 )
 
 evolve = Evolve(

--- a/.claude/skills/evolve/references/python/02-configuration.md
+++ b/.claude/skills/evolve/references/python/02-configuration.md
@@ -143,7 +143,7 @@ evolve = Evolve(
     # Agent configuration (optional if EVOLVE_API_KEY set, defaults to claude)
     config=AgentConfig(
         type='codex',                        # 'claude' | 'codex' | 'gemini' | 'qwen' | 'kimi' | 'opencode' | 'droid' - defaults to 'claude'
-        model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
+        model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
         reasoning_effort='medium',           # (optional) Native reasoning/thinking control; valid values vary by agent/model
         api_key=os.getenv('EVOLVE_API_KEY'), # (optional) Gateway mode - auto-resolves from env
         # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct mode (BYOK)

--- a/.claude/skills/evolve/references/typescript/01-getting-started.md
+++ b/.claude/skills/evolve/references/typescript/01-getting-started.md
@@ -275,12 +275,12 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 | type | models | default | Gateway | BYOK |
 |------|--------|---------|---------|------|
-| `"claude"` | `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
+| `"claude"` | `"fable"` `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.7-max"` `"qwen3.7-plus"` `"qwen3.6-flash"` `"qwen3.6-plus"` | `"qwen3.7-max"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
 | `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-turbo"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
-| `"opencode"` | `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
+| `"opencode"` | `"openrouter/anthropic/claude-fable-5"` `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 Agent-specific option: `reasoningEffort` controls how much reasoning/thinking the selected agent uses when that agent supports it.
@@ -295,7 +295,7 @@ Agent-specific option: `reasoningEffort` controls how much reasoning/thinking th
 | `"opencode"` | `"thinking"` + `"medium"` | `"thinking"` `"no-thinking"` `"minimal"` `"low"` `"medium"` `"high"` `"xhigh"` `"max"` |
 | `"droid"` | Droid/model default | `"off"` `"minimal"` `"low"` `"medium"` `"high"` `"xhigh"` `"max"`; exact values depend on the Droid model |
 
-For Claude 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
+For Claude Fable 5, use `model: "fable"`. For OpenCode via OpenRouter, use `model: "openrouter/anthropic/claude-fable-5"`. For Claude 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
 
 #### Evolve-Provided Gateway Models
 
@@ -325,6 +325,9 @@ const evolve = new Evolve()
 
 const evolve = new Evolve()
     .withAgent({ type: "claude", model: "opus" });
+
+const evolve = new Evolve()
+    .withAgent({ type: "claude", model: "fable" });
 
 const evolve = new Evolve()
     .withAgent({ type: "claude", reasoningEffort: "max" });
@@ -392,6 +395,9 @@ const evolve = new Evolve()
 
 const evolve = new Evolve()
     .withAgent({ type: "opencode", model: "openrouter/openai/gpt-5.2" });
+
+const evolve = new Evolve()
+    .withAgent({ type: "opencode", model: "openrouter/anthropic/claude-fable-5" });
 
 const evolve = new Evolve()
     .withAgent({ type: "opencode", reasoningEffort: "xhigh" });

--- a/.claude/skills/evolve/references/typescript/02-configuration.md
+++ b/.claude/skills/evolve/references/typescript/02-configuration.md
@@ -129,7 +129,7 @@ const evolve = new Evolve()
     // Agent configuration (optional if EVOLVE_API_KEY set, defaults to claude)
     .withAgent({
         type: "codex",                        // "claude" | "codex" | "gemini" | "qwen" | "kimi" | "opencode" | "droid" - defaults to "claude"
-        model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
+        model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "fable" for Claude Fable 5 or "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
         reasoningEffort: "medium",            // (optional) Native reasoning/thinking control; valid values vary by agent/model
         apiKey: process.env.EVOLVE_API_KEY!, // (optional) Gateway mode - auto-resolves from env
         // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct mode (BYOK)

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -272,12 +272,12 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 | type | models | default | Gateway | BYOK |
 |------|--------|---------|---------|------|
-| `'claude'` | `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
+| `'claude'` | `'fable'` `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.7-max'` `'qwen3.7-plus'` `'qwen3.6-flash'` `'qwen3.6-plus'` | `'qwen3.7-max'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
 | `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-turbo'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
-| `'opencode'` | `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
+| `'opencode'` | `'openrouter/anthropic/claude-fable-5'` `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 Agent-specific option: `reasoning_effort` controls how much reasoning/thinking the selected agent uses when that agent supports it.
@@ -292,7 +292,7 @@ Agent-specific option: `reasoning_effort` controls how much reasoning/thinking t
 | `'opencode'` | `'thinking'` + `'medium'` | `'thinking'` `'no-thinking'` `'minimal'` `'low'` `'medium'` `'high'` `'xhigh'` `'max'` |
 | `'droid'` | Droid/model default | `'off'` `'minimal'` `'low'` `'medium'` `'high'` `'xhigh'` `'max'`; exact values depend on the Droid model |
 
-For Claude 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
+For Claude Fable 5, use `model='fable'`. For OpenCode via OpenRouter, use `model='openrouter/anthropic/claude-fable-5'`. For Claude 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
 
 #### Evolve-Provided Gateway Models
 
@@ -323,6 +323,10 @@ evolve = Evolve(
 
 evolve = Evolve(
     config=AgentConfig(type='claude', model='opus'),
+)
+
+evolve = Evolve(
+    config=AgentConfig(type='claude', model='fable'),
 )
 
 evolve = Evolve(
@@ -405,6 +409,10 @@ evolve = Evolve(
 
 evolve = Evolve(
     config=AgentConfig(type='opencode', model='openrouter/openai/gpt-5.2'),
+)
+
+evolve = Evolve(
+    config=AgentConfig(type='opencode', model='openrouter/anthropic/claude-fable-5'),
 )
 
 evolve = Evolve(

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -143,7 +143,7 @@ evolve = Evolve(
     # Agent configuration (optional if EVOLVE_API_KEY set, defaults to claude)
     config=AgentConfig(
         type='codex',                        # 'claude' | 'codex' | 'gemini' | 'qwen' | 'kimi' | 'opencode' | 'droid' - defaults to 'claude'
-        model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
+        model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
         reasoning_effort='medium',           # (optional) Native reasoning/thinking control; valid values vary by agent/model
         api_key=os.getenv('EVOLVE_API_KEY'), # (optional) Gateway mode - auto-resolves from env
         # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct mode (BYOK)

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -275,12 +275,12 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 | type | models | default | Gateway | BYOK |
 |------|--------|---------|---------|------|
-| `"claude"` | `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
+| `"claude"` | `"fable"` `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.7-max"` `"qwen3.7-plus"` `"qwen3.6-flash"` `"qwen3.6-plus"` | `"qwen3.7-max"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
 | `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-turbo"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
-| `"opencode"` | `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
+| `"opencode"` | `"openrouter/anthropic/claude-fable-5"` `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 Agent-specific option: `reasoningEffort` controls how much reasoning/thinking the selected agent uses when that agent supports it.
@@ -295,7 +295,7 @@ Agent-specific option: `reasoningEffort` controls how much reasoning/thinking th
 | `"opencode"` | `"thinking"` + `"medium"` | `"thinking"` `"no-thinking"` `"minimal"` `"low"` `"medium"` `"high"` `"xhigh"` `"max"` |
 | `"droid"` | Droid/model default | `"off"` `"minimal"` `"low"` `"medium"` `"high"` `"xhigh"` `"max"`; exact values depend on the Droid model |
 
-For Claude 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
+For Claude Fable 5, use `model: "fable"`. For OpenCode via OpenRouter, use `model: "openrouter/anthropic/claude-fable-5"`. For Claude 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
 
 #### Evolve-Provided Gateway Models
 
@@ -325,6 +325,9 @@ const evolve = new Evolve()
 
 const evolve = new Evolve()
     .withAgent({ type: "claude", model: "opus" });
+
+const evolve = new Evolve()
+    .withAgent({ type: "claude", model: "fable" });
 
 const evolve = new Evolve()
     .withAgent({ type: "claude", reasoningEffort: "max" });
@@ -392,6 +395,9 @@ const evolve = new Evolve()
 
 const evolve = new Evolve()
     .withAgent({ type: "opencode", model: "openrouter/openai/gpt-5.2" });
+
+const evolve = new Evolve()
+    .withAgent({ type: "opencode", model: "openrouter/anthropic/claude-fable-5" });
 
 const evolve = new Evolve()
     .withAgent({ type: "opencode", reasoningEffort: "xhigh" });

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -129,7 +129,7 @@ const evolve = new Evolve()
     // Agent configuration (optional if EVOLVE_API_KEY set, defaults to claude)
     .withAgent({
         type: "codex",                        // "claude" | "codex" | "gemini" | "qwen" | "kimi" | "opencode" | "droid" - defaults to "claude"
-        model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
+        model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "fable" for Claude Fable 5 or "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
         reasoningEffort: "medium",            // (optional) Native reasoning/thinking control; valid values vary by agent/model
         apiKey: process.env.EVOLVE_API_KEY!, // (optional) Gateway mode - auto-resolves from env
         // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct mode (BYOK)

--- a/packages/sdk-py/evolve/config.py
+++ b/packages/sdk-py/evolve/config.py
@@ -117,7 +117,7 @@ class AgentConfig:
         provider_api_key: Provider API key for direct mode / BYOK (defaults to provider env var)
         oauth_token: OAuth token for Claude Max subscription (defaults to CLAUDE_CODE_OAUTH_TOKEN env var)
         provider_base_url: Provider base URL for direct mode (auto-detected for Qwen)
-        model: Model name (optional - uses agent's default if not specified). Use 'sonnet[1m]' / 'opus[1m]' for 1M context window (Claude only).
+        model: Model name (optional - uses agent's default if not specified). Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context window (Claude only).
         reasoning_effort: Reasoning effort for models that support it (optional)
     """
     type: Optional[AgentType] = None

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -200,6 +200,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     customHeadersEnv: "ANTHROPIC_CUSTOM_HEADERS",
     defaultModel: "opus",
     models: [
+      { alias: "fable", modelId: "claude-fable-5", description: "Highest capability, long-horizon agentic work" },
       { alias: "opus", modelId: "claude-opus-4-8", description: "Complex reasoning, R&D, architecting" },
       { alias: "sonnet", modelId: "claude-sonnet-4-6", description: "Daily coding, features, tests" },
       { alias: "haiku", modelId: "claude-haiku-4-5-20251001", description: "Quick tasks, syntax correction" },
@@ -399,6 +400,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     },
     gatewayConfigEnv: "OPENCODE_CONFIG_CONTENT",
     models: [
+      { alias: "openrouter/anthropic/claude-fable-5", modelId: "openrouter/anthropic/claude-fable-5", description: "Anthropic Fable via OpenRouter" },
       { alias: "openrouter/anthropic/claude-sonnet-4.6", modelId: "openrouter/anthropic/claude-sonnet-4.6", description: "Anthropic Sonnet via OpenRouter" },
       { alias: "openrouter/anthropic/claude-opus-4.8", modelId: "openrouter/anthropic/claude-opus-4.8", description: "Anthropic Opus via OpenRouter" },
       { alias: "openrouter/anthropic/claude-haiku-4.5", modelId: "openrouter/anthropic/claude-haiku-4.5", description: "Anthropic Haiku via OpenRouter" },

--- a/packages/sdk-ts/tests/unit/auth-config.test.ts
+++ b/packages/sdk-ts/tests/unit/auth-config.test.ts
@@ -123,6 +123,30 @@ async function runTests(): Promise<void> {
   console.log("\n=== Auth Config Unit Tests ===\n");
 
   // ─────────────────────────────────────────────────────────────────────────
+  // REGISTRY METADATA
+  // ─────────────────────────────────────────────────────────────────────────
+
+  console.log("Registry: Claude models");
+
+  {
+    const claude = AGENT_REGISTRY.claude;
+    const fable = claude.models.find((model) => model.alias === "fable");
+    assertEqual(claude.defaultModel, "opus", "Claude default stays opus");
+    assert(fable !== undefined, "Claude registry includes fable alias");
+    assertEqual(fable?.modelId, "claude-fable-5", "fable maps to claude-fable-5");
+
+    const opencodeFable = AGENT_REGISTRY.opencode.models.find(
+      (model) => model.alias === "openrouter/anthropic/claude-fable-5"
+    );
+    assert(opencodeFable !== undefined, "OpenCode registry includes OpenRouter Fable alias");
+    assertEqual(
+      opencodeFable?.modelId,
+      "openrouter/anthropic/claude-fable-5",
+      "OpenCode Fable alias keeps provider-prefixed OpenRouter model"
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
   // EXPLICIT CONFIG TESTS (always take priority)
   // ─────────────────────────────────────────────────────────────────────────
 

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -272,12 +272,12 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 | type | models | default | Gateway | BYOK |
 |------|--------|---------|---------|------|
-| `'claude'` | `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
+| `'claude'` | `'fable'` `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.7-max'` `'qwen3.7-plus'` `'qwen3.6-flash'` `'qwen3.6-plus'` | `'qwen3.7-max'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
 | `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-turbo'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
-| `'opencode'` | `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
+| `'opencode'` | `'openrouter/anthropic/claude-fable-5'` `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 Agent-specific option: `reasoning_effort` controls how much reasoning/thinking the selected agent uses when that agent supports it.
@@ -292,7 +292,7 @@ Agent-specific option: `reasoning_effort` controls how much reasoning/thinking t
 | `'opencode'` | `'thinking'` + `'medium'` | `'thinking'` `'no-thinking'` `'minimal'` `'low'` `'medium'` `'high'` `'xhigh'` `'max'` |
 | `'droid'` | Droid/model default | `'off'` `'minimal'` `'low'` `'medium'` `'high'` `'xhigh'` `'max'`; exact values depend on the Droid model |
 
-For Claude 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
+For Claude Fable 5, use `model='fable'`. For OpenCode via OpenRouter, use `model='openrouter/anthropic/claude-fable-5'`. For Claude 1M context window, use `model='sonnet[1m]'` or `model='opus[1m]'`.
 
 #### Evolve-Provided Gateway Models
 
@@ -323,6 +323,10 @@ evolve = Evolve(
 
 evolve = Evolve(
     config=AgentConfig(type='claude', model='opus'),
+)
+
+evolve = Evolve(
+    config=AgentConfig(type='claude', model='fable'),
 )
 
 evolve = Evolve(
@@ -405,6 +409,10 @@ evolve = Evolve(
 
 evolve = Evolve(
     config=AgentConfig(type='opencode', model='openrouter/openai/gpt-5.2'),
+)
+
+evolve = Evolve(
+    config=AgentConfig(type='opencode', model='openrouter/anthropic/claude-fable-5'),
 )
 
 evolve = Evolve(

--- a/skills/evolve/references/python/02-configuration.md
+++ b/skills/evolve/references/python/02-configuration.md
@@ -143,7 +143,7 @@ evolve = Evolve(
     # Agent configuration (optional if EVOLVE_API_KEY set, defaults to claude)
     config=AgentConfig(
         type='codex',                        # 'claude' | 'codex' | 'gemini' | 'qwen' | 'kimi' | 'opencode' | 'droid' - defaults to 'claude'
-        model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
+        model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
         reasoning_effort='medium',           # (optional) Native reasoning/thinking control; valid values vary by agent/model
         api_key=os.getenv('EVOLVE_API_KEY'), # (optional) Gateway mode - auto-resolves from env
         # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct mode (BYOK)

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -275,12 +275,12 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 | type | models | default | Gateway | BYOK |
 |------|--------|---------|---------|------|
-| `"claude"` | `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
+| `"claude"` | `"fable"` `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.7-max"` `"qwen3.7-plus"` `"qwen3.6-flash"` `"qwen3.6-plus"` | `"qwen3.7-max"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
 | `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-turbo"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
-| `"opencode"` | `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
+| `"opencode"` | `"openrouter/anthropic/claude-fable-5"` `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
 Agent-specific option: `reasoningEffort` controls how much reasoning/thinking the selected agent uses when that agent supports it.
@@ -295,7 +295,7 @@ Agent-specific option: `reasoningEffort` controls how much reasoning/thinking th
 | `"opencode"` | `"thinking"` + `"medium"` | `"thinking"` `"no-thinking"` `"minimal"` `"low"` `"medium"` `"high"` `"xhigh"` `"max"` |
 | `"droid"` | Droid/model default | `"off"` `"minimal"` `"low"` `"medium"` `"high"` `"xhigh"` `"max"`; exact values depend on the Droid model |
 
-For Claude 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
+For Claude Fable 5, use `model: "fable"`. For OpenCode via OpenRouter, use `model: "openrouter/anthropic/claude-fable-5"`. For Claude 1M context window, use `model: "sonnet[1m]"` or `model: "opus[1m]"`.
 
 #### Evolve-Provided Gateway Models
 
@@ -325,6 +325,9 @@ const evolve = new Evolve()
 
 const evolve = new Evolve()
     .withAgent({ type: "claude", model: "opus" });
+
+const evolve = new Evolve()
+    .withAgent({ type: "claude", model: "fable" });
 
 const evolve = new Evolve()
     .withAgent({ type: "claude", reasoningEffort: "max" });
@@ -392,6 +395,9 @@ const evolve = new Evolve()
 
 const evolve = new Evolve()
     .withAgent({ type: "opencode", model: "openrouter/openai/gpt-5.2" });
+
+const evolve = new Evolve()
+    .withAgent({ type: "opencode", model: "openrouter/anthropic/claude-fable-5" });
 
 const evolve = new Evolve()
     .withAgent({ type: "opencode", reasoningEffort: "xhigh" });

--- a/skills/evolve/references/typescript/02-configuration.md
+++ b/skills/evolve/references/typescript/02-configuration.md
@@ -129,7 +129,7 @@ const evolve = new Evolve()
     // Agent configuration (optional if EVOLVE_API_KEY set, defaults to claude)
     .withAgent({
         type: "codex",                        // "claude" | "codex" | "gemini" | "qwen" | "kimi" | "opencode" | "droid" - defaults to "claude"
-        model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
+        model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "fable" for Claude Fable 5 or "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
         reasoningEffort: "medium",            // (optional) Native reasoning/thinking control; valid values vary by agent/model
         apiKey: process.env.EVOLVE_API_KEY!, // (optional) Gateway mode - auto-resolves from env
         // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct mode (BYOK)


### PR DESCRIPTION
Adds Claude Fable model aliases for Claude Code and OpenCode/OpenRouter.\n\n- Claude: `fable` -> `claude-fable-5`\n- OpenCode/OpenRouter: `openrouter/anthropic/claude-fable-5`\n- Updates TS/Python docs and skill mirrors\n- Adds focused registry test\n\nVerified locally:\n- `npm run test:unit:auth --workspace=@evolvingmachines/sdk`\n- `npm run type-check --workspace=@evolvingmachines/sdk`\n- `npm run build:sdk`\n- `git diff --check`