### PR TITLE
Fix gateway mode with latest upstream e2b client

### DIFF
--- a/packages/sdk-ts/src/utils/sandbox.ts
+++ b/packages/sdk-ts/src/utils/sandbox.ts
@@ -16,6 +16,18 @@ import {
 } from "../constants";
 
 /**
+ * Encode an Evolve gateway key as an e2b-shaped key for the managed E2B route.
+ *
+ * The upstream e2b client validates `apiKey` against /^e2b_[0-9a-f]+$/ before
+ * sending any request, so the raw `sk-…` Evolve key can no longer ride in
+ * directly. Hex wrapping satisfies the client; the Dashboard managed route
+ * decodes it back before verifying the key against the gateway.
+ */
+export function toManagedE2BKey(evolveKey: string): string {
+  return `e2b_${Buffer.from(evolveKey, "utf8").toString("hex")}`;
+}
+
+/**
  * Resolve default sandbox provider from environment.
  *
  * Priority (user's sandbox keys first, gateway as fallback):
@@ -101,7 +113,7 @@ export async function resolveDefaultSandbox(): Promise<SandboxProvider> {
       // per-user sandbox ownership before the provider gateway injects E2B_API_KEY.
       // Keep this on the provider instance rather than process.env so later BYOK
       // E2B providers in the same process cannot inherit managed routing.
-      return createE2BProvider({ apiKey: evolveKey, apiUrl: getE2BGatewayUrl() });
+      return createE2BProvider({ apiKey: toManagedE2BKey(evolveKey), apiUrl: getE2BGatewayUrl() });
     } catch (e) {
       const error = e as Error;
       if (error.message?.includes("Cannot find module") || error.message?.includes("MODULE_NOT_FOUND")) {

--- a/packages/sdk-ts/tests/unit/auth-config.test.ts
+++ b/packages/sdk-ts/tests/unit/auth-config.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { resolveAgentConfig } from "../../src/utils/config.js";
-import { resolveDefaultSandbox } from "../../src/utils/sandbox.js";
+import { resolveDefaultSandbox, toManagedE2BKey } from "../../src/utils/sandbox.js";
 import { getE2BGatewayUrl, getGatewayUrl } from "../../src/constants.js";
 import { AGENT_REGISTRY } from "../../src/registry.js";
 
@@ -576,6 +576,17 @@ async function runTests(): Promise<void> {
     assert(provider !== null, "returns a provider");
     assertEqual(provider.providerType, "e2b", "provider type is e2b");
     assertEqual(process.env.E2B_API_URL, undefined, "does not mutate E2B_API_URL for gateway routing");
+  }
+
+  console.log("\ntoManagedE2BKey (gateway key wrapped for upstream e2b client)");
+  {
+    const encoded = toManagedE2BKey("sk-test-key");
+    assert(/^e2b_[0-9a-f]+$/.test(encoded), "encoded key matches upstream e2b client format");
+    assertEqual(
+      Buffer.from(encoded.slice(4), "hex").toString("utf8"),
+      "sk-test-key",
+      "encoding is reversible to the original gateway key"
+    );
   }
 
   // E2B_API_KEY takes priority over EVOLVE_API_KEY for sandbox billing/BYOK


### PR DESCRIPTION
Recent upstream e2b (>=2.28) validates apiKey against /^e2b_[0-9a-f]+$/ client-side, rejecting Evolve sk- gateway keys on any fresh install. Wrap the gateway key as e2b_<hex> for the managed E2B route; the Dashboard proxy unwraps it before the existing key verification. BYOK path untouched. Pairs with swarm_dashboard#<proxy-unwrap> which must deploy first (proxy handles both raw and wrapped keys).