### PR TITLE
Add Kimi Raptor managed models

### DIFF
--- a/.claude/skills/evolve/references/python/01-getting-started.md
+++ b/.claude/skills/evolve/references/python/01-getting-started.md
@@ -276,7 +276,7 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.7-max'` `'qwen3.7-plus'` `'qwen3.6-flash'` `'qwen3.6-plus'` | `'qwen3.7-max'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-turbo'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `'kimi'` | `'kimi-k2.6'` `'kimi-k2p6-raptor'` `'kimi-k2p7-code-raptor'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `'opencode'` | `'openrouter/anthropic/claude-fable-5'` `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
@@ -302,7 +302,8 @@ These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve fo
 
 | Agent | Model | Use |
 |-------|-------|-----|
-| `'kimi'` | `'kimi-k2.6-turbo'` | Kimi K2.6 turbo for interactive coding and agent runs |
+| `'kimi'` | `'kimi-k2p6-raptor'` | Kimi K2.6 Raptor route for interactive coding and agent runs |
+| `'kimi'` | `'kimi-k2p7-code-raptor'` | Kimi K2.7 Code Raptor route for interactive coding and agent runs |
 
 ### Agent Examples
 
@@ -397,7 +398,7 @@ evolve = Evolve(
 evolve = Evolve(
     config=AgentConfig(
         type='kimi',
-        model='kimi-k2.6-turbo',
+        model='kimi-k2p7-code-raptor',
         reasoning_effort='thinking',
     ),
 )

--- a/.claude/skills/evolve/references/typescript/01-getting-started.md
+++ b/.claude/skills/evolve/references/typescript/01-getting-started.md
@@ -279,7 +279,7 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.7-max"` `"qwen3.7-plus"` `"qwen3.6-flash"` `"qwen3.6-plus"` | `"qwen3.7-max"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-turbo"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `"kimi"` | `"kimi-k2.6"` `"kimi-k2p6-raptor"` `"kimi-k2p7-code-raptor"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `"opencode"` | `"openrouter/anthropic/claude-fable-5"` `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
@@ -305,7 +305,8 @@ These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve fo
 
 | Agent | Model | Use |
 |-------|-------|-----|
-| `"kimi"` | `"kimi-k2.6-turbo"` | Kimi K2.6 turbo for interactive coding and agent runs |
+| `"kimi"` | `"kimi-k2p6-raptor"` | Kimi K2.6 Raptor route for interactive coding and agent runs |
+| `"kimi"` | `"kimi-k2p7-code-raptor"` | Kimi K2.7 Code Raptor route for interactive coding and agent runs |
 
 ### Agent Examples
 
@@ -385,7 +386,7 @@ const evolve = new Evolve()
 const evolve = new Evolve()
     .withAgent({
         type: "kimi",
-        model: "kimi-k2.6-turbo",
+        model: "kimi-k2p7-code-raptor",
         reasoningEffort: "thinking",
     });
 ```

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -276,7 +276,7 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.7-max'` `'qwen3.7-plus'` `'qwen3.6-flash'` `'qwen3.6-plus'` | `'qwen3.7-max'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-turbo'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `'kimi'` | `'kimi-k2.6'` `'kimi-k2p6-raptor'` `'kimi-k2p7-code-raptor'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `'opencode'` | `'openrouter/anthropic/claude-fable-5'` `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
@@ -302,7 +302,8 @@ These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve fo
 
 | Agent | Model | Use |
 |-------|-------|-----|
-| `'kimi'` | `'kimi-k2.6-turbo'` | Kimi K2.6 turbo for interactive coding and agent runs |
+| `'kimi'` | `'kimi-k2p6-raptor'` | Kimi K2.6 Raptor route for interactive coding and agent runs |
+| `'kimi'` | `'kimi-k2p7-code-raptor'` | Kimi K2.7 Code Raptor route for interactive coding and agent runs |
 
 ### Agent Examples
 
@@ -397,7 +398,7 @@ evolve = Evolve(
 evolve = Evolve(
     config=AgentConfig(
         type='kimi',
-        model='kimi-k2.6-turbo',
+        model='kimi-k2p7-code-raptor',
         reasoning_effort='thinking',
     ),
 )

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -279,7 +279,7 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.7-max"` `"qwen3.7-plus"` `"qwen3.6-flash"` `"qwen3.6-plus"` | `"qwen3.7-max"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-turbo"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `"kimi"` | `"kimi-k2.6"` `"kimi-k2p6-raptor"` `"kimi-k2p7-code-raptor"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `"opencode"` | `"openrouter/anthropic/claude-fable-5"` `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
@@ -305,7 +305,8 @@ These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve fo
 
 | Agent | Model | Use |
 |-------|-------|-----|
-| `"kimi"` | `"kimi-k2.6-turbo"` | Kimi K2.6 turbo for interactive coding and agent runs |
+| `"kimi"` | `"kimi-k2p6-raptor"` | Kimi K2.6 Raptor route for interactive coding and agent runs |
+| `"kimi"` | `"kimi-k2p7-code-raptor"` | Kimi K2.7 Code Raptor route for interactive coding and agent runs |
 
 ### Agent Examples
 
@@ -385,7 +386,7 @@ const evolve = new Evolve()
 const evolve = new Evolve()
     .withAgent({
         type: "kimi",
-        model: "kimi-k2.6-turbo",
+        model: "kimi-k2p7-code-raptor",
         reasoningEffort: "thinking",
     });
 ```

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -351,7 +351,8 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     defaultModel: "kimi-k2.6",
     models: [
       { alias: "kimi-k2.6", modelId: "moonshot/kimi-k2.6", description: "Latest: long-horizon coding, swarm orchestration" },
-      { alias: "kimi-k2.6-turbo", modelId: "kimi-k2.6-turbo", description: "Evolve-managed Kimi K2.6 turbo route for latency-sensitive agent runs" },
+      { alias: "kimi-k2p6-raptor", modelId: "kimi-k2p6-raptor", description: "Evolve-managed Kimi K2.6 Raptor route for latency-sensitive agent runs" },
+      { alias: "kimi-k2p7-code-raptor", modelId: "kimi-k2p7-code-raptor", description: "Evolve-managed Kimi K2.7 Code Raptor route for latency-sensitive agent runs" },
       { alias: "kimi-k2.5", modelId: "moonshot/kimi-k2.5", description: "Previous multimodal flagship" },
     ],
     systemPromptFile: "AGENTS.md",
@@ -379,7 +380,8 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     ],
     gatewayModelAliases: {
       "kimi-k2.6": "moonshot/kimi-k2.6",
-      "kimi-k2.6-turbo": "kimi-k2.6-turbo",
+      "kimi-k2p6-raptor": "kimi-k2p6-raptor",
+      "kimi-k2p7-code-raptor": "kimi-k2p7-code-raptor",
       "kimi-k2.5": "moonshot/kimi-k2.5",
     },
     buildCommand: ({ prompt, isResume, reasoningEffort }) => {

--- a/packages/sdk-ts/tests/unit/cost-api.test.ts
+++ b/packages/sdk-ts/tests/unit/cost-api.test.ts
@@ -814,7 +814,8 @@ async function testKimiBuildCommandUsesPromptMode(): Promise<void> {
   const kimi = AGENT_REGISTRY.kimi;
   assertEqual(kimi.defaultModel, "kimi-k2.6", "Kimi default is user-facing");
   assertEqual(kimi.gatewayModelAliases?.["kimi-k2.5"], "moonshot/kimi-k2.5", "Kimi gateway maps to Moonshot route");
-  assertEqual(kimi.gatewayModelAliases?.["kimi-k2.6-turbo"], "kimi-k2.6-turbo", "Kimi turbo alias maps to gateway turbo route");
+  assertEqual(kimi.gatewayModelAliases?.["kimi-k2p6-raptor"], "kimi-k2p6-raptor", "Kimi K2.6 Raptor alias maps to gateway route");
+  assertEqual(kimi.gatewayModelAliases?.["kimi-k2p7-code-raptor"], "kimi-k2p7-code-raptor", "Kimi K2.7 Code Raptor alias maps to gateway route");
   assertEqual(kimi.mcpConfig.settingsDir, "~/.kimi-code", "Kimi Code settings dir");
   assertEqual(kimi.skillsConfig.targetDir, "/home/user/.kimi-code/skills", "Kimi Code skills dir");
   assert(kimi.checkpointExcludes?.includes(".kimi-code/config.toml") === true, "Kimi Code config.toml is excluded from checkpoints");
@@ -833,14 +834,14 @@ async function testKimiBuildCommandUsesPromptMode(): Promise<void> {
   assert(!gatewayCmd.includes("--yolo"), "omits prompt-incompatible --yolo flag");
   assert(!gatewayCmd.includes("--thinking"), "omits old thinking flag");
 
-  const turboGatewayAgent = new Agent({
+  const raptorGatewayAgent = new Agent({
     type: "kimi",
     apiKey: "test-gateway-key",
     isDirectMode: false,
-    model: "kimi-k2.6-turbo",
+    model: "kimi-k2p7-code-raptor",
   } as any, {});
-  const turboGatewayCmd = (turboGatewayAgent as any).buildCommand("hello") as string;
-  assert(turboGatewayCmd.includes("else kimi -p 'hello' --output-format stream-json"), "turbo gateway uses config default model in new Kimi branch");
+  const raptorGatewayCmd = (raptorGatewayAgent as any).buildCommand("hello") as string;
+  assert(raptorGatewayCmd.includes("else kimi -p 'hello' --output-format stream-json"), "raptor gateway uses config default model in new Kimi branch");
 
   const directAgent = new Agent({
     type: "kimi",
@@ -855,7 +856,7 @@ async function testKimiBuildCommandUsesPromptMode(): Promise<void> {
     type: "kimi",
     apiKey: "test-gateway-key",
     isDirectMode: false,
-    model: "kimi-k2.6-turbo",
+    model: "kimi-k2p6-raptor",
     reasoningEffort: "no-thinking",
   } as any, {});
   const noThinkingCmd = (noThinkingAgent as any).buildCommand("hello") as string;

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -276,7 +276,7 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `'gemini'` | `'gemini-3.1-pro-preview'` `'gemini-3.1-flash-lite-preview'` `'gemini-3.5-flash'` `'gemini-3-flash-preview'` `'gemini-2.5-pro'` `'gemini-2.5-flash'` `'gemini-2.5-flash-lite'` | `'gemini-3.1-pro-preview'` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `'qwen'` | `'qwen3.7-max'` `'qwen3.7-plus'` `'qwen3.6-flash'` `'qwen3.6-plus'` | `'qwen3.7-max'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `'kimi'` | `'kimi-k2.6'` `'kimi-k2.6-turbo'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `'kimi'` | `'kimi-k2.6'` `'kimi-k2p6-raptor'` `'kimi-k2p7-code-raptor'` `'kimi-k2.5'` | `'kimi-k2.6'` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `'opencode'` | `'openrouter/anthropic/claude-fable-5'` `'openrouter/anthropic/claude-opus-4.8'` `'openrouter/anthropic/claude-sonnet-4.6'` `'openrouter/anthropic/claude-haiku-4.5'` `'openrouter/openai/gpt-5.5'` `'openrouter/openai/gpt-5.4'` `'openrouter/openai/gpt-5.4-mini'` `'openrouter/openai/gpt-5.3-codex'` `'openrouter/openai/gpt-5.2'` `'openrouter/google/gemini-3.1-pro-preview'` `'openrouter/google/gemini-3.5-flash'` `'openrouter/google/gemini-3-flash-preview'` `'openrouter/qwen/qwen3-coder-next'` `'openrouter/qwen/qwen3-coder-plus'` `'openrouter/moonshotai/kimi-k2.6'` `'openrouter/moonshotai/kimi-k2.5'` `'openrouter/z-ai/glm-5'` | `'openrouter/anthropic/claude-sonnet-4.6'` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `'droid'` | `'claude-opus-4-8'` `'claude-opus-4-8-fast'` `'claude-sonnet-4-6'` `'claude-opus-4-6'` `'claude-opus-4-6-fast'` `'claude-opus-4-5'` `'claude-sonnet-4-5'` `'claude-haiku-4-5'` `'gpt-5.5'` `'gpt-5.5-fast'` `'gpt-5.5-pro'` `'gpt-5.4'` `'gpt-5.4-fast'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.3-codex-fast'` `'gpt-5.2'` `'gpt-5.2-codex'` `'gemini-3.1-pro-preview'` `'gemini-3-pro-preview'` `'gemini-3-flash-preview'` `'kimi-k2.6'` `'kimi-k2.5'` `'deepseek-v4-pro'` `'minimax-m2.7'` `'minimax-m2.5'` `'glm-5.1'` | `'gpt-5.5'` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
@@ -302,7 +302,8 @@ These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve fo
 
 | Agent | Model | Use |
 |-------|-------|-----|
-| `'kimi'` | `'kimi-k2.6-turbo'` | Kimi K2.6 turbo for interactive coding and agent runs |
+| `'kimi'` | `'kimi-k2p6-raptor'` | Kimi K2.6 Raptor route for interactive coding and agent runs |
+| `'kimi'` | `'kimi-k2p7-code-raptor'` | Kimi K2.7 Code Raptor route for interactive coding and agent runs |
 
 ### Agent Examples
 
@@ -397,7 +398,7 @@ evolve = Evolve(
 evolve = Evolve(
     config=AgentConfig(
         type='kimi',
-        model='kimi-k2.6-turbo',
+        model='kimi-k2p7-code-raptor',
         reasoning_effort='thinking',
     ),
 )

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -279,7 +279,7 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
 | `"gemini"` | `"gemini-3.1-pro-preview"` `"gemini-3.1-flash-lite-preview"` `"gemini-3.5-flash"` `"gemini-3-flash-preview"` `"gemini-2.5-pro"` `"gemini-2.5-flash"` `"gemini-2.5-flash-lite"` | `"gemini-3.1-pro-preview"` | `EVOLVE_API_KEY` | `GEMINI_API_KEY` or `GEMINI_OAUTH_FILE_PATH` |
 | `"qwen"` | `"qwen3.7-max"` `"qwen3.7-plus"` `"qwen3.6-flash"` `"qwen3.6-plus"` | `"qwen3.7-max"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` |
-| `"kimi"` | `"kimi-k2.6"` `"kimi-k2.6-turbo"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
+| `"kimi"` | `"kimi-k2.6"` `"kimi-k2p6-raptor"` `"kimi-k2p7-code-raptor"` `"kimi-k2.5"` | `"kimi-k2.6"` | `EVOLVE_API_KEY` | `KIMI_API_KEY` |
 | `"opencode"` | `"openrouter/anthropic/claude-fable-5"` `"openrouter/anthropic/claude-opus-4.8"` `"openrouter/anthropic/claude-sonnet-4.6"` `"openrouter/anthropic/claude-haiku-4.5"` `"openrouter/openai/gpt-5.5"` `"openrouter/openai/gpt-5.4"` `"openrouter/openai/gpt-5.4-mini"` `"openrouter/openai/gpt-5.3-codex"` `"openrouter/openai/gpt-5.2"` `"openrouter/google/gemini-3.1-pro-preview"` `"openrouter/google/gemini-3.5-flash"` `"openrouter/google/gemini-3-flash-preview"` `"openrouter/qwen/qwen3-coder-next"` `"openrouter/qwen/qwen3-coder-plus"` `"openrouter/moonshotai/kimi-k2.6"` `"openrouter/moonshotai/kimi-k2.5"` `"openrouter/z-ai/glm-5"` | `"openrouter/anthropic/claude-sonnet-4.6"` | `EVOLVE_API_KEY` | `OPENROUTER_API_KEY` |
 | `"droid"` | `"claude-opus-4-8"` `"claude-opus-4-8-fast"` `"claude-sonnet-4-6"` `"claude-opus-4-6"` `"claude-opus-4-6-fast"` `"claude-opus-4-5"` `"claude-sonnet-4-5"` `"claude-haiku-4-5"` `"gpt-5.5"` `"gpt-5.5-fast"` `"gpt-5.5-pro"` `"gpt-5.4"` `"gpt-5.4-fast"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.3-codex-fast"` `"gpt-5.2"` `"gpt-5.2-codex"` `"gemini-3.1-pro-preview"` `"gemini-3-pro-preview"` `"gemini-3-flash-preview"` `"kimi-k2.6"` `"kimi-k2.5"` `"deepseek-v4-pro"` `"minimax-m2.7"` `"minimax-m2.5"` `"glm-5.1"` | `"gpt-5.5"` | `EVOLVE_API_KEY` | `FACTORY_API_KEY` |
 
@@ -305,7 +305,8 @@ These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve fo
 
 | Agent | Model | Use |
 |-------|-------|-----|
-| `"kimi"` | `"kimi-k2.6-turbo"` | Kimi K2.6 turbo for interactive coding and agent runs |
+| `"kimi"` | `"kimi-k2p6-raptor"` | Kimi K2.6 Raptor route for interactive coding and agent runs |
+| `"kimi"` | `"kimi-k2p7-code-raptor"` | Kimi K2.7 Code Raptor route for interactive coding and agent runs |
 
 ### Agent Examples
 
@@ -385,7 +386,7 @@ const evolve = new Evolve()
 const evolve = new Evolve()
     .withAgent({
         type: "kimi",
-        model: "kimi-k2.6-turbo",
+        model: "kimi-k2p7-code-raptor",
         reasoningEffort: "thinking",
     });
 ```


### PR DESCRIPTION
## Summary
- expose managed Kimi aliases `kimi-k2p6-raptor` and `kimi-k2p7-code-raptor`
- remove the public `kimi-k2.6-turbo` SDK alias
- sync TypeScript/Python docs and Evolve skill references

## Validation
- `npm run type-check --workspace=@evolvingmachines/sdk`
- `npx tsx packages/sdk-ts/tests/unit/cost-api.test.ts`
- `npm run build --workspace=@evolvingmachines/sdk`
- stale public-name scan for fast/turbo aliases