### PR TITLE
Support dashboard provider runtime tokens in SDK

### DIFF
--- a/.claude/skills/evolve/SKILL.md
+++ b/.claude/skills/evolve/SKILL.md
@@ -25,12 +25,12 @@ Determine the language from (in priority order):
 Always read these three references **for the detected language** before writing any Evolve code:
 
 **TypeScript:**
-- [01-getting-started.md](references/typescript/01-getting-started.md) — Installation, authentication (Gateway/BYOK), core lifecycle, streaming basics, agent reference table
+- [01-getting-started.md](references/typescript/01-getting-started.md) — Installation, authentication (Gateway, managed BYO provider keys, direct provider-key mode), core lifecycle, streaming basics, agent reference table
 - [02-configuration.md](references/typescript/02-configuration.md) — Sandbox providers, full builder API, agent skills catalog, Managed integrations, MCP servers
 - [03-runtime.md](references/typescript/03-runtime.md) — run(), executeCommand(), upload/download files, session controls, workspace layout, structured output, session management, storage & checkpointing, StorageClient, sessions() client, cost tracking, observability, error handling
 
 **Python:**
-- [01-getting-started.md](references/python/01-getting-started.md) — Installation, authentication (Gateway/BYOK), core lifecycle, streaming basics, agent reference table
+- [01-getting-started.md](references/python/01-getting-started.md) — Installation, authentication (Gateway, managed BYO provider keys, direct provider-key mode), core lifecycle, streaming basics, agent reference table
 - [02-configuration.md](references/python/02-configuration.md) — Sandbox providers, full constructor API, agent skills catalog, Managed integrations, MCP servers
 - [03-runtime.md](references/python/03-runtime.md) — run(), execute_command(), upload/download files, session controls, workspace layout, structured output, session management, storage & checkpointing, StorageClient, sessions() client, cost tracking, observability, error handling
 
@@ -60,7 +60,7 @@ Read on demand when the user's task requires them:
 | Quick start (3 steps) | [TS](references/typescript/01-getting-started.md#quick-start) | [PY](references/python/01-getting-started.md#quick-start) |
 | Core lifecycle (run, output, kill) | [TS](references/typescript/01-getting-started.md#core-lifecycle) | [PY](references/python/01-getting-started.md#core-lifecycle) |
 | Streaming basics | [TS](references/typescript/01-getting-started.md#streaming) | [PY](references/python/01-getting-started.md#streaming) |
-| Gateway vs BYOK mode | [TS](references/typescript/01-getting-started.md#authentication) | [PY](references/python/01-getting-started.md#authentication) |
+| Gateway, managed BYO provider keys, and direct provider-key mode | [TS](references/typescript/01-getting-started.md#authentication) | [PY](references/python/01-getting-started.md#authentication) |
 | BYO subscriptions (Claude Max, Codex, Gemini) | [TS](references/typescript/01-getting-started.md#byo-claude-max-subscription) | [PY](references/python/01-getting-started.md#byo-claude-max-subscription) |
 | Supported agents, models & defaults | [TS](references/typescript/01-getting-started.md#agent-reference) | [PY](references/python/01-getting-started.md#agent-reference) |
 

--- a/.claude/skills/evolve/references/python/01-getting-started.md
+++ b/.claude/skills/evolve/references/python/01-getting-started.md
@@ -104,12 +104,14 @@ When using `EVOLVE_API_KEY`:
 
 ## Authentication
 
-| | Gateway Mode | BYOK Mode |
-|---|---------|---------------|
-| Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
-| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
-| Billing | Evolving Machines | Your provider accounts |
+| | Gateway Mode | Managed BYO Provider Keys | Direct Provider Key Mode |
+|---|---------|---------------------------|--------------------------|
+| Setup | `EVOLVE_API_KEY` | `EVOLVE_API_KEY` + provider key saved in Dashboard → Secrets → BYO Provider Keys | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
+| Provider key location | Evolve-managed | Encrypted Dashboard secret | Your local environment or app config |
+| Sandbox receives | Evolve gateway runtime config | Temporary `evrt_...` token and Dashboard proxy URL, not the raw provider key or `EVOLVE_API_KEY` for that provider route | Raw provider key environment variable |
+| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Same as Gateway Mode | Self-managed browser runtime; no managed live/replay |
+| Model billing | Evolving Machines | Your provider account for enabled providers | Your provider accounts |
 
 ---
 
@@ -134,9 +136,21 @@ await evolve.run(prompt='Hello')
 
 ---
 
-### BYOK Mode
+### Managed BYO Provider Keys
 
-Use your own provider keys. Requires [`E2B_API_KEY`](https://e2b.dev) for sandbox.
+Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+
+1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
+2. Keep `EVOLVE_API_KEY` in your app.
+3. Run Claude or Codex normally.
+
+When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
+
+---
+
+### Direct Provider Key Mode (Local BYOK)
+
+Use this when you want to pass provider keys from your own local environment or app config. Requires [`E2B_API_KEY`](https://e2b.dev) for sandbox.
 
 ```bash
 # .env
@@ -270,7 +284,9 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 > **IMPORTANT: Only use the exact model names listed below.** The SDK will error on unrecognized model names. Do not invent or guess model identifiers.
 
-| type | models | default | Gateway | BYOK |
+The Direct key column applies to Direct Provider Key Mode. Managed BYO Provider Keys use Gateway Mode plus Dashboard-stored provider keys.
+
+| type | models | default | Gateway | Direct key |
 |------|--------|---------|---------|------|
 | `'claude'` | `'fable'` `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
@@ -298,7 +314,7 @@ For Claude Fable 5, use `model='fable'`. For OpenCode via OpenRouter, use `model
 
 #### Evolve-Provided Gateway Models
 
-These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. Direct provider keys do not apply.
 
 | Agent | Model | Use |
 |-------|-------|-----|

--- a/.claude/skills/evolve/references/python/02-configuration.md
+++ b/.claude/skills/evolve/references/python/02-configuration.md
@@ -2,7 +2,7 @@
 
 ## Sandbox Providers
 
-Works with both Gateway mode (`EVOLVE_API_KEY`) and BYOK mode (provider API keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
+Works with both Gateway mode (`EVOLVE_API_KEY`) and Direct Provider Key Mode (local BYOK provider keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
 
 All providers use the `evolve-all` image with pre-installed CLIs.
 
@@ -30,7 +30,7 @@ MODAL_TOKEN_SECRET=as-...
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode with E2B (auto-resolves to E2B)
+# .env - Direct Provider Key Mode with E2B (auto-resolves to E2B)
 ANTHROPIC_API_KEY=sk-ant-...
 E2B_API_KEY=e2b_...
 ```
@@ -56,9 +56,9 @@ Only use explicit provider creation (below) if you need custom settings like tim
 EVOLVE_API_KEY=sk-...
 E2B_API_KEY=e2b_...              # Optional with EVOLVE_API_KEY (auto-resolves)
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
-E2B_API_KEY=e2b_...              # Required in BYOK mode
+E2B_API_KEY=e2b_...              # Required in Direct Provider Key Mode
 ```
 
 ```python
@@ -78,7 +78,7 @@ EVOLVE_API_KEY=sk-...
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
@@ -103,7 +103,7 @@ sandbox = ModalProvider(
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 DAYTONA_API_KEY=...
 ```
@@ -146,7 +146,7 @@ evolve = Evolve(
         model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
         reasoning_effort='medium',           # (optional) Native reasoning/thinking control; valid values vary by agent/model
         api_key=os.getenv('EVOLVE_API_KEY'), # (optional) Gateway mode - auto-resolves from env
-        # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct mode (BYOK)
+        # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct Provider Key Mode
         # oauth_token=os.getenv('CLAUDE_CODE_OAUTH_TOKEN'), # (optional) Claude Max subscription
     ),
 
@@ -390,7 +390,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - Use `browser={'provider': 'agent-browser', 'remote': True}`.
-- Not available with local browser mode, direct/BYOK provider mode, or existing sandbox sessions.
+- Not available with local browser mode, Direct Provider Key Mode, or existing sandbox sessions.
 
 Dashboard setup:
 

--- a/.claude/skills/evolve/references/python/03-runtime.md
+++ b/.claude/skills/evolve/references/python/03-runtime.md
@@ -783,7 +783,7 @@ replay = await session.browser_replay(
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
-This API is **gateway-only**. In BYOK/direct mode, historical traces remain
+This API is **gateway-only**. In Direct Provider Key Mode, historical traces remain
 available via local JSONL files in `~/.evolve-sdk/observability/sessions/`.
 
 ---

--- a/.claude/skills/evolve/references/typescript/01-getting-started.md
+++ b/.claude/skills/evolve/references/typescript/01-getting-started.md
@@ -120,12 +120,14 @@ When using `EVOLVE_API_KEY`:
 
 ## Authentication
 
-| | Gateway Mode | BYOK Mode |
-|---|---------|---------------|
-| Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
-| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
-| Billing | Evolving Machines | Your provider accounts |
+| | Gateway Mode | Managed BYO Provider Keys | Direct Provider Key Mode |
+|---|---------|---------------------------|--------------------------|
+| Setup | `EVOLVE_API_KEY` | `EVOLVE_API_KEY` + provider key saved in Dashboard → Secrets → BYO Provider Keys | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
+| Provider key location | Evolve-managed | Encrypted Dashboard secret | Your local environment or app config |
+| Sandbox receives | Evolve gateway runtime config | Temporary `evrt_...` token and Dashboard proxy URL, not the raw provider key or `EVOLVE_API_KEY` for that provider route | Raw provider key environment variable |
+| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Same as Gateway Mode | Self-managed browser runtime; no managed live/replay |
+| Model billing | Evolving Machines | Your provider account for enabled providers | Your provider accounts |
 
 ---
 
@@ -149,9 +151,21 @@ await evolve.run({ prompt: "Hello" });
 
 ---
 
-### BYOK Mode
+### Managed BYO Provider Keys
 
-Use your own provider keys. Requires [E2B API key](https://e2b.dev) for sandbox.
+Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+
+1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
+2. Keep `EVOLVE_API_KEY` in your app.
+3. Run Claude or Codex normally.
+
+When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
+
+---
+
+### Direct Provider Key Mode (Local BYOK)
+
+Use this when you want to pass provider keys from your own local environment or app config. Requires [E2B API key](https://e2b.dev) for sandbox.
 
 ```bash
 # .env
@@ -273,7 +287,9 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 > **IMPORTANT: Only use the exact model names listed below.** The SDK will error on unrecognized model names. Do not invent or guess model identifiers.
 
-| type | models | default | Gateway | BYOK |
+The Direct key column applies to Direct Provider Key Mode. Managed BYO Provider Keys use Gateway Mode plus Dashboard-stored provider keys.
+
+| type | models | default | Gateway | Direct key |
 |------|--------|---------|---------|------|
 | `"claude"` | `"fable"` `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
@@ -301,7 +317,7 @@ For Claude Fable 5, use `model: "fable"`. For OpenCode via OpenRouter, use `mode
 
 #### Evolve-Provided Gateway Models
 
-These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. Direct provider keys do not apply.
 
 | Agent | Model | Use |
 |-------|-------|-----|

--- a/.claude/skills/evolve/references/typescript/02-configuration.md
+++ b/.claude/skills/evolve/references/typescript/02-configuration.md
@@ -2,7 +2,7 @@
 
 ## Sandbox Providers
 
-Works with both Gateway mode (`EVOLVE_API_KEY`) and BYOK mode (provider API keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
+Works with both Gateway mode (`EVOLVE_API_KEY`) and Direct Provider Key Mode (local BYOK provider keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
 
 All providers use the `evolve-all` image with pre-installed CLIs.
 
@@ -30,7 +30,7 @@ MODAL_TOKEN_SECRET=as-...
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode with E2B (auto-resolves to E2B)
+# .env - Direct Provider Key Mode with E2B (auto-resolves to E2B)
 ANTHROPIC_API_KEY=sk-ant-...
 E2B_API_KEY=e2b_...
 ```
@@ -55,9 +55,9 @@ Only use explicit provider creation (below) if you need custom settings like tim
 EVOLVE_API_KEY=sk-...
 E2B_API_KEY=e2b_...              # Optional with EVOLVE_API_KEY (auto-resolves)
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
-E2B_API_KEY=e2b_...              # Required in BYOK mode
+E2B_API_KEY=e2b_...              # Required in Direct Provider Key Mode
 ```
 
 ```ts
@@ -77,7 +77,7 @@ EVOLVE_API_KEY=sk-...
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
@@ -102,7 +102,7 @@ const sandbox = createModalProvider({
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 DAYTONA_API_KEY=...
 ```
@@ -132,7 +132,7 @@ const evolve = new Evolve()
         model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "fable" for Claude Fable 5 or "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
         reasoningEffort: "medium",            // (optional) Native reasoning/thinking control; valid values vary by agent/model
         apiKey: process.env.EVOLVE_API_KEY!, // (optional) Gateway mode - auto-resolves from env
-        // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct mode (BYOK)
+        // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct Provider Key Mode
         // oauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN!, // (optional) Claude Max subscription
     })
 
@@ -392,7 +392,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - `.withBrowser()` uses that recommended remote setup by default.
-- Not available with local browser mode, direct/BYOK provider mode, or `.withSession()`.
+- Not available with local browser mode, Direct Provider Key Mode, or `.withSession()`.
 
 Dashboard setup:
 

--- a/.claude/skills/evolve/references/typescript/03-runtime.md
+++ b/.claude/skills/evolve/references/typescript/03-runtime.md
@@ -745,7 +745,7 @@ const replay = await session.browserReplay(info.id, {
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
-Gateway-only — requires `EVOLVE_API_KEY`. In BYOK/direct mode, traces remain
+Gateway-only — requires `EVOLVE_API_KEY`. In Direct Provider Key Mode, traces remain
 available as local JSONL files in `~/.evolve-sdk/observability/sessions/`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.0.51 - 2026-06-30
+
+### Highlights
+
+- Added Dashboard-managed BYO Provider Keys for Claude and Codex gateway sessions.
+- Preserved Direct Provider Key Mode for local BYOK users.
+- Published TypeScript and Python packages at `0.0.51`.
+
+### SDK
+
+- Requests sandbox-bound provider runtime tokens from Dashboard for managed Claude/Anthropic and Codex/OpenAI routes.
+- Routes managed BYO provider-key calls through Dashboard model proxy without exposing the raw provider key or Evolve API key in the sandbox for that provider route.
+- Binds provider runtime tokens to sandbox lifecycle and revokes them on cleanup, session switch, and failure paths.
+- Keeps the existing gateway fallback path when managed provider keys are disabled or unavailable.
+
+### Documentation And Skills
+
+- Clarified the two BYO paths: Managed BYO Provider Keys vs Direct Provider Key Mode.
+- Synced TypeScript, Python, and Evolve skill references for the updated authentication model.
+
 ## v0.0.50 - 2026-06-15
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -48,17 +48,19 @@ pip install evolve-sdk    # Python
 
 ### 2. Run your first agent
 
-Bring your own keys:
-```bash
-# .env - Direct (BYOK)
-ANTHROPIC_API_KEY=sk-ant-...         # or CLAUDE_CODE_OAUTH_TOKEN (Claude Max), OPENAI_API_KEY, GEMINI_API_KEY
-E2B_API_KEY=e2b_...                  # sandbox provider, get at https://e2b.dev
-```
-
-Or get your Evolve API key at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) ([see 3. below](#evolve-gateway)):
+Get your Evolve API key at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) ([see 3. below](#evolve-gateway)):
 ```bash
 # .env - Gateway
 EVOLVE_API_KEY=sk-...
+```
+
+To bring your own provider billing while keeping gateway features, save Anthropic/OpenAI keys in Dashboard → Secrets → BYO Provider Keys. Your app still uses only `EVOLVE_API_KEY`.
+
+For fully local direct provider keys:
+```bash
+# .env - Direct Provider Key Mode (local BYOK)
+ANTHROPIC_API_KEY=sk-ant-...         # or CLAUDE_CODE_OAUTH_TOKEN (Claude Max), OPENAI_API_KEY, GEMINI_API_KEY
+E2B_API_KEY=e2b_...                  # sandbox provider, get at https://e2b.dev
 ```
 
 Then run:

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -25,12 +25,12 @@ Determine the language from (in priority order):
 Always read these three references **for the detected language** before writing any Evolve code:
 
 **TypeScript:**
-- [01-getting-started.md](references/typescript/01-getting-started.md) — Installation, authentication (Gateway/BYOK), core lifecycle, streaming basics, agent reference table
+- [01-getting-started.md](references/typescript/01-getting-started.md) — Installation, authentication (Gateway, managed BYO provider keys, direct provider-key mode), core lifecycle, streaming basics, agent reference table
 - [02-configuration.md](references/typescript/02-configuration.md) — Sandbox providers, full builder API, agent skills catalog, Managed integrations, MCP servers
 - [03-runtime.md](references/typescript/03-runtime.md) — run(), executeCommand(), upload/download files, session controls, workspace layout, structured output, session management, storage & checkpointing, StorageClient, sessions() client, cost tracking, observability, error handling
 
 **Python:**
-- [01-getting-started.md](references/python/01-getting-started.md) — Installation, authentication (Gateway/BYOK), core lifecycle, streaming basics, agent reference table
+- [01-getting-started.md](references/python/01-getting-started.md) — Installation, authentication (Gateway, managed BYO provider keys, direct provider-key mode), core lifecycle, streaming basics, agent reference table
 - [02-configuration.md](references/python/02-configuration.md) — Sandbox providers, full constructor API, agent skills catalog, Managed integrations, MCP servers
 - [03-runtime.md](references/python/03-runtime.md) — run(), execute_command(), upload/download files, session controls, workspace layout, structured output, session management, storage & checkpointing, StorageClient, sessions() client, cost tracking, observability, error handling
 
@@ -60,7 +60,7 @@ Read on demand when the user's task requires them:
 | Quick start (3 steps) | [TS](references/typescript/01-getting-started.md#quick-start) | [PY](references/python/01-getting-started.md#quick-start) |
 | Core lifecycle (run, output, kill) | [TS](references/typescript/01-getting-started.md#core-lifecycle) | [PY](references/python/01-getting-started.md#core-lifecycle) |
 | Streaming basics | [TS](references/typescript/01-getting-started.md#streaming) | [PY](references/python/01-getting-started.md#streaming) |
-| Gateway vs BYOK mode | [TS](references/typescript/01-getting-started.md#authentication) | [PY](references/python/01-getting-started.md#authentication) |
+| Gateway, managed BYO provider keys, and direct provider-key mode | [TS](references/typescript/01-getting-started.md#authentication) | [PY](references/python/01-getting-started.md#authentication) |
 | BYO subscriptions (Claude Max, Codex, Gemini) | [TS](references/typescript/01-getting-started.md#byo-claude-max-subscription) | [PY](references/python/01-getting-started.md#byo-claude-max-subscription) |
 | Supported agents, models & defaults | [TS](references/typescript/01-getting-started.md#agent-reference) | [PY](references/python/01-getting-started.md#agent-reference) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,17 +17,19 @@ pip install evolve-sdk         # Python
 
 ### 2. Run your first agent
 
-Bring your own keys:
-```bash
-# .env - Direct (BYOK)
-ANTHROPIC_API_KEY=sk-ant-...         # or CLAUDE_CODE_OAUTH_TOKEN (Claude Max), OPENAI_API_KEY, GEMINI_API_KEY
-E2B_API_KEY=e2b_...                  # sandbox provider, get at https://e2b.dev
-```
-
-Or get your Evolve API key at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) ([see 3. below](#evolve-gateway)):
+Get your Evolve API key at [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) ([see 3. below](#evolve-gateway)):
 ```bash
 # .env - Gateway
 EVOLVE_API_KEY=sk-...
+```
+
+To bring your own provider billing while keeping gateway features, save Anthropic/OpenAI keys in Dashboard → Secrets → BYO Provider Keys. Your app still uses only `EVOLVE_API_KEY`.
+
+For fully local direct provider keys:
+```bash
+# .env - Direct Provider Key Mode (local BYOK)
+ANTHROPIC_API_KEY=sk-ant-...         # or CLAUDE_CODE_OAUTH_TOKEN (Claude Max), OPENAI_API_KEY, GEMINI_API_KEY
+E2B_API_KEY=e2b_...                  # sandbox provider, get at https://e2b.dev
 ```
 
 Then run:

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -104,12 +104,14 @@ When using `EVOLVE_API_KEY`:
 
 ## Authentication
 
-| | Gateway Mode | BYOK Mode |
-|---|---------|---------------|
-| Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
-| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
-| Billing | Evolving Machines | Your provider accounts |
+| | Gateway Mode | Managed BYO Provider Keys | Direct Provider Key Mode |
+|---|---------|---------------------------|--------------------------|
+| Setup | `EVOLVE_API_KEY` | `EVOLVE_API_KEY` + provider key saved in Dashboard → Secrets → BYO Provider Keys | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
+| Provider key location | Evolve-managed | Encrypted Dashboard secret | Your local environment or app config |
+| Sandbox receives | Evolve gateway runtime config | Temporary `evrt_...` token and Dashboard proxy URL, not the raw provider key or `EVOLVE_API_KEY` for that provider route | Raw provider key environment variable |
+| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Same as Gateway Mode | Self-managed browser runtime; no managed live/replay |
+| Model billing | Evolving Machines | Your provider account for enabled providers | Your provider accounts |
 
 ---
 
@@ -134,9 +136,21 @@ await evolve.run(prompt='Hello')
 
 ---
 
-### BYOK Mode
+### Managed BYO Provider Keys
 
-Use your own provider keys. Requires [`E2B_API_KEY`](https://e2b.dev) for sandbox.
+Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+
+1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
+2. Keep `EVOLVE_API_KEY` in your app.
+3. Run Claude or Codex normally.
+
+When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
+
+---
+
+### Direct Provider Key Mode (Local BYOK)
+
+Use this when you want to pass provider keys from your own local environment or app config. Requires [`E2B_API_KEY`](https://e2b.dev) for sandbox.
 
 ```bash
 # .env
@@ -270,7 +284,9 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 > **IMPORTANT: Only use the exact model names listed below.** The SDK will error on unrecognized model names. Do not invent or guess model identifiers.
 
-| type | models | default | Gateway | BYOK |
+The Direct key column applies to Direct Provider Key Mode. Managed BYO Provider Keys use Gateway Mode plus Dashboard-stored provider keys.
+
+| type | models | default | Gateway | Direct key |
 |------|--------|---------|---------|------|
 | `'claude'` | `'fable'` `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
@@ -298,7 +314,7 @@ For Claude Fable 5, use `model='fable'`. For OpenCode via OpenRouter, use `model
 
 #### Evolve-Provided Gateway Models
 
-These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. Direct provider keys do not apply.
 
 | Agent | Model | Use |
 |-------|-------|-----|

--- a/docs/python/02-configuration.md
+++ b/docs/python/02-configuration.md
@@ -2,7 +2,7 @@
 
 ## Sandbox Providers
 
-Works with both Gateway mode (`EVOLVE_API_KEY`) and BYOK mode (provider API keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
+Works with both Gateway mode (`EVOLVE_API_KEY`) and Direct Provider Key Mode (local BYOK provider keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
 
 All providers use the `evolve-all` image with pre-installed CLIs.
 
@@ -30,7 +30,7 @@ MODAL_TOKEN_SECRET=as-...
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode with E2B (auto-resolves to E2B)
+# .env - Direct Provider Key Mode with E2B (auto-resolves to E2B)
 ANTHROPIC_API_KEY=sk-ant-...
 E2B_API_KEY=e2b_...
 ```
@@ -56,9 +56,9 @@ Only use explicit provider creation (below) if you need custom settings like tim
 EVOLVE_API_KEY=sk-...
 E2B_API_KEY=e2b_...              # Optional with EVOLVE_API_KEY (auto-resolves)
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
-E2B_API_KEY=e2b_...              # Required in BYOK mode
+E2B_API_KEY=e2b_...              # Required in Direct Provider Key Mode
 ```
 
 ```python
@@ -78,7 +78,7 @@ EVOLVE_API_KEY=sk-...
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
@@ -103,7 +103,7 @@ sandbox = ModalProvider(
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 DAYTONA_API_KEY=...
 ```
@@ -146,7 +146,7 @@ evolve = Evolve(
         model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
         reasoning_effort='medium',           # (optional) Native reasoning/thinking control; valid values vary by agent/model
         api_key=os.getenv('EVOLVE_API_KEY'), # (optional) Gateway mode - auto-resolves from env
-        # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct mode (BYOK)
+        # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct Provider Key Mode
         # oauth_token=os.getenv('CLAUDE_CODE_OAUTH_TOKEN'), # (optional) Claude Max subscription
     ),
 
@@ -390,7 +390,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - Use `browser={'provider': 'agent-browser', 'remote': True}`.
-- Not available with local browser mode, direct/BYOK provider mode, or existing sandbox sessions.
+- Not available with local browser mode, Direct Provider Key Mode, or existing sandbox sessions.
 
 Dashboard setup:
 

--- a/docs/python/03-runtime.md
+++ b/docs/python/03-runtime.md
@@ -783,7 +783,7 @@ replay = await session.browser_replay(
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
-This API is **gateway-only**. In BYOK/direct mode, historical traces remain
+This API is **gateway-only**. In Direct Provider Key Mode, historical traces remain
 available via local JSONL files in `~/.evolve-sdk/observability/sessions/`.
 
 ---

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -25,10 +25,11 @@ await evolve.run(prompt='Hello world')
 | Quick Start (3 steps) | [Getting Started → Quick Start](./01-getting-started.md#quick-start) |
 | Core Lifecycle (run → get_output_files → kill) | [Getting Started → Core Lifecycle](./01-getting-started.md#core-lifecycle) |
 | Streaming basics | [Getting Started → Streaming](./01-getting-started.md#streaming) |
-| Gateway vs BYOK mode | [Getting Started → Authentication](./01-getting-started.md#authentication) |
+| Gateway, managed BYO provider keys, and direct keys | [Getting Started → Authentication](./01-getting-started.md#authentication) |
 | Gateway mode (EVOLVE_API_KEY) | [Getting Started → Gateway Mode](./01-getting-started.md#gateway-mode-evolve_api_key) |
-| BYOK mode (your own keys) | [Getting Started → BYOK Mode](./01-getting-started.md#byok-mode) |
-| BYO Claude Max / Codex / Gemini subscription | [Getting Started → BYOK Mode](./01-getting-started.md#byo-claude-max-subscription) |
+| Managed BYO provider keys | [Getting Started → Managed BYO Provider Keys](./01-getting-started.md#managed-byo-provider-keys) |
+| Direct provider key mode (local BYOK) | [Getting Started → Direct Provider Key Mode](./01-getting-started.md#direct-provider-key-mode-local-byok) |
+| BYO Claude Max / Codex / Gemini subscription | [Getting Started → BYO Claude Max Subscription](./01-getting-started.md#byo-claude-max-subscription) |
 | Supported agents & models | [Getting Started → Agent Reference](./01-getting-started.md#agent-reference) |
 | Agent-specific options (reasoning_effort) | [Getting Started → Agent Reference](./01-getting-started.md#agent-reference) |
 

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -120,12 +120,14 @@ When using `EVOLVE_API_KEY`:
 
 ## Authentication
 
-| | Gateway Mode | BYOK Mode |
-|---|---------|---------------|
-| Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
-| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
-| Billing | Evolving Machines | Your provider accounts |
+| | Gateway Mode | Managed BYO Provider Keys | Direct Provider Key Mode |
+|---|---------|---------------------------|--------------------------|
+| Setup | `EVOLVE_API_KEY` | `EVOLVE_API_KEY` + provider key saved in Dashboard → Secrets → BYO Provider Keys | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
+| Provider key location | Evolve-managed | Encrypted Dashboard secret | Your local environment or app config |
+| Sandbox receives | Evolve gateway runtime config | Temporary `evrt_...` token and Dashboard proxy URL, not the raw provider key or `EVOLVE_API_KEY` for that provider route | Raw provider key environment variable |
+| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Same as Gateway Mode | Self-managed browser runtime; no managed live/replay |
+| Model billing | Evolving Machines | Your provider account for enabled providers | Your provider accounts |
 
 ---
 
@@ -149,9 +151,21 @@ await evolve.run({ prompt: "Hello" });
 
 ---
 
-### BYOK Mode
+### Managed BYO Provider Keys
 
-Use your own provider keys. Requires [E2B API key](https://e2b.dev) for sandbox.
+Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+
+1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
+2. Keep `EVOLVE_API_KEY` in your app.
+3. Run Claude or Codex normally.
+
+When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
+
+---
+
+### Direct Provider Key Mode (Local BYOK)
+
+Use this when you want to pass provider keys from your own local environment or app config. Requires [E2B API key](https://e2b.dev) for sandbox.
 
 ```bash
 # .env
@@ -273,7 +287,9 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 > **IMPORTANT: Only use the exact model names listed below.** The SDK will error on unrecognized model names. Do not invent or guess model identifiers.
 
-| type | models | default | Gateway | BYOK |
+The Direct key column applies to Direct Provider Key Mode. Managed BYO Provider Keys use Gateway Mode plus Dashboard-stored provider keys.
+
+| type | models | default | Gateway | Direct key |
 |------|--------|---------|---------|------|
 | `"claude"` | `"fable"` `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
@@ -301,7 +317,7 @@ For Claude Fable 5, use `model: "fable"`. For OpenCode via OpenRouter, use `mode
 
 #### Evolve-Provided Gateway Models
 
-These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. Direct provider keys do not apply.
 
 | Agent | Model | Use |
 |-------|-------|-----|

--- a/docs/typescript/02-configuration.md
+++ b/docs/typescript/02-configuration.md
@@ -2,7 +2,7 @@
 
 ## Sandbox Providers
 
-Works with both Gateway mode (`EVOLVE_API_KEY`) and BYOK mode (provider API keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
+Works with both Gateway mode (`EVOLVE_API_KEY`) and Direct Provider Key Mode (local BYOK provider keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
 
 All providers use the `evolve-all` image with pre-installed CLIs.
 
@@ -30,7 +30,7 @@ MODAL_TOKEN_SECRET=as-...
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode with E2B (auto-resolves to E2B)
+# .env - Direct Provider Key Mode with E2B (auto-resolves to E2B)
 ANTHROPIC_API_KEY=sk-ant-...
 E2B_API_KEY=e2b_...
 ```
@@ -55,9 +55,9 @@ Only use explicit provider creation (below) if you need custom settings like tim
 EVOLVE_API_KEY=sk-...
 E2B_API_KEY=e2b_...              # Optional with EVOLVE_API_KEY (auto-resolves)
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
-E2B_API_KEY=e2b_...              # Required in BYOK mode
+E2B_API_KEY=e2b_...              # Required in Direct Provider Key Mode
 ```
 
 ```ts
@@ -77,7 +77,7 @@ EVOLVE_API_KEY=sk-...
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
@@ -102,7 +102,7 @@ const sandbox = createModalProvider({
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 DAYTONA_API_KEY=...
 ```
@@ -132,7 +132,7 @@ const evolve = new Evolve()
         model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "fable" for Claude Fable 5 or "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
         reasoningEffort: "medium",            // (optional) Native reasoning/thinking control; valid values vary by agent/model
         apiKey: process.env.EVOLVE_API_KEY!, // (optional) Gateway mode - auto-resolves from env
-        // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct mode (BYOK)
+        // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct Provider Key Mode
         // oauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN!, // (optional) Claude Max subscription
     })
 
@@ -392,7 +392,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - `.withBrowser()` uses that recommended remote setup by default.
-- Not available with local browser mode, direct/BYOK provider mode, or `.withSession()`.
+- Not available with local browser mode, Direct Provider Key Mode, or `.withSession()`.
 
 Dashboard setup:
 

--- a/docs/typescript/03-runtime.md
+++ b/docs/typescript/03-runtime.md
@@ -745,7 +745,7 @@ const replay = await session.browserReplay(info.id, {
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
-Gateway-only — requires `EVOLVE_API_KEY`. In BYOK/direct mode, traces remain
+Gateway-only — requires `EVOLVE_API_KEY`. In Direct Provider Key Mode, traces remain
 available as local JSONL files in `~/.evolve-sdk/observability/sessions/`.
 
 ---

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -25,10 +25,11 @@ await evolve.run({ prompt: "Hello world" });
 | Quick Start (3 steps) | [Getting Started → Quick Start](./01-getting-started.md#quick-start) |
 | Core Lifecycle (run → getOutputFiles → kill) | [Getting Started → Core Lifecycle](./01-getting-started.md#core-lifecycle) |
 | Streaming basics | [Getting Started → Streaming](./01-getting-started.md#streaming) |
-| Gateway vs BYOK mode | [Getting Started → Authentication](./01-getting-started.md#authentication) |
+| Gateway, managed BYO provider keys, and direct keys | [Getting Started → Authentication](./01-getting-started.md#authentication) |
 | Gateway mode (EVOLVE_API_KEY) | [Getting Started → Gateway Mode](./01-getting-started.md#gateway-mode-evolve_api_key) |
-| BYOK mode (your own keys) | [Getting Started → BYOK Mode](./01-getting-started.md#byok-mode) |
-| BYO Claude Max / Codex / Gemini subscription | [Getting Started → BYOK Mode](./01-getting-started.md#byo-claude-max-subscription) |
+| Managed BYO provider keys | [Getting Started → Managed BYO Provider Keys](./01-getting-started.md#managed-byo-provider-keys) |
+| Direct provider key mode (local BYOK) | [Getting Started → Direct Provider Key Mode](./01-getting-started.md#direct-provider-key-mode-local-byok) |
+| BYO Claude Max / Codex / Gemini subscription | [Getting Started → BYO Claude Max Subscription](./01-getting-started.md#byo-claude-max-subscription) |
 | Supported agents & models | [Getting Started → Agent Reference](./01-getting-started.md#agent-reference) |
 | Agent-specific options (reasoningEffort) | [Getting Started → Agent Reference](./01-getting-started.md#agent-reference) |
 

--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -39,16 +39,42 @@ import type {
   SessionCost,
 } from "./types";
 import { VALIDATION_PRESETS } from "./types";
-import { getAgentConfig, getOpenCodeReasoningVariant, isThinkingEnabled, type AgentRegistryEntry } from "./registry";
-import { writeMcpConfig, writeCodexSpendProvider, writeJsonSpendHeaders, writeQwenThinkingConfig, writeKimiSpendConfig, writeDroidGatewaySettings } from "./mcp";
+import {
+  getAgentConfig,
+  getOpenCodeReasoningVariant,
+  isThinkingEnabled,
+  type AgentRegistryEntry,
+} from "./registry";
+import {
+  writeMcpConfig,
+  writeCodexSpendProvider,
+  writeJsonSpendHeaders,
+  writeQwenThinkingConfig,
+  writeKimiSpendConfig,
+  writeDroidGatewaySettings,
+} from "./mcp";
 import { createAgentParser, type AgentParser } from "./parsers";
 import type { OutputEvent } from "./parsers/types";
-import { DEFAULT_TIMEOUT_MS, DEFAULT_WORKING_DIR, DEFAULT_DASHBOARD_URL, ENV_EVOLVE_API_KEY, LITELLM_CUSTOMER_ID_HEADER, LITELLM_TAGS_HEADER, RUN_TAG_PREFIX, getGatewayUrl } from "./constants";
+import {
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_WORKING_DIR,
+  DEFAULT_DASHBOARD_URL,
+  ENV_EVOLVE_API_KEY,
+  LITELLM_CUSTOMER_ID_HEADER,
+  LITELLM_TAGS_HEADER,
+  RUN_TAG_PREFIX,
+  getGatewayUrl,
+} from "./constants";
 import { buildWorkerSystemPrompt } from "./prompts";
 import { isZodSchema } from "./utils";
 import { SessionLogger } from "./observability";
 import { setupIntegrations } from "./integrations";
-import { createCheckpoint, restoreCheckpoint, getLatestCheckpoint, type RestoreMetadata } from "./storage";
+import {
+  createCheckpoint,
+  restoreCheckpoint,
+  getLatestCheckpoint,
+  type RestoreMetadata,
+} from "./storage";
 import { installAgentPlugins } from "./plugins";
 import {
   createManagedBrowserSession,
@@ -56,7 +82,18 @@ import {
   stopManagedBrowserSession,
   type ManagedBrowserSession,
 } from "./browser";
-import { BROWSER_LOGIN_MCP_SERVER_NAME, createBrowserLoginMcpServer } from "./browser-credentials";
+import {
+  BROWSER_LOGIN_MCP_SERVER_NAME,
+  createBrowserLoginMcpServer,
+} from "./browser-credentials";
+import {
+  bindProviderRuntimeToken as bindProviderRuntimeTokenRequest,
+  createProviderRuntimeToken,
+  isProviderRuntimeTokenEndpointMissing,
+  PROVIDER_RUNTIME_BINDING_HEADER,
+  revokeProviderRuntimeToken as revokeProviderRuntimeTokenRequest,
+  type ProviderRuntimeToken,
+} from "./provider-secrets";
 
 // Re-export types for external consumers
 export type {
@@ -77,6 +114,20 @@ export type {
 // =============================================================================
 
 const DROID_SESSION_STATE_PATH = "/home/user/.factory/evolve-session.json";
+const PROVIDER_RUNTIME_BINDING_ENV = "EVOLVE_PROVIDER_RUNTIME_BINDING";
+
+function providerRuntimeProviderForAgent(
+  agentType: AgentType,
+): ProviderRuntimeToken["provider"] | null {
+  switch (agentType) {
+    case "claude":
+      return "anthropic";
+    case "codex":
+      return "openai";
+    default:
+      return null;
+  }
+}
 
 /**
  * Escape prompt for bash double-quoted strings
@@ -112,16 +163,21 @@ function generateSessionTag(prefix: string): string {
  *
  * @param format - "newline" for Claude (ANTHROPIC_CUSTOM_HEADERS), "comma" for Gemini (GEMINI_CLI_CUSTOM_HEADERS)
  */
-function mergeCustomHeaders(existing: string | undefined, updates: Record<string, string>, format: "newline" | "comma" = "newline"): string {
+function mergeCustomHeaders(
+  existing: string | undefined,
+  updates: Record<string, string>,
+  format: "newline" | "comma" = "newline",
+): string {
   const merged = new Map<string, string>();
 
   // Parse existing headers (case-insensitive key lookup)
   if (existing) {
     // Newline format (Claude): "Name: Value\nName2: Value2"
     // Comma format (Gemini):   "Name: Value, Name2: Value2"
-    const entries = format === "comma"
-      ? existing.split(/,(?=\s*[^,:]+:)/)  // Gemini: split on commas before "key:" pattern
-      : existing.split(/\r?\n/);            // Claude: split on newlines
+    const entries =
+      format === "comma"
+        ? existing.split(/,(?=\s*[^,:]+:)/) // Gemini: split on commas before "key:" pattern
+        : existing.split(/\r?\n/); // Claude: split on newlines
     for (const entry of entries) {
       const trimmed = entry.trim();
       if (!trimmed) continue;
@@ -136,7 +192,11 @@ function mergeCustomHeaders(existing: string | undefined, updates: Record<string
   // Apply updates (overwrites matching keys, except tags which are appended in newline format)
   for (const [name, value] of Object.entries(updates)) {
     const key = name.toLowerCase();
-    if (key === LITELLM_TAGS_HEADER && merged.has(key) && format === "newline") {
+    if (
+      key === LITELLM_TAGS_HEADER &&
+      merged.has(key) &&
+      format === "newline"
+    ) {
       // Append to existing tags (comma-separated list) — safe in newline format only.
       // In comma format (Gemini), appending "run:<id>" after a comma creates ambiguity:
       // Gemini's regex /,(?=\s*[^,:]+:)/ would split "run:<id>" as a new header.
@@ -155,11 +215,21 @@ function mergeCustomHeaders(existing: string | undefined, updates: Record<string
 const KIMI_CODE_DEFAULT_CONTEXT_SIZE = 262144;
 // Kimi Code accepts these as provider-dependent config/env values; Moonshot's
 // public Kimi API documents thinking on/off/keep, not stable effort levels.
-const KIMI_CODE_THINKING_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max"]);
+const KIMI_CODE_THINKING_EFFORTS = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 
-function getKimiCodeThinkingEffort(reasoningEffort?: string): string | undefined {
+function getKimiCodeThinkingEffort(
+  reasoningEffort?: string,
+): string | undefined {
   if (!reasoningEffort) return undefined;
-  return KIMI_CODE_THINKING_EFFORTS.has(reasoningEffort) ? reasoningEffort : undefined;
+  return KIMI_CODE_THINKING_EFFORTS.has(reasoningEffort)
+    ? reasoningEffort
+    : undefined;
 }
 
 function withOpenAiV1Path(baseUrl: string): string {
@@ -200,6 +270,8 @@ export class Agent {
   private agentState: AgentRuntimeState = "idle";
   private droidSessionId?: string;
   private managedBrowserSession?: ManagedBrowserSession;
+  private providerRuntimeToken?: ProviderRuntimeToken;
+  private providerRuntimeRoutingUnavailable = false;
 
   // Skills storage
   private readonly skills?: SkillName[];
@@ -231,7 +303,9 @@ export class Agent {
       if (isZodSchema(options.schema)) {
         this.zodSchema = options.schema;
         if (options.schemaOptions) {
-          console.warn("[Evolve] schemaOptions ignored for Zod schemas - use .passthrough(), .strip(), z.coerce instead");
+          console.warn(
+            "[Evolve] schemaOptions ignored for Zod schemas - use .passthrough(), .strip(), z.coerce instead",
+          );
         }
       } else {
         // JSON Schema - validate at config time (fail fast)
@@ -265,12 +339,16 @@ export class Agent {
     };
   }
 
-  private browserResponseInfo(): Pick<BrowserRuntimeInfo, "liveUrl"> | undefined {
+  private browserResponseInfo():
+    Pick<BrowserRuntimeInfo, "liveUrl"> | undefined {
     if (!this.managedBrowserSession) return undefined;
     return { liveUrl: this.managedBrowserSession.liveUrl };
   }
 
-  private emitLifecycle(callbacks: StreamCallbacks | undefined, reason: LifecycleReason): void {
+  private emitLifecycle(
+    callbacks: StreamCallbacks | undefined,
+    reason: LifecycleReason,
+  ): void {
     const browser = this.browserRuntimeInfo();
     callbacks?.onLifecycle?.({
       sandboxId: this.getSession(),
@@ -293,7 +371,7 @@ export class Agent {
     kind: "run" | "command",
     handle: SandboxCommandHandle,
     callbacks: StreamCallbacks | undefined,
-    reason: LifecycleReason
+    reason: LifecycleReason,
   ): number {
     const opId = ++this.nextOperationId;
     this.activeOperationId = opId;
@@ -311,7 +389,7 @@ export class Agent {
     callbacks: StreamCallbacks | undefined,
     reason: LifecycleReason,
     nextAgentState: AgentRuntimeState = "idle",
-    nextSandboxState: SandboxLifecycleState = "ready"
+    nextSandboxState: SandboxLifecycleState = "ready",
   ): boolean {
     if (this.activeOperationId !== opId) {
       return false;
@@ -328,10 +406,12 @@ export class Agent {
     kind: "run" | "command",
     handle: SandboxCommandHandle,
     callbacks?: StreamCallbacks,
-    sandbox?: SandboxInstance
+    sandbox?: SandboxInstance,
   ): void {
     const completeReason: LifecycleReason =
-      kind === "run" ? "run_background_complete" : "command_background_complete";
+      kind === "run"
+        ? "run_background_complete"
+        : "command_background_complete";
     const failedReason: LifecycleReason =
       kind === "run" ? "run_background_failed" : "command_background_failed";
     const interruptedReason: LifecycleReason =
@@ -340,9 +420,15 @@ export class Agent {
     void handle
       .wait()
       .then(async (result) => {
-        const interrupted = this.interruptedOperations.delete(opId) || result.exitCode === 130;
+        const interrupted =
+          this.interruptedOperations.delete(opId) || result.exitCode === 130;
         if (interrupted) {
-          this.finalizeOperation(opId, callbacks, interruptedReason, "interrupted");
+          this.finalizeOperation(
+            opId,
+            callbacks,
+            interruptedReason,
+            "interrupted",
+          );
           return;
         }
         if (kind === "run" && sandbox) {
@@ -367,10 +453,18 @@ export class Agent {
     const opts = {
       ...preset,
       // Individual options override preset
-      ...(this.schemaOptions?.coerceTypes !== undefined && { coerceTypes: this.schemaOptions.coerceTypes }),
-      ...(this.schemaOptions?.removeAdditional !== undefined && { removeAdditional: this.schemaOptions.removeAdditional }),
-      ...(this.schemaOptions?.useDefaults !== undefined && { useDefaults: this.schemaOptions.useDefaults }),
-      ...(this.schemaOptions?.allErrors !== undefined && { allErrors: this.schemaOptions.allErrors }),
+      ...(this.schemaOptions?.coerceTypes !== undefined && {
+        coerceTypes: this.schemaOptions.coerceTypes,
+      }),
+      ...(this.schemaOptions?.removeAdditional !== undefined && {
+        removeAdditional: this.schemaOptions.removeAdditional,
+      }),
+      ...(this.schemaOptions?.useDefaults !== undefined && {
+        useDefaults: this.schemaOptions.useDefaults,
+      }),
+      ...(this.schemaOptions?.allErrors !== undefined && {
+        allErrors: this.schemaOptions.allErrors,
+      }),
     };
     // Disable strict mode - allows unknown formats (e.g., date-time from Pydantic schemas)
     // Ajv validates structure, Pydantic handles format validation for rich types
@@ -394,6 +488,7 @@ export class Agent {
     const provider = this.options.sandboxProvider;
     this.sandboxState = "booting";
     this.emitLifecycle(callbacks, "sandbox_boot");
+    let createdSandboxInThisCall = false;
     try {
       if (this.options.sandboxId) {
         // Connect to existing sandbox - skip setup
@@ -408,7 +503,7 @@ export class Agent {
           this.options.browserCredentials
         ) {
           console.warn(
-            "[Evolve] Connecting to existing sandbox - ignoring mcpServers, integrations, plugins, context, files, systemPrompt, managed browser setup, and browser credentials"
+            "[Evolve] Connecting to existing sandbox - ignoring mcpServers, integrations, plugins, context, files, systemPrompt, managed browser setup, and browser credentials",
           );
         }
         this.sandbox = await provider.connect(this.options.sandboxId);
@@ -421,12 +516,15 @@ export class Agent {
       } else {
         // Create new sandbox with full initialization
         await this.ensureManagedBrowserSession(callbacks);
+        await this.ensureProviderRuntimeToken();
         const envVars = this.buildEnvironmentVariables();
 
         this.sandbox = await provider.create({
           envs: envVars,
           workingDirectory: this.workingDir,
         });
+        createdSandboxInThisCall = true;
+        await this.bindProviderRuntimeToken(this.sandbox.sandboxId);
 
         await this.setupManagedBrowser(this.sandbox);
 
@@ -443,7 +541,12 @@ export class Agent {
         this.emitLifecycle(callbacks, "sandbox_ready");
       }
     } catch (error) {
+      if (createdSandboxInThisCall && this.sandbox) {
+        await this.sandbox.kill().catch(() => {});
+        this.sandbox = undefined;
+      }
       await this.closeManagedBrowserSession().catch(() => {});
+      await this.closeProviderRuntimeToken().catch(() => {});
       this.sandboxState = "error";
       this.agentState = "error";
       this.emitLifecycle(callbacks, "sandbox_error");
@@ -458,14 +561,24 @@ export class Agent {
    */
   private buildEnvironmentVariables(): Record<string, string> {
     const envVars: Record<string, string> = {};
+    const userSecrets = this.validatedUserSecretsForEnvironment();
 
     if (this.agentConfig.type === "kimi" && this.agentConfig.isDirectMode) {
-      const thinkingEnabled = isThinkingEnabled(this.agentConfig.reasoningEffort);
-      const thinkingEffort = getKimiCodeThinkingEffort(this.agentConfig.reasoningEffort);
-      envVars.KIMI_MODEL_NAME = this.resolveCommandModel(this.agentConfig.model || this.registry.defaultModel);
+      const thinkingEnabled = isThinkingEnabled(
+        this.agentConfig.reasoningEffort,
+      );
+      const thinkingEffort = getKimiCodeThinkingEffort(
+        this.agentConfig.reasoningEffort,
+      );
+      envVars.KIMI_MODEL_NAME = this.resolveCommandModel(
+        this.agentConfig.model || this.registry.defaultModel,
+      );
       envVars.KIMI_MODEL_API_KEY = this.agentConfig.apiKey;
       envVars.KIMI_MODEL_PROVIDER_TYPE = "kimi";
-      envVars.KIMI_MODEL_MAX_CONTEXT_SIZE = String(this.registry.spendTrackingTomlProvider?.maxContextSize ?? KIMI_CODE_DEFAULT_CONTEXT_SIZE);
+      envVars.KIMI_MODEL_MAX_CONTEXT_SIZE = String(
+        this.registry.spendTrackingTomlProvider?.maxContextSize ??
+          KIMI_CODE_DEFAULT_CONTEXT_SIZE,
+      );
       envVars.KIMI_MODEL_DEFAULT_THINKING = thinkingEnabled ? "true" : "false";
       envVars.KIMI_MODEL_THINKING_MODE = thinkingEnabled ? "on" : "off";
       if (thinkingEffort) {
@@ -478,12 +591,19 @@ export class Agent {
       // File-based OAuth (Codex, Gemini): auth file handles auth, no API key env var needed
       // Some agents need an activation env var (e.g., Gemini needs GOOGLE_GENAI_USE_GCA=true)
       if (this.registry.oauthActivationEnv) {
-        envVars[this.registry.oauthActivationEnv.key] = this.registry.oauthActivationEnv.value;
+        envVars[this.registry.oauthActivationEnv.key] =
+          this.registry.oauthActivationEnv.value;
       }
-    } else if (this.agentConfig.type === "kimi" && !this.agentConfig.isDirectMode) {
+    } else if (
+      this.agentConfig.type === "kimi" &&
+      !this.agentConfig.isDirectMode
+    ) {
       // Kimi Code gateway auth is written to ~/.kimi-code/config.toml per run.
       // The old KIMI_API_KEY/KIMI_BASE_URL envs are not read by Kimi Code.
-    } else if (this.registry.skipApiKeyEnvInGateway && !this.agentConfig.isDirectMode) {
+    } else if (
+      this.registry.skipApiKeyEnvInGateway &&
+      !this.agentConfig.isDirectMode
+    ) {
       // Gateway mode for generated-settings agents (Droid): EVOLVE_API_KEY is
       // injected below and referenced from the settings file, not provider env.
     } else if (this.registry.providerEnvMap && !this.agentConfig.isDirectMode) {
@@ -495,16 +615,25 @@ export class Agent {
     } else {
       // Single-provider: resolve model-specific key env for multi-provider CLIs in direct mode
       const providerPrefix = this.agentConfig.model?.split("/")[0];
-      const providerMapping = providerPrefix ? this.registry.providerEnvMap?.[providerPrefix] : undefined;
-      const effectiveKeyEnv = providerMapping ? providerMapping.keyEnv : this.registry.apiKeyEnv;
+      const providerMapping = providerPrefix
+        ? this.registry.providerEnvMap?.[providerPrefix]
+        : undefined;
+      const effectiveKeyEnv = providerMapping
+        ? providerMapping.keyEnv
+        : this.registry.apiKeyEnv;
       // OAuth mode uses oauthEnv (e.g., CLAUDE_CODE_OAUTH_TOKEN), else apiKeyEnv
-      const keyEnv = this.agentConfig.isOAuth && this.registry.oauthEnv
-        ? this.registry.oauthEnv
-        : effectiveKeyEnv;
+      const keyEnv =
+        this.agentConfig.isOAuth && this.registry.oauthEnv
+          ? this.registry.oauthEnv
+          : effectiveKeyEnv;
       envVars[keyEnv] = this.agentConfig.apiKey;
     }
 
-    if (this.agentConfig.isDirectMode && !this.agentConfig.isOAuth && this.agentConfig.type !== "kimi") {
+    if (
+      this.agentConfig.isDirectMode &&
+      !this.agentConfig.isOAuth &&
+      this.agentConfig.type !== "kimi"
+    ) {
       // Direct mode (non-OAuth): use resolved baseUrl if set (e.g., Qwen needs Dashscope endpoint)
       if (this.agentConfig.baseUrl && this.registry.baseUrlEnv) {
         envVars[this.registry.baseUrlEnv] = this.agentConfig.baseUrl;
@@ -512,6 +641,8 @@ export class Agent {
     } else if (!this.agentConfig.isDirectMode) {
       // Gateway mode: route through Evolve gateway
       const gatewayUrl = getGatewayUrl(this.registry.gatewayPath);
+      const providerRuntime =
+        this.activeProviderRuntimeToken();
 
       if (this.registry.gatewayConfigEnv) {
         // Session-level: only customer-id header. Per-run tag added in buildRunEnvs().
@@ -521,27 +652,39 @@ export class Agent {
       } else {
         // Single-provider: set base URL env var
         if (this.registry.baseUrlEnv && this.agentConfig.type !== "kimi") {
-          envVars[this.registry.baseUrlEnv] = gatewayUrl;
+          envVars[this.registry.baseUrlEnv] =
+            providerRuntime?.baseUrl ?? gatewayUrl;
         }
       }
 
-      // Expose EVOLVE_API_KEY in sandbox for gateway services (e.g., browser-use)
-      envVars['EVOLVE_API_KEY'] = this.agentConfig.apiKey;
+      if (providerRuntime) {
+        envVars[this.registry.apiKeyEnv] = providerRuntime.token;
+        if (this.registry.spendTrackingEnvs) {
+          envVars[PROVIDER_RUNTIME_BINDING_ENV] =
+            providerRuntime.bindingSecret;
+        }
+      }
+
+      // BYOK provider routing uses a run-scoped proxy token instead of exposing
+      // the account gateway key to the sandbox.
+      if (!providerRuntime) {
+        envVars[ENV_EVOLVE_API_KEY] = this.agentConfig.apiKey;
+      }
     }
     // OAuth direct mode: no baseUrl needed (Claude Code CLI handles it)
 
     if (this.managedBrowserSession && this.options.managedBrowser) {
       Object.assign(
         envVars,
-        getManagedBrowserSandboxSetup(this.options.managedBrowser.provider, this.managedBrowserSession).envs
+        getManagedBrowserSandboxSetup(
+          this.options.managedBrowser.provider,
+          this.managedBrowserSession,
+        ).envs,
       );
     }
 
-    if (this.options.secrets) {
-      if (Object.prototype.hasOwnProperty.call(this.options.secrets, ENV_EVOLVE_API_KEY)) {
-        throw new Error(`${ENV_EVOLVE_API_KEY} is reserved for Evolve-managed sandbox services and cannot be set with secrets`);
-      }
-      Object.assign(envVars, this.options.secrets);
+    if (userSecrets) {
+      Object.assign(envVars, userSecrets);
     }
 
     // Spend tracking: merge session-level LiteLLM header (gateway mode only).
@@ -549,9 +692,14 @@ export class Agent {
     if (!this.agentConfig.isDirectMode && this.registry.customHeadersEnv) {
       const headerEnv = this.registry.customHeadersEnv;
       const fmt = this.registry.customHeadersFormat || "newline";
-      envVars[headerEnv] = mergeCustomHeaders(envVars[headerEnv], {
-        [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
-      }, fmt);
+      envVars[headerEnv] = mergeCustomHeaders(
+        envVars[headerEnv],
+        {
+          [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
+          ...this.providerRuntimeHeaderUpdates(),
+        },
+        fmt,
+      );
     }
 
     // Spend tracking via per-env-var headers (e.g., Codex env_http_headers in TOML).
@@ -563,18 +711,105 @@ export class Agent {
     return envVars;
   }
 
-  private async ensureManagedBrowserSession(callbacks?: StreamCallbacks): Promise<void> {
+  private validatedUserSecretsForEnvironment():
+    Record<string, string> | undefined {
+    if (!this.options.secrets) return undefined;
+
+    const reserved = new Set<string>([ENV_EVOLVE_API_KEY]);
+    const add = (value?: string) => {
+      if (value) reserved.add(value);
+    };
+
+    add(this.registry.apiKeyEnv);
+    add(this.registry.baseUrlEnv);
+    for (const mapping of Object.values(this.registry.providerEnvMap ?? {})) {
+      add(mapping.keyEnv);
+    }
+
+    const safeSecrets: Record<string, string> = {};
+    for (const [key, value] of Object.entries(this.options.secrets)) {
+      if (reserved.has(key)) {
+        throw new Error(
+          `${key} is reserved for Evolve-managed sandbox services and cannot be set with secrets`,
+        );
+      }
+      if (key === this.registry.gatewayConfigEnv) {
+        continue;
+      }
+      safeSecrets[key] = value;
+    }
+    return safeSecrets;
+  }
+
+  private async ensureManagedBrowserSession(
+    callbacks?: StreamCallbacks,
+  ): Promise<void> {
     if (this.managedBrowserSession || !this.options.managedBrowser) return;
-    this.managedBrowserSession = await createManagedBrowserSession(this.options.managedBrowser, this.sessionTag, {
-      browserCredentials: this.options.browserCredentials !== undefined,
-    });
+    this.managedBrowserSession = await createManagedBrowserSession(
+      this.options.managedBrowser,
+      this.sessionTag,
+      {
+        browserCredentials: this.options.browserCredentials !== undefined,
+      },
+    );
     this.emitLifecycle(callbacks, "browser_ready");
+  }
+
+  private async ensureProviderRuntimeToken(): Promise<void> {
+    const provider = providerRuntimeProviderForAgent(this.agentConfig.type);
+    if (this.agentConfig.isDirectMode || !provider) return;
+    if (!this.options.providerRouting) return;
+    if (this.providerRuntimeRoutingUnavailable && !this.providerRuntimeToken) {
+      return;
+    }
+
+    if (this.providerRuntimeToken) return;
+
+    let token: ProviderRuntimeToken | null;
+    try {
+      token = await createProviderRuntimeToken(this.options.providerRouting, {
+        provider,
+        sessionTag: this.sessionTag,
+      });
+    } catch (error) {
+      if (isProviderRuntimeTokenEndpointMissing(error)) {
+        this.providerRuntimeRoutingUnavailable = true;
+        console.warn(
+          `[Evolve] ${provider} BYOK provider routing endpoint is not available; falling back to Evolve gateway key: ${(error as Error).message}`,
+        );
+        return;
+      }
+      throw error;
+    }
+
+    this.providerRuntimeRoutingUnavailable = token === null;
+    this.providerRuntimeToken = token ?? undefined;
+    if (this.providerRuntimeToken && this.sandbox?.sandboxId) {
+      await this.bindProviderRuntimeToken(this.sandbox.sandboxId);
+    }
+  }
+
+  private async bindProviderRuntimeToken(sandboxId: string): Promise<void> {
+    if (!this.providerRuntimeToken || !this.options.providerRouting) return;
+    const ok = await bindProviderRuntimeTokenRequest(
+      this.options.providerRouting,
+      {
+        token: this.providerRuntimeToken.token,
+        sandboxId,
+      },
+    );
+    if (!ok) {
+      throw new Error("Failed to bind provider runtime token to sandbox");
+    }
   }
 
   private async setupManagedBrowser(sandbox: SandboxInstance): Promise<void> {
     if (!this.managedBrowserSession || !this.options.managedBrowser) return;
 
-    const setup = getManagedBrowserSandboxSetup(this.options.managedBrowser.provider, this.managedBrowserSession);
+    const setup = getManagedBrowserSandboxSetup(
+      this.options.managedBrowser.provider,
+      this.managedBrowserSession,
+    );
     for (const dir of setup.directories) {
       await sandbox.files.makeDir(dir);
     }
@@ -590,7 +825,24 @@ export class Agent {
     try {
       await stopManagedBrowserSession(this.options.managedBrowser, session);
     } catch (error) {
-      console.warn(`[Evolve] Managed browser cleanup failed: ${(error as Error).message}`);
+      console.warn(
+        `[Evolve] Managed browser cleanup failed: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  private async closeProviderRuntimeToken(): Promise<void> {
+    if (!this.providerRuntimeToken || !this.options.providerRouting) return;
+    const token = this.providerRuntimeToken;
+    this.providerRuntimeToken = undefined;
+    try {
+      await revokeProviderRuntimeTokenRequest(this.options.providerRouting, {
+        token: token.token,
+      });
+    } catch (error) {
+      console.warn(
+        `[Evolve] Provider runtime token cleanup failed: ${(error as Error).message}`,
+      );
     }
   }
 
@@ -607,27 +859,37 @@ export class Agent {
    */
   private buildGatewayConfigJson(headers: Record<string, string>): string {
     const gatewayUrl = getGatewayUrl(this.registry.gatewayPath);
-    const selectedModel = this.resolveCommandModel(this.agentConfig.model || this.registry.defaultModel);
+    const selectedModel = this.resolveCommandModel(
+      this.agentConfig.model || this.registry.defaultModel,
+    );
 
     // Start from user-provided config if available, preserving non-litellm settings
     let config: Record<string, unknown> = {};
     const userValue = this.options.secrets?.[this.registry.gatewayConfigEnv!];
     if (userValue) {
-      try { config = JSON.parse(userValue); } catch { /* invalid JSON — start fresh */ }
+      try {
+        config = JSON.parse(userValue);
+      } catch {
+        /* invalid JSON — start fresh */
+      }
     }
 
     const providers = (config.provider as Record<string, unknown>) ?? {};
     const litellm = (providers.litellm as Record<string, unknown>) ?? {};
     const existingOptions = (litellm.options as Record<string, unknown>) ?? {};
     const existingModels = (litellm.models as Record<string, unknown>) ?? {};
-    const existingModel = (existingModels[selectedModel] as Record<string, unknown>) ?? {};
-    const existingHeaders = (existingModel.headers as Record<string, string>) ?? {};
-    const reasoningVariant = this.agentConfig.type === "opencode"
-      ? getOpenCodeReasoningVariant(this.agentConfig.reasoningEffort)
-      : undefined;
-    const existingVariants = (existingModel.variants as Record<string, unknown>) ?? {};
+    const existingModel =
+      (existingModels[selectedModel] as Record<string, unknown>) ?? {};
+    const existingHeaders =
+      (existingModel.headers as Record<string, string>) ?? {};
+    const reasoningVariant =
+      this.agentConfig.type === "opencode"
+        ? getOpenCodeReasoningVariant(this.agentConfig.reasoningEffort)
+        : undefined;
+    const existingVariants =
+      (existingModel.variants as Record<string, unknown>) ?? {};
     const selectedVariant = reasoningVariant
-      ? (existingVariants[reasoningVariant] as Record<string, unknown>) ?? {}
+      ? ((existingVariants[reasoningVariant] as Record<string, unknown>) ?? {})
       : undefined;
 
     config.provider = {
@@ -646,21 +908,96 @@ export class Agent {
             ...existingModel,
             name: selectedModel,
             headers: { ...existingHeaders, ...headers },
-            ...(reasoningVariant ? {
-              variants: {
-                ...existingVariants,
-                [reasoningVariant]: {
-                  ...selectedVariant,
-                  reasoningEffort: reasoningVariant,
-                },
-              },
-            } : {}),
+            ...(reasoningVariant
+              ? {
+                  variants: {
+                    ...existingVariants,
+                    [reasoningVariant]: {
+                      ...selectedVariant,
+                      reasoningEffort: reasoningVariant,
+                    },
+                  },
+                }
+              : {}),
           },
         },
       },
     };
 
     return JSON.stringify(config);
+  }
+
+  private activeProviderRuntimeToken(): ProviderRuntimeToken | undefined {
+    const provider = providerRuntimeProviderForAgent(this.agentConfig.type);
+    return provider && this.providerRuntimeToken?.provider === provider
+      ? this.providerRuntimeToken
+      : undefined;
+  }
+
+  private ensureSessionLogger(sandbox: SandboxInstance): void {
+    if (this.sessionLogger) return;
+    const provider = this.options.sandboxProvider;
+    this.sessionLogger = new SessionLogger({
+      provider: provider?.name || provider?.providerType || "unknown",
+      agent: this.agentConfig.type,
+      model: this.agentConfig.model || this.registry.defaultModel,
+      sandboxId: sandbox.sandboxId,
+      tag: this.sessionTag,
+      apiKey: this.agentConfig.isDirectMode
+        ? undefined
+        : this.agentConfig.apiKey,
+      observability: {
+        ...this.options.observability,
+        ...(this.managedBrowserSession && this.options.managedBrowser
+          ? {
+              browser_provider: this.options.managedBrowser.provider,
+              browser_session_id: this.managedBrowserSession.id,
+              dashboard_session_id: this.managedBrowserSession.sessionId,
+              browser_session_tag: this.managedBrowserSession.sessionTag,
+              browser_live_url: this.managedBrowserSession.liveUrl,
+            }
+          : {}),
+      },
+    });
+  }
+
+  private async flushSessionLoggerWithTimeout(timeoutMs = 2000): Promise<void> {
+    if (!this.sessionLogger) return;
+    await Promise.race([
+      this.sessionLogger.flush(),
+      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+    ]);
+  }
+
+  private providerRuntimeHeaderUpdates(): Record<string, string> {
+    const providerRuntime = this.activeProviderRuntimeToken();
+    return providerRuntime
+      ? { [PROVIDER_RUNTIME_BINDING_HEADER]: providerRuntime.bindingSecret }
+      : {};
+  }
+
+  private buildProviderRuntimeProcessEnvs(): Record<string, string> {
+    const providerRuntime = this.activeProviderRuntimeToken();
+    if (!providerRuntime) return {};
+    const envs: Record<string, string> = {
+      [this.registry.apiKeyEnv]: providerRuntime.token,
+    };
+    if (this.registry.baseUrlEnv) {
+      envs[this.registry.baseUrlEnv] = providerRuntime.baseUrl;
+    }
+    if (this.registry.spendTrackingEnvs) {
+      envs[PROVIDER_RUNTIME_BINDING_ENV] = providerRuntime.bindingSecret;
+    }
+    if (this.registry.customHeadersEnv) {
+      const headerEnv = this.registry.customHeadersEnv;
+      const fmt = this.registry.customHeadersFormat || "newline";
+      envs[headerEnv] = mergeCustomHeaders(
+        this.options.secrets?.[headerEnv],
+        this.providerRuntimeHeaderUpdates(),
+        fmt,
+      );
+    }
+    return envs;
   }
 
   /**
@@ -671,24 +1008,30 @@ export class Agent {
    */
   private buildRunEnvs(runId: string): Record<string, string> | undefined {
     if (this.agentConfig.isDirectMode) return undefined;
+    const envs = this.buildProviderRuntimeProcessEnvs();
 
     // Path 1: single custom headers env var (Claude, Gemini)
     const headerEnv = this.registry.customHeadersEnv;
     if (headerEnv) {
       const base = this.options.secrets?.[headerEnv];
       const fmt = this.registry.customHeadersFormat || "newline";
-      return {
-        [headerEnv]: mergeCustomHeaders(base, {
+      envs[headerEnv] = mergeCustomHeaders(
+        base,
+        {
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
           [LITELLM_TAGS_HEADER]: `${RUN_TAG_PREFIX}${runId}`,
-        }, fmt),
-      };
+          ...this.providerRuntimeHeaderUpdates(),
+        },
+        fmt,
+      );
+      return envs;
     }
 
     // Path 2: per-env-var headers (Codex TOML env_http_headers)
     const trackingEnvs = this.registry.spendTrackingEnvs;
     if (trackingEnvs) {
       return {
+        ...envs,
         [trackingEnvs.sessionTagEnv]: this.sessionTag,
         [trackingEnvs.runTagEnv]: `${RUN_TAG_PREFIX}${runId}`,
       };
@@ -698,6 +1041,7 @@ export class Agent {
     // Per-run override with both session + run headers.
     if (this.registry.gatewayConfigEnv) {
       return {
+        ...envs,
         [this.registry.gatewayConfigEnv]: this.buildGatewayConfigJson({
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
           [LITELLM_TAGS_HEADER]: `${RUN_TAG_PREFIX}${runId}`,
@@ -705,15 +1049,19 @@ export class Agent {
       };
     }
 
-    return undefined;
+    return Object.keys(envs).length > 0 ? envs : undefined;
   }
 
-  private captureDroidSession(rawLine: string, events: OutputEvent[] | null): void {
+  private captureDroidSession(
+    rawLine: string,
+    events: OutputEvent[] | null,
+  ): void {
     if (this.agentConfig.type !== "droid") return;
 
-    const eventSessionId = events?.find((event) => (
-      typeof event.sessionId === "string" && event.sessionId.length > 0
-    ))?.sessionId;
+    const eventSessionId = events?.find(
+      (event) =>
+        typeof event.sessionId === "string" && event.sessionId.length > 0,
+    )?.sessionId;
     if (eventSessionId) {
       this.droidSessionId = eventSessionId;
       return;
@@ -734,14 +1082,17 @@ export class Agent {
   }
 
   private findDroidSessionId(value: unknown): string | undefined {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      return undefined;
     const record = value as Record<string, unknown>;
     const direct = record.sessionId ?? record.session_id;
     if (typeof direct === "string" && direct.length > 0) return direct;
 
-    return this.findDroidSessionId(record.result) ??
+    return (
+      this.findDroidSessionId(record.result) ??
       this.findDroidSessionId(record.params) ??
-      this.findDroidSessionId(record.notification);
+      this.findDroidSessionId(record.notification)
+    );
   }
 
   private async loadDroidSessionState(sandbox: SandboxInstance): Promise<void> {
@@ -758,12 +1109,14 @@ export class Agent {
     }
   }
 
-  private async writeDroidSessionState(sandbox: SandboxInstance): Promise<void> {
+  private async writeDroidSessionState(
+    sandbox: SandboxInstance,
+  ): Promise<void> {
     if (this.agentConfig.type !== "droid" || !this.droidSessionId) return;
     await sandbox.files.makeDir("/home/user/.factory");
     await sandbox.files.write(
       DROID_SESSION_STATE_PATH,
-      JSON.stringify({ sessionId: this.droidSessionId }, null, 2)
+      JSON.stringify({ sessionId: this.droidSessionId }, null, 2),
     );
   }
 
@@ -785,19 +1138,47 @@ export class Agent {
   private async setupAgentAuth(sandbox: SandboxInstance): Promise<void> {
     // File-based OAuth: write auth file directly
     if (this.agentConfig.oauthFileContent && this.registry.oauthFileName) {
-      const settingsDir = this.registry.mcpConfig.settingsDir.replace(/^~/, "/home/user");
+      const settingsDir = this.registry.mcpConfig.settingsDir.replace(
+        /^~/,
+        "/home/user",
+      );
       await sandbox.files.makeDir(settingsDir);
-      await sandbox.files.write(`${settingsDir}/${this.registry.oauthFileName}`, this.agentConfig.oauthFileContent);
+      await sandbox.files.write(
+        `${settingsDir}/${this.registry.oauthFileName}`,
+        this.agentConfig.oauthFileContent,
+      );
       return;
     }
     // Default: run setup command (e.g., "codex login --with-api-key")
     if (this.registry.setupCommand) {
-      await sandbox.commands.run(this.registry.setupCommand, { timeoutMs: 30000 });
+      await sandbox.commands.run(this.registry.setupCommand, {
+        timeoutMs: 30000,
+      });
     }
   }
 
   private async setupAgentPlugins(sandbox: SandboxInstance): Promise<void> {
-    await installAgentPlugins(this.agentConfig.type, sandbox, this.options.plugins);
+    await installAgentPlugins(
+      this.agentConfig.type,
+      sandbox,
+      this.options.plugins,
+    );
+  }
+
+  private assertProviderRuntimeDoesNotExposeGatewayKey(
+    mcpServers: Record<string, McpServerConfig>,
+  ): void {
+    if (!this.activeProviderRuntimeToken()) return;
+    const gatewayKey = this.agentConfig.apiKey;
+    for (const [name, config] of Object.entries(mcpServers)) {
+      for (const value of Object.values(config.headers || {})) {
+        if (value.includes(gatewayKey)) {
+          throw new Error(
+            `MCP server "${name}" would expose the Evolve API key inside a provider BYOK sandbox. Use managed agent-browser or remove this gateway-authenticated MCP server.`,
+          );
+        }
+      }
+    }
   }
 
   /**
@@ -808,14 +1189,15 @@ export class Agent {
    */
   private async setupWorkspace(
     sandbox: SandboxInstance,
-    opts?: { skipSystemPrompt?: boolean }
+    opts?: { skipSystemPrompt?: boolean },
   ): Promise<void> {
     const workspaceMode = this.options.workspaceMode || "knowledge";
 
     // Create workspace folders (swe mode includes repo/)
-    const folders = workspaceMode === "swe"
-      ? `${this.workingDir}/repo ${this.workingDir}/context ${this.workingDir}/scripts ${this.workingDir}/temp ${this.workingDir}/output`
-      : `${this.workingDir}/context ${this.workingDir}/scripts ${this.workingDir}/temp ${this.workingDir}/output`;
+    const folders =
+      workspaceMode === "swe"
+        ? `${this.workingDir}/repo ${this.workingDir}/context ${this.workingDir}/scripts ${this.workingDir}/temp ${this.workingDir}/output`
+        : `${this.workingDir}/context ${this.workingDir}/scripts ${this.workingDir}/temp ${this.workingDir}/output`;
 
     await sandbox.commands.run(`mkdir -p ${folders}`, { timeoutMs: 30000 });
 
@@ -864,11 +1246,22 @@ export class Agent {
     }
 
     if (this.options.browserCredentials) {
-      if (!this.options.managedBrowser || this.options.managedBrowser.provider !== "agent-browser") {
-        throw new Error("Browser credentials require managed remote agent-browser.");
+      if (
+        !this.options.managedBrowser ||
+        this.options.managedBrowser.provider !== "agent-browser"
+      ) {
+        throw new Error(
+          "Browser credentials require managed remote agent-browser.",
+        );
       }
-      if (!this.managedBrowserSession?.id || !this.managedBrowserSession.sessionTag || !this.managedBrowserSession.browserAuthGrantToken) {
-        throw new Error("Managed browser session is missing browser credential grant data.");
+      if (
+        !this.managedBrowserSession?.id ||
+        !this.managedBrowserSession.sessionTag ||
+        !this.managedBrowserSession.browserAuthGrantToken
+      ) {
+        throw new Error(
+          "Managed browser session is missing browser credential grant data.",
+        );
       }
       const browserLoginMcp = await createBrowserLoginMcpServer({
         apiKey: this.options.browserCredentials.apiKey,
@@ -890,28 +1283,41 @@ export class Agent {
     // current Evolve instance generates — stale tokens from the checkpoint won't
     // work. Gateway mode and managed integrations both produce session-scoped URLs.
     if (Object.keys(mcpServers).length > 0) {
+      this.assertProviderRuntimeDoesNotExposeGatewayKey(mcpServers);
       await writeMcpConfig(
         this.agentConfig.type,
         sandbox,
         this.workingDir,
-        mcpServers
+        mcpServers,
       );
     }
 
     // Spend tracking: write model provider config for agents using env_http_headers
     // (e.g., Codex). Must run after MCP config so we append to existing config.toml.
-    if (!this.agentConfig.isDirectMode && this.registry.spendTrackingEnvs && this.agentConfig.type === "codex") {
+    if (
+      !this.agentConfig.isDirectMode &&
+      this.registry.spendTrackingEnvs &&
+      this.agentConfig.type === "codex"
+    ) {
       await writeCodexSpendProvider(
         sandbox,
-        this.agentConfig.baseUrl || getGatewayUrl(),
+        this.activeProviderRuntimeToken()?.baseUrl ||
+          this.agentConfig.baseUrl ||
+          getGatewayUrl(),
         this.registry.spendTrackingEnvs,
+        this.activeProviderRuntimeToken()
+          ? { [PROVIDER_RUNTIME_BINDING_HEADER]: PROVIDER_RUNTIME_BINDING_ENV }
+          : undefined,
       );
     }
 
     // Spend tracking: write customHeaders to JSON settings file for agents that read
     // headers from config (e.g., Qwen). Session-level only — per-run tags are written
     // before each spawn in run().
-    if (!this.agentConfig.isDirectMode && this.registry.spendTrackingJsonConfig) {
+    if (
+      !this.agentConfig.isDirectMode &&
+      this.registry.spendTrackingJsonConfig
+    ) {
       await writeJsonSpendHeaders(
         sandbox,
         this.agentConfig.type as "qwen",
@@ -955,7 +1361,7 @@ export class Agent {
    */
   private async uploadContextFiles(
     sandbox: SandboxInstance,
-    files: FileMap
+    files: FileMap,
   ): Promise<void> {
     const entries = Object.entries(files).map(([name, content]) => ({
       path: `${this.workingDir}/context/${name}`,
@@ -966,7 +1372,9 @@ export class Agent {
 
     // Create parent directories
     const dirs = new Set(
-      entries.map((e) => e.path.substring(0, e.path.lastIndexOf("/"))).filter(Boolean)
+      entries
+        .map((e) => e.path.substring(0, e.path.lastIndexOf("/")))
+        .filter(Boolean),
     );
     if (dirs.size > 0) {
       await sandbox.commands.run(`mkdir -p ${Array.from(dirs).join(" ")}`, {
@@ -982,7 +1390,7 @@ export class Agent {
    */
   private async uploadWorkspaceFiles(
     sandbox: SandboxInstance,
-    files: FileMap
+    files: FileMap,
   ): Promise<void> {
     const entries = Object.entries(files).map(([path, content]) => ({
       // Support absolute paths (use as-is) and relative paths (prefix with workingDir)
@@ -994,7 +1402,9 @@ export class Agent {
 
     // Create parent directories
     const dirs = new Set(
-      entries.map((e) => e.path.substring(0, e.path.lastIndexOf("/"))).filter(Boolean)
+      entries
+        .map((e) => e.path.substring(0, e.path.lastIndexOf("/")))
+        .filter(Boolean),
     );
     if (dirs.size > 0) {
       await sandbox.commands.run(`mkdir -p ${Array.from(dirs).join(" ")}`, {
@@ -1015,9 +1425,12 @@ export class Agent {
   private buildCommand(prompt: string): string {
     return this.registry.buildCommand({
       prompt: this.agentConfig.type === "droid" ? prompt : escapePrompt(prompt),
-      model: this.resolveCommandModel(this.agentConfig.model || this.registry.defaultModel),
+      model: this.resolveCommandModel(
+        this.agentConfig.model || this.registry.defaultModel,
+      ),
       isResume: this.hasRun,
-      sessionId: this.agentConfig.type === "droid" ? this.droidSessionId : undefined,
+      sessionId:
+        this.agentConfig.type === "droid" ? this.droidSessionId : undefined,
       reasoningEffort: this.agentConfig.reasoningEffort,
       isDirectMode: this.agentConfig.isDirectMode,
       skills: this.skills,
@@ -1035,13 +1448,18 @@ export class Agent {
    */
   async run(
     options: RunOptions,
-    callbacks?: StreamCallbacks
+    callbacks?: StreamCallbacks,
   ): Promise<AgentResponse> {
-    const { prompt, timeoutMs = DEFAULT_TIMEOUT_MS, background = false, checkpointComment } = options;
+    const {
+      prompt,
+      timeoutMs = DEFAULT_TIMEOUT_MS,
+      background = false,
+      checkpointComment,
+    } = options;
     let { from } = options;
     if (this.activeCommand) {
       throw new Error(
-        "Agent is already running. Call interrupt(), wait for the active/background run to finish, or create a new Evolve instance."
+        "Agent is already running. Call interrupt(), wait for the active/background run to finish, or create a new Evolve instance.",
       );
     }
 
@@ -1051,7 +1469,7 @@ export class Agent {
     if (from) {
       if (this.sandbox || this.options.sandboxId) {
         throw new Error(
-          "Cannot restore into existing sandbox. Call kill() first, or create a new Evolve instance."
+          "Cannot restore into existing sandbox. Call kill() first, or create a new Evolve instance.",
         );
       }
     }
@@ -1061,11 +1479,13 @@ export class Agent {
     // =========================================================================
     if (from === "latest") {
       if (!this.storage) {
-        throw new Error("Storage not configured. Call .withStorage() before using from: \"latest\".");
+        throw new Error(
+          'Storage not configured. Call .withStorage() before using from: "latest".',
+        );
       }
       const latest = await getLatestCheckpoint(this.storage);
       if (!latest) {
-        throw new Error("No checkpoints found for from: \"latest\".");
+        throw new Error('No checkpoints found for from: "latest".');
       }
       from = latest.id;
     }
@@ -1075,7 +1495,9 @@ export class Agent {
     // =========================================================================
     if (from) {
       if (!this.storage) {
-        throw new Error("Storage not configured. Call .withStorage() before using 'from'.");
+        throw new Error(
+          "Storage not configured. Call .withStorage() before using 'from'.",
+        );
       }
       if (!this.options.sandboxProvider) {
         throw new Error("No sandbox provider configured");
@@ -1083,6 +1505,7 @@ export class Agent {
 
       // Create fresh sandbox
       await this.ensureManagedBrowserSession(callbacks);
+      await this.ensureProviderRuntimeToken();
       const envVars = this.buildEnvironmentVariables();
       this.sandboxState = "booting";
       this.emitLifecycle(callbacks, "sandbox_boot");
@@ -1091,17 +1514,25 @@ export class Agent {
           envs: envVars,
           workingDirectory: this.workingDir,
         });
+        await this.bindProviderRuntimeToken(this.sandbox.sandboxId);
 
         // Restore checkpoint archive into sandbox (returns metadata for validation)
-        const ckptMeta = await restoreCheckpoint(this.sandbox, this.storage, from);
+        const ckptMeta = await restoreCheckpoint(
+          this.sandbox,
+          this.storage,
+          from,
+        );
 
         await this.setupManagedBrowser(this.sandbox);
 
         // Validate agent type — changing agent type on restore is structural (wrong
         // dirs, wrong CLI, wrong config format). Model changes are fine.
-        if (ckptMeta.agentType && ckptMeta.agentType !== this.agentConfig.type) {
+        if (
+          ckptMeta.agentType &&
+          ckptMeta.agentType !== this.agentConfig.type
+        ) {
           throw new Error(
-            `Cannot restore checkpoint: agent type mismatch (checkpoint: ${ckptMeta.agentType}, current: ${this.agentConfig.type})`
+            `Cannot restore checkpoint: agent type mismatch (checkpoint: ${ckptMeta.agentType}, current: ${this.agentConfig.type})`,
           );
         }
 
@@ -1111,7 +1542,7 @@ export class Agent {
         const currentMode = this.options.workspaceMode || "knowledge";
         if (ckptMeta.workspaceMode && ckptMeta.workspaceMode !== currentMode) {
           throw new Error(
-            `Cannot restore checkpoint: workspace mode mismatch (checkpoint: ${ckptMeta.workspaceMode}, current: ${currentMode})`
+            `Cannot restore checkpoint: workspace mode mismatch (checkpoint: ${ckptMeta.workspaceMode}, current: ${currentMode})`,
           );
         }
 
@@ -1147,6 +1578,7 @@ export class Agent {
           this.sandbox = undefined;
         }
         await this.closeManagedBrowserSession().catch(() => {});
+        await this.closeProviderRuntimeToken().catch(() => {});
         this.sandboxState = "error";
         this.agentState = "error";
         this.emitLifecycle(callbacks, "sandbox_error");
@@ -1155,6 +1587,7 @@ export class Agent {
     }
 
     const sandbox = await this.getSandbox(callbacks);
+    await this.ensureProviderRuntimeToken();
     await this.loadDroidSessionState(sandbox);
 
     // Track turn start time BEFORE process starts (for output file filtering)
@@ -1162,30 +1595,13 @@ export class Agent {
     this.lastRunTimestamp = Date.now();
 
     // Initialize session logger on first run (local logging always, dashboard sync only in gateway mode)
-    if (!this.sessionLogger) {
-      const provider = this.options.sandboxProvider;
-      this.sessionLogger = new SessionLogger({
-        provider: provider?.name || provider?.providerType || "unknown",
-        agent: this.agentConfig.type,
-        model: this.agentConfig.model || this.registry.defaultModel,
-        sandboxId: sandbox.sandboxId,
-        tag: this.sessionTag,
-        apiKey: this.agentConfig.isDirectMode ? undefined : this.agentConfig.apiKey,
-        observability: {
-          ...this.options.observability,
-          ...(this.managedBrowserSession && this.options.managedBrowser ? {
-            browser_provider: this.options.managedBrowser.provider,
-            browser_session_id: this.managedBrowserSession.id,
-            dashboard_session_id: this.managedBrowserSession.sessionId,
-            browser_session_tag: this.managedBrowserSession.sessionTag,
-            browser_live_url: this.managedBrowserSession.liveUrl,
-          } : {}),
-        },
-      });
-    }
+    this.ensureSessionLogger(sandbox);
 
     // Log the prompt (non-blocking)
-    this.sessionLogger.writePrompt(prompt);
+    this.sessionLogger?.writePrompt(prompt);
+    if (this.activeProviderRuntimeToken()) {
+      await this.flushSessionLoggerWithTimeout();
+    }
 
     // Build command and per-run spend tracking env
     const command = this.buildCommand(prompt);
@@ -1195,7 +1611,10 @@ export class Agent {
     // Per-run config-file spend tracking (Qwen): write both session + run headers
     // to settings.json before spawning. Each run gets a fresh file write because
     // the CLI reads the config at startup (not per-request from env).
-    if (!this.agentConfig.isDirectMode && this.registry.spendTrackingJsonConfig) {
+    if (
+      !this.agentConfig.isDirectMode &&
+      this.registry.spendTrackingJsonConfig
+    ) {
       await writeJsonSpendHeaders(
         sandbox,
         this.agentConfig.type as "qwen",
@@ -1208,12 +1627,18 @@ export class Agent {
     }
 
     if (this.agentConfig.type === "qwen") {
-      await writeQwenThinkingConfig(sandbox, isThinkingEnabled(this.agentConfig.reasoningEffort));
+      await writeQwenThinkingConfig(
+        sandbox,
+        isThinkingEnabled(this.agentConfig.reasoningEffort),
+      );
     }
 
     // Per-run TOML provider spend tracking (Kimi): write provider with custom_headers
     // before spawning. CLI reads config at startup, so each run gets a fresh write.
-    if (!this.agentConfig.isDirectMode && this.registry.spendTrackingTomlProvider) {
+    if (
+      !this.agentConfig.isDirectMode &&
+      this.registry.spendTrackingTomlProvider
+    ) {
       await writeKimiSpendConfig(
         sandbox,
         this.registry.spendTrackingTomlProvider,
@@ -1224,9 +1649,13 @@ export class Agent {
         {
           baseUrl: withOpenAiV1Path(getGatewayUrl(this.registry.gatewayPath)),
           apiKey: this.agentConfig.apiKey,
-          model: this.resolveCommandModel(this.agentConfig.model || this.registry.defaultModel),
+          model: this.resolveCommandModel(
+            this.agentConfig.model || this.registry.defaultModel,
+          ),
           defaultThinking: isThinkingEnabled(this.agentConfig.reasoningEffort),
-          thinkingEffort: getKimiCodeThinkingEffort(this.agentConfig.reasoningEffort),
+          thinkingEffort: getKimiCodeThinkingEffort(
+            this.agentConfig.reasoningEffort,
+          ),
         },
       );
     }
@@ -1238,7 +1667,9 @@ export class Agent {
         sandbox,
         {
           ...this.registry.droidGatewaySettings,
-          model: this.resolveCommandModel(this.agentConfig.model || this.registry.defaultModel),
+          model: this.resolveCommandModel(
+            this.agentConfig.model || this.registry.defaultModel,
+          ),
           baseUrl: `${getGatewayUrl()}/v1`,
           apiKeyEnv: "EVOLVE_API_KEY",
         },
@@ -1323,7 +1754,8 @@ export class Agent {
       throw error;
     }
 
-    const interrupted = this.interruptedOperations.delete(opId) || result.exitCode === 130;
+    const interrupted =
+      this.interruptedOperations.delete(opId) || result.exitCode === 130;
     if (interrupted) {
       this.finalizeOperation(opId, callbacks, "run_interrupted", "interrupted");
     } else if (result.exitCode === 0) {
@@ -1359,10 +1791,7 @@ export class Agent {
     // as part of run() — no reliance on timers or explicit kill().
     // Capped at 2s so dashboard slowness never delays the caller.
     if (this.sessionLogger && !background) {
-      await Promise.race([
-        this.sessionLogger.flush(),
-        new Promise<void>((resolve) => setTimeout(resolve, 2000)),
-      ]);
+      await this.flushSessionLoggerWithTimeout();
     }
 
     // =========================================================================
@@ -1382,12 +1811,14 @@ export class Agent {
             workspaceMode: this.options.workspaceMode || "knowledge",
             comment: checkpointComment,
             parentId: this.lastCheckpointId,
-          }
+          },
         );
         this.lastCheckpointId = checkpoint.id;
       } catch (e) {
         // Non-fatal: log warning, return response without checkpoint
-        console.warn(`[Evolve] Auto-checkpoint failed: ${(e as Error).message}`);
+        console.warn(
+          `[Evolve] Auto-checkpoint failed: ${(e as Error).message}`,
+        );
       }
     }
 
@@ -1413,19 +1844,26 @@ export class Agent {
   async executeCommand(
     command: string,
     options: ExecuteCommandOptions = {},
-    callbacks?: StreamCallbacks
+    callbacks?: StreamCallbacks,
   ): Promise<AgentResponse> {
     const { timeoutMs = DEFAULT_TIMEOUT_MS, background = false } = options;
     if (this.activeCommand) {
       throw new Error(
-        "Agent is already running. Call interrupt(), wait for the active/background command to finish, or create a new Evolve instance."
+        "Agent is already running. Call interrupt(), wait for the active/background command to finish, or create a new Evolve instance.",
       );
     }
     const sandbox = await this.getSandbox(callbacks);
+    await this.ensureProviderRuntimeToken();
 
     // Track turn start time BEFORE process starts (for output file filtering)
     // Files modified AFTER this time will be returned by getOutputFiles()
     this.lastRunTimestamp = Date.now();
+
+    if (this.activeProviderRuntimeToken()) {
+      this.ensureSessionLogger(sandbox);
+      this.sessionLogger?.writePrompt(command);
+      await this.flushSessionLoggerWithTimeout();
+    }
 
     let stdout = "";
     let stderr = "";
@@ -1440,13 +1878,20 @@ export class Agent {
       callbacks?.onStderr?.(chunk);
     };
 
+    const commandEnvs = this.buildProviderRuntimeProcessEnvs();
     const handle = await sandbox.commands.spawn(command, {
       cwd: this.workingDir,
       timeoutMs,
+      envs: Object.keys(commandEnvs).length > 0 ? commandEnvs : undefined,
       onStdout,
       onStderr,
     });
-    const opId = this.beginOperation("command", handle, callbacks, "command_start");
+    const opId = this.beginOperation(
+      "command",
+      handle,
+      callbacks,
+      "command_start",
+    );
 
     if (background) {
       this.watchBackgroundOperation(opId, "command", handle, callbacks);
@@ -1469,9 +1914,15 @@ export class Agent {
       throw error;
     }
 
-    const interrupted = this.interruptedOperations.delete(opId) || result.exitCode === 130;
+    const interrupted =
+      this.interruptedOperations.delete(opId) || result.exitCode === 130;
     if (interrupted) {
-      this.finalizeOperation(opId, callbacks, "command_interrupted", "interrupted");
+      this.finalizeOperation(
+        opId,
+        callbacks,
+        "command_interrupted",
+        "interrupted",
+      );
     } else if (result.exitCode === 0) {
       this.finalizeOperation(opId, callbacks, "command_complete", "idle");
     } else {
@@ -1518,7 +1969,9 @@ export class Agent {
    *
    * @param recursive - Include files in subdirectories (default: false)
    */
-  async getOutputFiles<T = unknown>(recursive = false): Promise<OutputResult<T>> {
+  async getOutputFiles<T = unknown>(
+    recursive = false,
+  ): Promise<OutputResult<T>> {
     const sandbox = await this.getSandbox();
     const outputDir = `${this.workingDir}/output`;
 
@@ -1528,7 +1981,7 @@ export class Agent {
     const depthArg = recursive ? "" : "-maxdepth 1";
     const result = await sandbox.commands.run(
       `find ${outputDir} ${depthArg} -type f -exec stat -c '%n|%Z' {} \\; 2>/dev/null || true`,
-      { timeoutMs: 30000 }
+      { timeoutMs: 30000 },
     );
 
     const lines = result.stdout.split("\n").filter(Boolean);
@@ -1571,7 +2024,7 @@ export class Agent {
         } catch {
           return null;
         }
-      })
+      }),
     );
 
     for (const r of results) {
@@ -1584,11 +2037,18 @@ export class Agent {
     // Validate result.json against schema
     const json = files["result.json"];
     if (!json) {
-      return { files, data: null, error: "Schema provided but agent did not create output/result.json" };
+      return {
+        files,
+        data: null,
+        error: "Schema provided but agent did not create output/result.json",
+      };
     }
 
     // Convert to string once (for parsing and rawData)
-    const rawData = typeof json === "string" ? json : new TextDecoder().decode(json as Uint8Array);
+    const rawData =
+      typeof json === "string"
+        ? json
+        : new TextDecoder().decode(json as Uint8Array);
 
     try {
       const parsed = JSON.parse(rawData);
@@ -1598,7 +2058,12 @@ export class Agent {
         const validated = this.zodSchema.safeParse(parsed);
         return validated.success
           ? { files, data: validated.data as T }
-          : { files, data: null, error: `Schema validation failed: ${validated.error.message}`, rawData };
+          : {
+              files,
+              data: null,
+              error: `Schema validation failed: ${validated.error.message}`,
+              rawData,
+            };
       }
 
       // Validate with Ajv (JSON Schema)
@@ -1607,16 +2072,27 @@ export class Agent {
         if (valid) {
           return { files, data: parsed as T };
         } else {
-          const errors = this.compiledValidator.errors
-            ?.map((e) => `${e.instancePath} ${e.message}`)
-            .join(", ") || "Unknown validation error";
-          return { files, data: null, error: `Schema validation failed: ${errors}`, rawData };
+          const errors =
+            this.compiledValidator.errors
+              ?.map((e) => `${e.instancePath} ${e.message}`)
+              .join(", ") || "Unknown validation error";
+          return {
+            files,
+            data: null,
+            error: `Schema validation failed: ${errors}`,
+            rawData,
+          };
         }
       }
 
       return { files, data: null };
     } catch (e) {
-      return { files, data: null, error: `Failed to parse result.json: ${(e as Error).message}`, rawData };
+      return {
+        files,
+        data: null,
+        error: `Failed to parse result.json: ${(e as Error).message}`,
+        rawData,
+      };
     }
   }
 
@@ -1650,7 +2126,7 @@ export class Agent {
         workspaceMode: this.options.workspaceMode || "knowledge",
         comment: options?.comment,
         parentId: this.lastCheckpointId,
-      }
+      },
     );
     this.lastCheckpointId = result.id;
     return result;
@@ -1680,12 +2156,13 @@ export class Agent {
       const interrupted = await this.interrupt();
       if (!interrupted) {
         throw new Error(
-          "Cannot switch session while an active process is running and could not be interrupted."
+          "Cannot switch session while an active process is running and could not be interrupted.",
         );
       }
     }
 
     await this.rotateSession();
+    await this.closeProviderRuntimeToken();
     await this.closeManagedBrowserSession();
 
     this.options.sandboxId = sandboxId;
@@ -1696,6 +2173,7 @@ export class Agent {
     this.agentState = "idle";
     // Assume existing sandbox may have prior runs - use continue command
     this.hasRun = true;
+    this.providerRuntimeRoutingUnavailable = false;
     // Reset lineage — switching sandbox breaks checkpoint chain
     this.lastCheckpointId = undefined;
   }
@@ -1721,7 +2199,7 @@ export class Agent {
   async resume(callbacks?: StreamCallbacks): Promise<void> {
     if (this.sandbox && this.options.sandboxProvider) {
       this.sandbox = await this.options.sandboxProvider.connect(
-        this.sandbox.sandboxId
+        this.sandbox.sandboxId,
       );
       this.sandboxState = "ready";
       this.agentState = "idle";
@@ -1764,9 +2242,8 @@ export class Agent {
     this.sandboxState = "ready";
     this.agentState = "interrupted";
 
-    const reason: LifecycleReason = operationKind === "run"
-      ? "run_interrupted"
-      : "command_interrupted";
+    const reason: LifecycleReason =
+      operationKind === "run" ? "run_interrupted" : "command_interrupted";
     this.emitLifecycle(callbacks, reason);
 
     return killed;
@@ -1810,6 +2287,7 @@ export class Agent {
     } catch (error) {
       killError = error;
     } finally {
+      await this.closeProviderRuntimeToken();
       await this.closeManagedBrowserSession();
     }
 
@@ -1824,6 +2302,7 @@ export class Agent {
     this.sandboxState = "stopped";
     this.agentState = "idle";
     this.hasRun = false;
+    this.providerRuntimeRoutingUnavailable = false;
     this.lastCheckpointId = undefined;
     this.emitLifecycle(callbacks, "sandbox_killed");
   }
@@ -1889,7 +2368,9 @@ export class Agent {
     if (hadActivity) {
       this.previousSessionTag = this.sessionTag;
     }
-    this.sessionTag = generateSessionTag(this.options.sessionTagPrefix || "evolve");
+    this.sessionTag = generateSessionTag(
+      this.options.sessionTagPrefix || "evolve",
+    );
   }
 
   // ===========================================================================
@@ -1902,13 +2383,16 @@ export class Agent {
    */
   private async fetchSpend(params: URLSearchParams): Promise<Response> {
     if (this.agentConfig.isDirectMode) {
-      throw new Error("Cost tracking requires gateway mode (set EVOLVE_API_KEY).");
+      throw new Error(
+        "Cost tracking requires gateway mode (set EVOLVE_API_KEY).",
+      );
     }
     const apiKey = this.agentConfig.apiKey;
     if (!apiKey) {
       throw new Error("Cost tracking requires an API key.");
     }
-    const dashboardUrl = process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL;
+    const dashboardUrl =
+      process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL;
     const res = await fetch(`${dashboardUrl}/api/sessions/spend?${params}`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(10000),
@@ -1939,9 +2423,9 @@ export class Agent {
    * @internal
    */
   private normalizeRunCost(
-    run: Omit<RunCost, "asOf" | "isComplete" | "truncated">
-      & Partial<Pick<RunCost, "asOf" | "isComplete" | "truncated">>,
-    defaults: Pick<RunCost, "asOf" | "isComplete" | "truncated">
+    run: Omit<RunCost, "asOf" | "isComplete" | "truncated"> &
+      Partial<Pick<RunCost, "asOf" | "isComplete" | "truncated">>,
+    defaults: Pick<RunCost, "asOf" | "isComplete" | "truncated">,
   ): RunCost {
     return {
       ...run,
@@ -1980,7 +2464,7 @@ export class Agent {
     const tag = this.resolveSpendTag();
     const params = new URLSearchParams({ tag });
     const res = await this.fetchSpend(params);
-    const raw = await res.json() as SessionCost;
+    const raw = (await res.json()) as SessionCost;
     return this.normalizeSessionCost(raw);
   }
 
@@ -1992,14 +2476,19 @@ export class Agent {
    * Also works after kill() for the most recent session only.
    * Requires gateway mode (EVOLVE_API_KEY).
    */
-  async getRunCost(run: { runId: string } | { index: number }): Promise<RunCost> {
+  async getRunCost(
+    run: { runId: string } | { index: number },
+  ): Promise<RunCost> {
     const tag = this.resolveSpendTag();
 
     if ("runId" in run) {
       const params = new URLSearchParams({ tag, runId: run.runId });
       const res = await this.fetchSpend(params);
-      const raw = await res.json() as Omit<RunCost, "asOf" | "isComplete" | "truncated">
-        & Partial<Pick<RunCost, "asOf" | "isComplete" | "truncated">>;
+      const raw = (await res.json()) as Omit<
+        RunCost,
+        "asOf" | "isComplete" | "truncated"
+      > &
+        Partial<Pick<RunCost, "asOf" | "isComplete" | "truncated">>;
       return this.normalizeRunCost(raw, {
         asOf: new Date().toISOString(),
         isComplete: false,
@@ -2013,7 +2502,7 @@ export class Agent {
     const found = session.runs[idx];
     if (!found) {
       throw new Error(
-        `Run index ${run.index} out of range. Session has ${session.runs.length} run(s).`
+        `Run index ${run.index} out of range. Session has ${session.runs.length} run(s).`,
       );
     }
     return found;

--- a/packages/sdk-ts/src/evolve.ts
+++ b/packages/sdk-ts/src/evolve.ts
@@ -523,6 +523,12 @@ export class Evolve extends EventEmitter {
             dashboardUrl: process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL,
           }
         : undefined,
+      providerRouting: !agentConfig.isDirectMode
+        ? {
+            apiKey: agentConfig.apiKey,
+            dashboardUrl: process.env.EVOLVE_DASHBOARD_URL || DEFAULT_DASHBOARD_URL,
+          }
+        : undefined,
       // Storage / Checkpointing
       storage: resolvedStorage,
     };

--- a/packages/sdk-ts/src/mcp/toml.ts
+++ b/packages/sdk-ts/src/mcp/toml.ts
@@ -177,6 +177,7 @@ export async function writeCodexSpendProvider(
   sandbox: SandboxInstance,
   baseUrl: string,
   spendTrackingEnvs: { sessionTagEnv: string; runTagEnv: string },
+  envHttpHeaders: Record<string, string> = {},
 ): Promise<void> {
   const settingsDir = getMcpSettingsDir("codex");
   const settingsPath = getMcpSettingsPath("codex");
@@ -199,32 +200,43 @@ export async function writeCodexSpendProvider(
   const rootPortion = firstSectionIdx >= 0 ? existingToml.slice(0, firstSectionIdx) : existingToml;
   const restPortion = firstSectionIdx >= 0 ? existingToml.slice(firstSectionIdx) : "";
 
-  // Skip if both the provider section and root key are already correct.
   // hasRootKey checks only the root portion so a profile-scoped model_provider doesn't match.
   const hasProviderSection = existingToml.includes("[model_providers.evolve-gateway]");
   const hasRootKey = /^model_provider\s*=\s*"evolve-gateway"/m.test(rootPortion);
-  if (hasProviderSection && hasRootKey) {
+  const providerHeaders = {
+    [LITELLM_CUSTOMER_ID_HEADER]: spendTrackingEnvs.sessionTagEnv,
+    [LITELLM_TAGS_HEADER]: spendTrackingEnvs.runTagEnv,
+    ...envHttpHeaders,
+  };
+  const desiredProviderSection = [
+    "[model_providers.evolve-gateway]",
+    `name = "Evolve Gateway"`,
+    `base_url = ${serializeTomlValue(baseUrl)}`,
+    `env_key = "OPENAI_API_KEY"`,
+    `env_http_headers = ${serializeTomlValue(providerHeaders)}`,
+  ].join("\n");
+  if (
+    hasProviderSection &&
+    hasRootKey &&
+    existingToml.includes(desiredProviderSection)
+  ) {
     return;
   }
 
   // Strip any existing model_provider root key to avoid duplicate TOML keys.
   const cleanedRoot = rootPortion.replace(/^model_provider\s*=\s*.*$/m, "").replace(/\n{3,}/g, "\n\n");
 
-  existingToml = (cleanedRoot + restPortion).replace(/^\n+/, "");
+  existingToml = (cleanedRoot + restPortion)
+    .replace(
+      /\n?\[model_providers\.evolve-gateway\][\s\S]*?(?=\n\[|\s*$)/,
+      "",
+    )
+    .replace(/^\n+/, "");
 
   // model_provider must be a root-level TOML key (before any [section] headers).
   // The [model_providers.evolve-gateway] table goes at the end.
   const rootKey = `model_provider = "evolve-gateway"`;
-  const providerSection = hasProviderSection ? "" : [
-    "[model_providers.evolve-gateway]",
-    `name = "Evolve Gateway"`,
-    `base_url = ${serializeTomlValue(baseUrl)}`,
-    `env_key = "OPENAI_API_KEY"`,
-    `env_http_headers = ${serializeTomlValue({
-      [LITELLM_CUSTOMER_ID_HEADER]: spendTrackingEnvs.sessionTagEnv,
-      [LITELLM_TAGS_HEADER]: spendTrackingEnvs.runTagEnv,
-    })}`,
-  ].join("\n");
+  const providerSection = desiredProviderSection;
 
   let content: string;
   if (!existingToml.trim()) {

--- a/packages/sdk-ts/src/observability/session-logger.ts
+++ b/packages/sdk-ts/src/observability/session-logger.ts
@@ -22,7 +22,11 @@ import {
   DASHBOARD_RETRY_DELAY_MS,
   getDashboardUrl,
 } from "../constants";
-import { createAgentParser, type AgentParser, type OutputEvent } from "../parsers";
+import {
+  createAgentParser,
+  type AgentParser,
+  type OutputEvent,
+} from "../parsers";
 
 const LOCAL_STORAGE_PATH = join(homedir(), SESSION_LOGS_DIR);
 
@@ -72,7 +76,9 @@ export class SessionLogger {
 
   // Local file: sequential write queue
   private localQueue: Promise<void> = Promise.resolve();
-  private dirReady = mkdir(LOCAL_STORAGE_PATH, { recursive: true }).catch(() => {});
+  private dirReady = mkdir(LOCAL_STORAGE_PATH, { recursive: true }).catch(
+    () => {},
+  );
 
   // Dashboard: event buffer + flush queue
   private eventBuffer: unknown[] = [];
@@ -92,7 +98,9 @@ export class SessionLogger {
     this.observability = config.observability;
 
     // Use provided tag or generate one
-    this.tag = config.tag || `${config.tagPrefix || "evolve"}-${randomBytes(8).toString("hex")}`;
+    this.tag =
+      config.tag ||
+      `${config.tagPrefix || "evolve"}-${randomBytes(8).toString("hex")}`;
 
     // Generate timestamp
     this.timestamp = new Date().toISOString();
@@ -127,7 +135,10 @@ export class SessionLogger {
    * Write event with pre-parsed events (avoids double parsing).
    * Use this when caller already has parsed events.
    */
-  writeEventParsed(eventLine: string, parsedEvents: OutputEvent[] | null): void {
+  writeEventParsed(
+    eventLine: string,
+    parsedEvents: OutputEvent[] | null,
+  ): void {
     if (this.isClosed) return;
 
     // LOCAL FILE: Write raw line
@@ -173,7 +184,6 @@ export class SessionLogger {
 
   async close(): Promise<void> {
     if (this.isClosed) return;
-    this.isClosed = true;
 
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
@@ -182,6 +192,7 @@ export class SessionLogger {
 
     // Write session end marker
     this.write({ _sessionEnd: { timestamp: new Date().toISOString() } });
+    this.isClosed = true;
 
     await this.flush();
   }
@@ -340,7 +351,9 @@ export class SessionLogger {
         // Retryable: rate limit, auth timeout, server error
         if (res.status === 429 || res.status === 401 || res.status >= 500) {
           if (attempt === DASHBOARD_MAX_RETRIES) {
-            console.debug(`[SessionLogger] Dashboard ${res.status} after ${attempt} retries, requeueing`);
+            console.debug(
+              `[SessionLogger] Dashboard ${res.status} after ${attempt} retries, requeueing`,
+            );
             this.requeueEvents(events);
             return;
           }
@@ -349,11 +362,16 @@ export class SessionLogger {
         }
 
         // Non-retryable client error - drop
-        console.debug(`[SessionLogger] Dashboard ${res.status}, dropping events`);
+        console.debug(
+          `[SessionLogger] Dashboard ${res.status}, dropping events`,
+        );
         return;
       } catch (error) {
         if (attempt === DASHBOARD_MAX_RETRIES) {
-          console.debug("[SessionLogger] Dashboard sync failed after retries, requeueing:", error);
+          console.debug(
+            "[SessionLogger] Dashboard sync failed after retries, requeueing:",
+            error,
+          );
           this.requeueEvents(events);
         } else {
           await this.delay(DASHBOARD_RETRY_DELAY_MS * attempt);
@@ -387,10 +405,12 @@ export class SessionLogger {
   }
 
   /** Filter out undefined values from an object */
-  private filterUndefined(obj?: Record<string, unknown>): Record<string, unknown> {
+  private filterUndefined(
+    obj?: Record<string, unknown>,
+  ): Record<string, unknown> {
     if (!obj) return {};
     return Object.fromEntries(
-      Object.entries(obj).filter(([, v]) => v !== undefined)
+      Object.entries(obj).filter(([, v]) => v !== undefined),
     );
   }
 }

--- a/packages/sdk-ts/src/provider-secrets.ts
+++ b/packages/sdk-ts/src/provider-secrets.ts
@@ -1,0 +1,122 @@
+import { DEFAULT_DASHBOARD_URL } from "./constants";
+
+export type ProviderRuntimeToken = {
+  provider: "anthropic" | "openai";
+  token: string;
+  bindingSecret: string;
+  baseUrl: string;
+  expiresAt: string;
+};
+
+export const PROVIDER_RUNTIME_BINDING_HEADER =
+  "x-evolve-provider-runtime-binding";
+
+export interface ProviderRuntimeTokenClientConfig {
+  apiKey: string;
+  dashboardUrl?: string;
+}
+
+function dashboardBaseUrl(url?: string): string {
+  return (
+    url ||
+    process.env.EVOLVE_DASHBOARD_URL ||
+    DEFAULT_DASHBOARD_URL
+  ).replace(/\/$/, "");
+}
+
+async function readError(response: Response): Promise<string> {
+  return await response.text().catch(() => "");
+}
+
+class ProviderRuntimeTokenRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProviderRuntimeTokenRequestError";
+  }
+}
+
+export function isProviderRuntimeTokenEndpointMissing(error: unknown): boolean {
+  return (
+    error instanceof ProviderRuntimeTokenRequestError && error.status === 404
+  );
+}
+
+async function requestJson<T>(
+  config: ProviderRuntimeTokenClientConfig,
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const response = await fetch(
+    `${dashboardBaseUrl(config.dashboardUrl)}${path}`,
+    {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        accept: "application/json",
+        ...(init.body ? { "content-type": "application/json" } : {}),
+        ...(init.headers || {}),
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new ProviderRuntimeTokenRequestError(
+      response.status,
+      `Provider runtime token request failed (${response.status}): ${await readError(response)}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+export async function createProviderRuntimeToken(
+  config: ProviderRuntimeTokenClientConfig,
+  input: { provider: "anthropic" | "openai"; sessionTag: string },
+): Promise<ProviderRuntimeToken | null> {
+  const result = await requestJson<
+    | { enabled: false; provider: "anthropic" | "openai" }
+    | {
+        enabled: true;
+        provider: "anthropic" | "openai";
+        token: string;
+        bindingSecret: string;
+        baseUrl: string;
+        expiresAt: string;
+      }
+  >(config, "/api/provider-secrets/runtime-token", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return result.enabled ? result : null;
+}
+
+export async function bindProviderRuntimeToken(
+  config: ProviderRuntimeTokenClientConfig,
+  input: { token: string; sandboxId: string },
+): Promise<boolean> {
+  const result = await requestJson<{ ok: boolean }>(
+    config,
+    "/api/provider-secrets/runtime-token",
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+  );
+  return result.ok;
+}
+
+export async function revokeProviderRuntimeToken(
+  config: ProviderRuntimeTokenClientConfig,
+  input: { token: string },
+): Promise<boolean> {
+  const result = await requestJson<{ ok: boolean }>(
+    config,
+    "/api/provider-secrets/runtime-token",
+    {
+      method: "DELETE",
+      body: JSON.stringify(input),
+    },
+  );
+  return result.ok;
+}

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -414,6 +414,11 @@ export interface AgentOptions {
     apiKey: string;
     dashboardUrl?: string;
   };
+  /** Evolve-managed provider routing tokens for dashboard-stored BYOK provider keys. */
+  providerRouting?: {
+    apiKey: string;
+    dashboardUrl?: string;
+  };
   /** Plugins/extensions to install in the sandbox user profile before first run */
   plugins?: AgentPluginConfig[];
   /** Skills to enable (e.g., ["pdf", "dev-browser"]) */

--- a/packages/sdk-ts/tests/unit/cost-api.test.ts
+++ b/packages/sdk-ts/tests/unit/cost-api.test.ts
@@ -338,6 +338,8 @@ async function testTomlSkipsWhenAlreadyCorrect(): Promise<void> {
     "[model_providers.evolve-gateway]",
     'name = "Evolve Gateway"',
     'base_url = "https://gateway.example.com"',
+    'env_key = "OPENAI_API_KEY"',
+    'env_http_headers = { x-litellm-customer-id = "EVOLVE_LITELLM_CUSTOMER_ID", x-litellm-tags = "EVOLVE_LITELLM_TAGS" }',
     "",
   ].join("\n");
   const { sandbox, written } = createFakeSandbox(existing);
@@ -553,7 +555,8 @@ async function testTomlRootKeyDriftRepair(): Promise<void> {
     "",
     "[model_providers.evolve-gateway]",
     'name = "Evolve Gateway"',
-    'base_url = "https://gateway.example.com"',
+    'base_url = "https://old-gateway.example.com"',
+    'env_key = "OPENAI_API_KEY"',
     "",
   ].join("\n");
   const { sandbox, written } = createFakeSandbox(existing);
@@ -566,6 +569,8 @@ async function testTomlRootKeyDriftRepair(): Promise<void> {
   // Provider section should NOT be duplicated
   const sectionMatches = content.match(/\[model_providers\.evolve-gateway\]/g) || [];
   assertEqual(sectionMatches.length, 1, "provider section not duplicated");
+  assert(content.includes('base_url = "https://gateway.example.com"'), "provider base_url repaired");
+  assert(content.includes("EVOLVE_LITELLM_CUSTOMER_ID"), "provider headers repaired");
 }
 
 // =============================================================================
@@ -925,6 +930,79 @@ async function testKimiDirectModeSkipsHeaders(): Promise<void> {
 
   const envs = (agent as any).buildRunEnvs("run-direct") as Record<string, string> | undefined;
   assertEqual(envs, undefined, "no env overrides in direct mode");
+}
+
+async function testClaudeProviderRuntimeEnvIsolation(): Promise<void> {
+  console.log("\n[30a] Claude provider runtime token replaces sandbox gateway key");
+  const agent = new Agent({
+    type: "claude",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+  } as any, {});
+  (agent as any).providerRuntimeToken = {
+    provider: "anthropic",
+    token: "evrt_runtime_token",
+    bindingSecret: "evrb_binding_secret",
+    baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
+    expiresAt: new Date(Date.now() + 60000).toISOString(),
+  };
+
+  const envs = (agent as any).buildEnvironmentVariables() as Record<string, string>;
+  assertEqual(envs.ANTHROPIC_API_KEY, "evrt_runtime_token", "sets Anthropic env to runtime token");
+  assertEqual(envs.ANTHROPIC_BASE_URL, "https://dashboard.test/api/model-proxy/anthropic", "sets Anthropic base URL to proxy");
+  assert(envs.ANTHROPIC_CUSTOM_HEADERS.includes("x-evolve-provider-runtime-binding: evrb_binding_secret"), "sets binding header for provider runtime token");
+  assert(!("EVOLVE_API_KEY" in envs), "does not expose Evolve gateway key when provider runtime token is active");
+}
+
+async function testCodexProviderRuntimeEnvIsolation(): Promise<void> {
+  console.log("\n[30aa] Codex provider runtime token replaces sandbox gateway key");
+  const agent = new Agent({
+    type: "codex",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+  } as any, {});
+  (agent as any).providerRuntimeToken = {
+    provider: "openai",
+    token: "evrt_openai_runtime_token",
+    bindingSecret: "evrb_openai_binding_secret",
+    baseUrl: "https://dashboard.test/api/model-proxy/openai",
+    expiresAt: new Date(Date.now() + 60000).toISOString(),
+  };
+
+  const envs = (agent as any).buildEnvironmentVariables() as Record<string, string>;
+  assertEqual(envs.OPENAI_API_KEY, "evrt_openai_runtime_token", "sets OpenAI env to runtime token");
+  assertEqual(envs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai", "sets OpenAI base URL to proxy");
+  assertEqual(envs.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_binding_secret", "sets provider runtime binding env for Codex TOML headers");
+  assert(!("EVOLVE_API_KEY" in envs), "does not expose Evolve gateway key when OpenAI provider runtime token is active");
+
+  const runEnvs = (agent as any).buildRunEnvs("run-openai-1") as Record<string, string>;
+  assertEqual(runEnvs.OPENAI_API_KEY, "evrt_openai_runtime_token", "Codex run env uses runtime token");
+  assertEqual(runEnvs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai", "Codex run env uses proxy base URL");
+  assertEqual(runEnvs.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_binding_secret", "Codex run env includes binding secret");
+  assertEqual(runEnvs.EVOLVE_LITELLM_TAGS, "run:run-openai-1", "Codex run env keeps run tag");
+}
+
+async function testGatewaySecretsCannotOverrideManagedProviderEnv(): Promise<void> {
+  console.log("\n[30b] withSecrets cannot override gateway/provider managed env");
+  const agent = new Agent({
+    type: "claude",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+  } as any, {
+    secrets: {
+      ANTHROPIC_API_KEY: "attacker-provider-key",
+    },
+  });
+
+  let threw = false;
+  try {
+    (agent as any).buildEnvironmentVariables();
+  } catch (error) {
+    threw = true;
+    const message = error instanceof Error ? error.message : String(error);
+    assert(message.includes("ANTHROPIC_API_KEY is reserved"), "throws clear reserved env error");
+  }
+  assertEqual(threw, true, "rejects provider key override");
 }
 
 async function testQwenWriteJsonPreservesUserDefinedHeaders(): Promise<void> {
@@ -1359,6 +1437,9 @@ async function main(): Promise<void> {
   await testKimiEnvironmentVariables();
   await testKimiBuildRunEnvsReturnsUndefined();
   await testKimiDirectModeSkipsHeaders();
+  await testClaudeProviderRuntimeEnvIsolation();
+  await testCodexProviderRuntimeEnvIsolation();
+  await testGatewaySecretsCannotOverrideManagedProviderEnv();
   await testOpenCodeBuildRunEnvsIncludesHeaders();
   await testOpenCodeBuildRunEnvsPerRunOverwrite();
   await testOpenCodeDirectModeSkipsHeaders();

--- a/packages/sdk-ts/tests/unit/plugins-config.test.ts
+++ b/packages/sdk-ts/tests/unit/plugins-config.test.ts
@@ -113,7 +113,9 @@ async function testDefaultAgentUsesClaudeInstaller(): Promise<void> {
   console.log("\n[2] default agent: plugins target claude");
 
   const previousKey = process.env.ANTHROPIC_API_KEY;
+  const previousEvolveKey = process.env.EVOLVE_API_KEY;
   process.env.ANTHROPIC_API_KEY = "provider-key";
+  delete process.env.EVOLVE_API_KEY;
   try {
     const { provider, commands } = createRecordingProvider();
     const kit = new Evolve().withPlugins({
@@ -130,6 +132,11 @@ async function testDefaultAgentUsesClaudeInstaller(): Promise<void> {
       delete process.env.ANTHROPIC_API_KEY;
     } else {
       process.env.ANTHROPIC_API_KEY = previousKey;
+    }
+    if (previousEvolveKey === undefined) {
+      delete process.env.EVOLVE_API_KEY;
+    } else {
+      process.env.EVOLVE_API_KEY = previousEvolveKey;
     }
   }
 }

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -54,7 +54,8 @@ function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
   return new Promise((resolve, reject) => {
     const tick = () => {
       if (predicate()) return resolve();
-      if (Date.now() - started > timeoutMs) return reject(new Error("waitFor timeout"));
+      if (Date.now() - started > timeoutMs)
+        return reject(new Error("waitFor timeout"));
       setTimeout(tick, 10);
     };
     tick();
@@ -74,10 +75,18 @@ class MockFiles implements SandboxFiles {
     if (value === undefined) throw new Error("not found");
     return value;
   }
-  async write(path: string, content: string | Buffer | ArrayBuffer | Uint8Array): Promise<void> {
+  async write(
+    path: string,
+    content: string | Buffer | ArrayBuffer | Uint8Array,
+  ): Promise<void> {
     this.writes.set(path, String(content));
   }
-  async writeBatch(_files: Array<{ path: string; data: string | Buffer | ArrayBuffer | Uint8Array }>): Promise<void> {}
+  async writeBatch(
+    _files: Array<{
+      path: string;
+      data: string | Buffer | ArrayBuffer | Uint8Array;
+    }>,
+  ): Promise<void> {}
   async makeDir(path: string): Promise<void> {
     this.dirs.push(path);
   }
@@ -87,16 +96,24 @@ type SpawnMode = "instant" | "hang";
 
 class MockCommands implements SandboxCommands {
   public spawned: string[] = [];
+  public spawnOptions: Array<SandboxSpawnOptions | undefined> = [];
   public mode: SpawnMode = "instant";
   public killSucceeds = true;
   public activeHandle: SandboxCommandHandle | null = null;
 
-  async run(_command: string, _options?: SandboxRunOptions): Promise<SandboxCommandResult> {
+  async run(
+    _command: string,
+    _options?: SandboxRunOptions,
+  ): Promise<SandboxCommandResult> {
     return { exitCode: 0, stdout: "", stderr: "" };
   }
 
-  async spawn(command: string, options?: SandboxSpawnOptions): Promise<SandboxCommandHandle> {
+  async spawn(
+    command: string,
+    options?: SandboxSpawnOptions,
+  ): Promise<SandboxCommandHandle> {
     this.spawned.push(command);
+    this.spawnOptions.push(options);
     const processId = `p-${this.spawned.length}`;
 
     let finished = false;
@@ -166,6 +183,7 @@ class MockSandbox implements SandboxInstance {
   readonly sandboxId: string;
   readonly commands: MockCommands;
   readonly files: MockFiles;
+  public killed = false;
 
   constructor(id: string, commands: MockCommands) {
     this.sandboxId = id;
@@ -178,6 +196,7 @@ class MockSandbox implements SandboxInstance {
   }
 
   async kill(): Promise<void> {
+    this.killed = true;
     await this.commands.activeHandle?.kill();
   }
 
@@ -201,7 +220,10 @@ class MockProvider implements SandboxProvider {
     return this.sandbox;
   }
 
-  async connect(_sandboxId: string, _timeoutMs?: number): Promise<SandboxInstance> {
+  async connect(
+    _sandboxId: string,
+    _timeoutMs?: number,
+  ): Promise<SandboxInstance> {
     this.connectCalls++;
     return this.sandbox;
   }
@@ -224,9 +246,17 @@ async function testStatusAndLifecycle(): Promise<void> {
   kit.on("lifecycle", (event) => events.push(event));
 
   const before = await kit.status();
-  assertEqual(before.sandbox, "ready", "status() before run reports ready for attached session");
+  assertEqual(
+    before.sandbox,
+    "ready",
+    "status() before run reports ready for attached session",
+  );
   assertEqual(before.agent, "idle", "status() before run reports idle agent");
-  assertEqual(before.hasRun, true, "status() before run reports hasRun=true for attached session");
+  assertEqual(
+    before.hasRun,
+    true,
+    "status() before run reports hasRun=true for attached session",
+  );
   assert(Boolean(before.timestamp), "status() exposes timestamp");
 
   const result = await kit.run({ prompt: "test prompt", timeoutMs: 10_000 });
@@ -240,10 +270,16 @@ async function testStatusAndLifecycle(): Promise<void> {
 
   const reasons = events.map((e) => e.reason);
   assert(reasons.includes("sandbox_boot"), "lifecycle includes sandbox_boot");
-  assert(reasons.includes("sandbox_connected"), "lifecycle includes sandbox_connected");
+  assert(
+    reasons.includes("sandbox_connected"),
+    "lifecycle includes sandbox_connected",
+  );
   assert(reasons.includes("run_start"), "lifecycle includes run_start");
   assert(reasons.includes("run_complete"), "lifecycle includes run_complete");
-  assert(events.every((e) => e.sandboxId !== undefined), "all lifecycle events include sandboxId");
+  assert(
+    events.every((e) => e.sandboxId !== undefined),
+    "all lifecycle events include sandboxId",
+  );
 }
 
 async function testWithSecretsCannotOverrideEvolveApiKey(): Promise<void> {
@@ -257,11 +293,69 @@ async function testWithSecretsCannotOverrideEvolveApiKey(): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     assert(
       message.includes("EVOLVE_API_KEY is reserved"),
-      "withSecrets() throws clear reserved-key error"
+      "withSecrets() throws clear reserved-key error",
     );
   }
 
   assertEqual(threw, true, "withSecrets() rejects EVOLVE_API_KEY");
+}
+
+async function testKillFlushesSessionEnd(): Promise<void> {
+  console.log("\n[2a] kill() flushes session end marker");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  const ingestBodies: Array<{ events?: unknown[] }> = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({ enabled: false, provider: "anthropic" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      ingestBodies.push(JSON.parse(String(init?.body || "{}")));
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  commands.mode = "instant";
+  const sandbox = new MockSandbox("sess-end", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    await kit.run({ prompt: "test", timeoutMs: 10_000 });
+    await kit.kill();
+    const events = ingestBodies.flatMap((body) => body.events ?? []);
+    assert(
+      events.some(
+        (event) =>
+          Boolean(event) && typeof event === "object" && "_sessionEnd" in event,
+      ),
+      "kill() flushes _sessionEnd to dashboard ingest",
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
 }
 
 async function testManagedBrowserLifecycle(): Promise<void> {
@@ -270,22 +364,57 @@ async function testManagedBrowserLifecycle(): Promise<void> {
   const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
   process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
 
-  const liveUrl = "https://dashboard.test/browser-sessions/browser_123/live?token=view-token";
-  const cdpUrl = "wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token";
+  const liveUrl =
+    "https://dashboard.test/browser-sessions/browser_123/live?token=view-token";
+  const cdpUrl =
+    "wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token";
 
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url === "https://dashboard.test/api/browser-sessions" && init?.method === "POST") {
-      return new Response(JSON.stringify({ id: "browser_123", sessionId: "session_db_123", sessionTag: "evolve-browser", cdpUrl, liveUrl }), {
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({ enabled: false, provider: "anthropic" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/browser-sessions" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({
+          id: "browser_123",
+          sessionId: "session_db_123",
+          sessionTag: "evolve-browser",
+          cdpUrl,
+          liveUrl,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/browser-sessions/browser_123" &&
+      init?.method === "DELETE"
+    ) {
+      return new Response("{}", {
         status: 200,
         headers: { "content-type": "application/json" },
       });
     }
-    if (url === "https://dashboard.test/api/browser-sessions/browser_123" && init?.method === "DELETE") {
-      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
-    }
     if (url.endsWith("/api/sessions/ingest")) {
-      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     throw new Error(`unexpected fetch: ${url}`);
   }) as typeof fetch;
@@ -305,32 +434,73 @@ async function testManagedBrowserLifecycle(): Promise<void> {
 
   try {
     const result = await kit.run({ prompt: "test prompt", timeoutMs: 10_000 });
-    assertEqual(result.exitCode, 0, "run() with managed browser returns success");
-    assertEqual(result.sessionId, "session_db_123", "run() exposes Dashboard session id");
-    assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed browser live URL");
-    assert(!JSON.stringify(provider.createOptions?.envs).includes("proxy-token"), "sandbox env does not include CDP token");
+    assertEqual(
+      result.exitCode,
+      0,
+      "run() with managed browser returns success",
+    );
+    assertEqual(
+      result.sessionId,
+      "session_db_123",
+      "run() exposes Dashboard session id",
+    );
+    assertEqual(
+      result.browser?.liveUrl,
+      liveUrl,
+      "run() exposes managed browser live URL",
+    );
+    assert(
+      !JSON.stringify(provider.createOptions?.envs).includes("proxy-token"),
+      "sandbox env does not include CDP token",
+    );
 
     assertEqual(
       provider.createOptions?.envs?.AGENT_BROWSER_CONFIG,
       "/home/user/.agent-browser/config.json",
-      "sandbox env points agent-browser to managed config"
+      "sandbox env points agent-browser to managed config",
     );
-    const config = sandbox.files.writes.get("/home/user/.agent-browser/config.json");
-    assert(sandbox.files.dirs.includes("/home/user/.agent-browser"), "agent-browser config directory created");
-    assert(config !== undefined, "agent-browser config file written");
-    assert(config?.includes(cdpUrl) ?? false, "agent-browser config uses proxied CDP endpoint");
-    assert(!config?.includes("_managedTransport"), "agent-browser config does not expose transport selector");
-
-    const browserReady = events.find((event) => event.reason === "browser_ready");
-    assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes live URL immediately");
-    assertEqual(browserReady?.browser?.sessionId, "session_db_123", "browser_ready exposes Dashboard session id");
+    const config = sandbox.files.writes.get(
+      "/home/user/.agent-browser/config.json",
+    );
     assert(
-      events.findIndex((event) => event.reason === "browser_ready") < events.findIndex((event) => event.reason === "sandbox_ready"),
-      "browser_ready is emitted before sandbox ready"
+      sandbox.files.dirs.includes("/home/user/.agent-browser"),
+      "agent-browser config directory created",
+    );
+    assert(config !== undefined, "agent-browser config file written");
+    assert(
+      config?.includes(cdpUrl) ?? false,
+      "agent-browser config uses proxied CDP endpoint",
+    );
+    assert(
+      !config?.includes("_managedTransport"),
+      "agent-browser config does not expose transport selector",
+    );
+
+    const browserReady = events.find(
+      (event) => event.reason === "browser_ready",
+    );
+    assertEqual(
+      browserReady?.browser?.liveUrl,
+      liveUrl,
+      "browser_ready exposes live URL immediately",
+    );
+    assertEqual(
+      browserReady?.browser?.sessionId,
+      "session_db_123",
+      "browser_ready exposes Dashboard session id",
+    );
+    assert(
+      events.findIndex((event) => event.reason === "browser_ready") <
+        events.findIndex((event) => event.reason === "sandbox_ready"),
+      "browser_ready is emitted before sandbox ready",
     );
 
     const status = await kit.status();
-    assertEqual(status.browser?.liveUrl, liveUrl, "status() exposes managed browser live URL");
+    assertEqual(
+      status.browser?.liveUrl,
+      liveUrl,
+      "status() exposes managed browser live URL",
+    );
   } finally {
     await kit.kill();
     globalThis.fetch = previousFetch;
@@ -348,24 +518,59 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
   const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
   process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
 
-  const liveUrl = "https://dashboard.test/browser-sessions/browser_456/live?token=view-token";
-  const cdpUrl = "wss://dashboard.test/api/browser-sessions/browser_456/cdp?token=proxy-token";
+  const liveUrl =
+    "https://dashboard.test/browser-sessions/browser_456/live?token=view-token";
+  const cdpUrl =
+    "wss://dashboard.test/api/browser-sessions/browser_456/cdp?token=proxy-token";
   let createBody: any;
 
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url === "https://dashboard.test/api/browser-sessions" && init?.method === "POST") {
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({ enabled: false, provider: "anthropic" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/browser-sessions" &&
+      init?.method === "POST"
+    ) {
       createBody = JSON.parse(String(init.body));
-      return new Response(JSON.stringify({ id: "browser_456", sessionId: "session_db_456", sessionTag: "evolve-agent-browser", cdpUrl, liveUrl }), {
+      return new Response(
+        JSON.stringify({
+          id: "browser_456",
+          sessionId: "session_db_456",
+          sessionTag: "evolve-agent-browser",
+          cdpUrl,
+          liveUrl,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/browser-sessions/browser_456" &&
+      init?.method === "DELETE"
+    ) {
+      return new Response("{}", {
         status: 200,
         headers: { "content-type": "application/json" },
       });
     }
-    if (url === "https://dashboard.test/api/browser-sessions/browser_456" && init?.method === "DELETE") {
-      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
-    }
     if (url.endsWith("/api/sessions/ingest")) {
-      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     throw new Error(`unexpected fetch: ${url}`);
   }) as typeof fetch;
@@ -385,30 +590,79 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
 
   try {
     const result = await kit.run({ prompt: "test prompt", timeoutMs: 10_000 });
-    assertEqual(result.exitCode, 0, "run() with managed agent-browser returns success");
-    assert(!("provider" in createBody), "managed browser create does not expose automation provider");
-    assertEqual(createBody.options?.remote, true, "managed browser create uses remote option");
-    assertEqual(createBody.browserAuth, false, "managed browser create does not request browser auth by default");
-    assert(!("_managedTransport" in createBody.options), "managed browser create does not expose transport selector");
-    assertEqual(result.browser?.liveUrl, liveUrl, "run() exposes managed agent-browser live URL");
+    assertEqual(
+      result.exitCode,
+      0,
+      "run() with managed agent-browser returns success",
+    );
+    assert(
+      !("provider" in createBody),
+      "managed browser create does not expose automation provider",
+    );
+    assertEqual(
+      createBody.options?.remote,
+      true,
+      "managed browser create uses remote option",
+    );
+    assertEqual(
+      createBody.browserAuth,
+      false,
+      "managed browser create does not request browser auth by default",
+    );
+    assert(
+      !("_managedTransport" in createBody.options),
+      "managed browser create does not expose transport selector",
+    );
+    assertEqual(
+      result.browser?.liveUrl,
+      liveUrl,
+      "run() exposes managed agent-browser live URL",
+    );
     assertEqual(
       provider.createOptions?.envs?.AGENT_BROWSER_CONFIG,
       "/home/user/.agent-browser/config.json",
-      "sandbox env points agent-browser to managed config"
+      "sandbox env points agent-browser to managed config",
     );
-    assert(!JSON.stringify(provider.createOptions?.envs).includes("proxy-token"), "sandbox env does not include CDP token");
+    assert(
+      !JSON.stringify(provider.createOptions?.envs).includes("proxy-token"),
+      "sandbox env does not include CDP token",
+    );
 
-    const config = sandbox.files.writes.get("/home/user/.agent-browser/config.json");
-    assert(sandbox.files.dirs.includes("/home/user/.agent-browser"), "agent-browser config directory created");
+    const config = sandbox.files.writes.get(
+      "/home/user/.agent-browser/config.json",
+    );
+    assert(
+      sandbox.files.dirs.includes("/home/user/.agent-browser"),
+      "agent-browser config directory created",
+    );
     assert(config !== undefined, "agent-browser config file written");
     const parsedConfig = JSON.parse(config!);
-    assert(!("session" in parsedConfig), "agent-browser config leaves session default to agent-browser");
-    assert(config?.includes(cdpUrl) ?? false, "agent-browser config uses proxied CDP endpoint");
-    assert(!config?.includes("_managedTransport"), "agent-browser config does not expose transport selector");
+    assert(
+      !("session" in parsedConfig),
+      "agent-browser config leaves session default to agent-browser",
+    );
+    assert(
+      config?.includes(cdpUrl) ?? false,
+      "agent-browser config uses proxied CDP endpoint",
+    );
+    assert(
+      !config?.includes("_managedTransport"),
+      "agent-browser config does not expose transport selector",
+    );
 
-    const browserReady = events.find((event) => event.reason === "browser_ready");
-    assertEqual(browserReady?.browser?.liveUrl, liveUrl, "browser_ready exposes agent-browser live URL");
-    assertEqual(browserReady?.browser?.sessionId, "session_db_456", "browser_ready exposes agent-browser Dashboard session id");
+    const browserReady = events.find(
+      (event) => event.reason === "browser_ready",
+    );
+    assertEqual(
+      browserReady?.browser?.liveUrl,
+      liveUrl,
+      "browser_ready exposes agent-browser live URL",
+    );
+    assertEqual(
+      browserReady?.browser?.sessionId,
+      "session_db_456",
+      "browser_ready exposes agent-browser Dashboard session id",
+    );
   } finally {
     await kit.kill();
     globalThis.fetch = previousFetch;
@@ -442,35 +696,67 @@ async function testInterrupt(): Promise<void> {
   await sleep(20);
 
   const running = await kit.status();
-  assertEqual(running.sandbox, "running", "status() while active run reports running sandbox");
-  assertEqual(running.agent, "running", "status() while active run reports running agent");
+  assertEqual(
+    running.sandbox,
+    "running",
+    "status() while active run reports running sandbox",
+  );
+  assertEqual(
+    running.agent,
+    "running",
+    "status() while active run reports running agent",
+  );
 
   commands.killSucceeds = false;
   const failedInterrupt = await kit.interrupt();
-  assertEqual(failedInterrupt, false, "interrupt() returns false when kill cannot be performed");
+  assertEqual(
+    failedInterrupt,
+    false,
+    "interrupt() returns false when kill cannot be performed",
+  );
   const stillRunning = await kit.status();
-  assertEqual(stillRunning.agent, "running", "failed interrupt keeps agent in running state");
+  assertEqual(
+    stillRunning.agent,
+    "running",
+    "failed interrupt keeps agent in running state",
+  );
 
   commands.killSucceeds = true;
   const interrupted = await kit.interrupt();
-  assertEqual(interrupted, true, "interrupt() returns true when process is active");
+  assertEqual(
+    interrupted,
+    true,
+    "interrupt() returns true when process is active",
+  );
 
   const result = await runPromise;
   assertEqual(result.exitCode, 130, "interrupted run exits with code 130");
 
   const after = await kit.status();
-  assertEqual(after.sandbox, "ready", "status() after interrupt reports ready sandbox");
-  assertEqual(after.agent, "interrupted", "status() after interrupt reports interrupted agent");
+  assertEqual(
+    after.sandbox,
+    "ready",
+    "status() after interrupt reports ready sandbox",
+  );
+  assertEqual(
+    after.agent,
+    "interrupted",
+    "status() after interrupt reports interrupted agent",
+  );
 
   const reasons = events.map((e) => e.reason);
   assertEqual(
     reasons.filter((reason) => reason === "run_interrupted").length,
     1,
-    "lifecycle emits run_interrupted exactly once"
+    "lifecycle emits run_interrupted exactly once",
   );
 
   const interruptedWhenIdle = await kit.interrupt();
-  assertEqual(interruptedWhenIdle, false, "interrupt() returns false when no active process");
+  assertEqual(
+    interruptedWhenIdle,
+    false,
+    "interrupt() returns false when no active process",
+  );
 }
 
 async function testBackgroundCompletionLifecycle(): Promise<void> {
@@ -489,11 +775,15 @@ async function testBackgroundCompletionLifecycle(): Promise<void> {
 
   const run = await kit.run({ prompt: "turn 1", background: true });
   assertEqual(run.exitCode, 0, "background run handshake succeeds");
-  await waitFor(() => events.some((event) => event.reason === "run_background_complete"));
+  await waitFor(() =>
+    events.some((event) => event.reason === "run_background_complete"),
+  );
 }
 
 async function testPauseAndKillDoNotGetOverwritten(): Promise<void> {
-  console.log("\n[6] pause()/kill() state is not overwritten by stale completion");
+  console.log(
+    "\n[6] pause()/kill() state is not overwritten by stale completion",
+  );
   const commands = new MockCommands();
   commands.mode = "hang";
   const sandbox = new MockSandbox("sess-4", commands);
@@ -510,7 +800,11 @@ async function testPauseAndKillDoNotGetOverwritten(): Promise<void> {
   await pauseRun;
 
   const paused = await kit.status();
-  assertEqual(paused.sandbox, "paused", "pause() leaves sandbox in paused state");
+  assertEqual(
+    paused.sandbox,
+    "paused",
+    "pause() leaves sandbox in paused state",
+  );
   assertEqual(paused.agent, "idle", "pause() leaves agent idle");
 
   await kit.resume();
@@ -551,7 +845,7 @@ async function testConcurrentRunFailsFast(): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     assert(
       message.includes("Agent is already running"),
-      "second concurrent run throws clear already-running error"
+      "second concurrent run throws clear already-running error",
     );
   }
 
@@ -561,7 +855,9 @@ async function testConcurrentRunFailsFast(): Promise<void> {
 }
 
 async function testSetSessionFailsWhenActiveCannotInterrupt(): Promise<void> {
-  console.log("\n[8] setSession() fails if active process cannot be interrupted");
+  console.log(
+    "\n[8] setSession() fails if active process cannot be interrupted",
+  );
   const commands = new MockCommands();
   commands.mode = "hang";
   commands.killSucceeds = false;
@@ -583,15 +879,612 @@ async function testSetSessionFailsWhenActiveCannotInterrupt(): Promise<void> {
     threw = true;
     const message = error instanceof Error ? error.message : String(error);
     assert(
-      message.includes("Cannot switch session while an active process is running"),
-      "setSession() throws clear error when interruption fails"
+      message.includes(
+        "Cannot switch session while an active process is running",
+      ),
+      "setSession() throws clear error when interruption fails",
     );
   }
-  assertEqual(threw, true, "setSession() rejects when active process cannot be interrupted");
+  assertEqual(
+    threw,
+    true,
+    "setSession() rejects when active process cannot be interrupted",
+  );
 
   commands.killSucceeds = true;
   await kit.interrupt();
   await firstRun;
+}
+
+async function testProviderRuntimeEndpointMissingFallsBackToGatewayKey(): Promise<void> {
+  console.log(
+    "\n[10] missing provider runtime token endpoint preserves gateway path",
+  );
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  let runtimeTokenCalls = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      runtimeTokenCalls++;
+      return new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  const sandbox = new MockSandbox("sess-byok-fail", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    await kit.run({ prompt: "test", timeoutMs: 10_000 });
+    assertEqual(
+      runtimeTokenCalls,
+      1,
+      "missing runtime-token endpoint is cached for the session",
+    );
+    assertEqual(provider.createCalls, 1, "sandbox is still created");
+    assertEqual(
+      provider.createOptions?.envs?.EVOLVE_API_KEY,
+      "evolve-key",
+      "gateway key remains available for old path",
+    );
+    assertEqual(
+      provider.createOptions?.envs?.ANTHROPIC_API_KEY,
+      "evolve-key",
+      "Anthropic gateway env keeps using Evolve key",
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testProviderRuntimeTokenServerErrorFailsClosed(): Promise<void> {
+  console.log("\n[10a] provider runtime token server error fails closed");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(JSON.stringify({ error: "unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  const sandbox = new MockSandbox("sess-byok-server-error", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    let threw = false;
+    try {
+      await kit.run({ prompt: "test", timeoutMs: 10_000 });
+    } catch (error) {
+      threw = true;
+      assert(
+        error instanceof Error &&
+          error.message.includes("Provider runtime token request failed (503)"),
+        "runtime-token server error is surfaced",
+      );
+    }
+    assertEqual(threw, true, "server error fails closed");
+    assertEqual(
+      provider.createCalls,
+      0,
+      "sandbox is not created after runtime-token server error",
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testProviderRuntimeBindFailureKillsSandbox(): Promise<void> {
+  console.log("\n[11] provider runtime bind failure kills created sandbox");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          provider: "anthropic",
+          token: "evrt_token",
+          bindingSecret: "evrb_binding",
+          baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      return new Response(JSON.stringify({ ok: false }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  const sandbox = new MockSandbox("sess-bind-fail", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    let threw = false;
+    try {
+      await kit.run({ prompt: "test", timeoutMs: 10_000 });
+    } catch (error) {
+      threw = true;
+      assert(
+        error instanceof Error &&
+          error.message.includes("Failed to bind provider runtime token"),
+        "bind failure is surfaced",
+      );
+    }
+    assertEqual(threw, true, "run fails when bind fails");
+    assertEqual(
+      provider.createCalls,
+      1,
+      "sandbox was created before bind failure",
+    );
+    assertEqual(
+      sandbox.killed,
+      true,
+      "created sandbox is killed on bind failure",
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testProviderRuntimeTokenDoesNotRefreshAndAddsCommandBindingEnv(): Promise<void> {
+  console.log(
+    "\n[12] provider runtime token is session-bound and command env includes binding",
+  );
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  let refreshCalls = 0;
+  let bindCalls = 0;
+  const ingestBodies: Array<{ events?: unknown[] }> = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          provider: "anthropic",
+          token: "evrt_session_token",
+          bindingSecret: "evrb_session_binding",
+          baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
+          expiresAt: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      const body = JSON.parse(String(init.body));
+      if (body.action === "refresh") {
+        refreshCalls++;
+        return new Response(JSON.stringify({ error: "refresh disabled" }), {
+          status: 410,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      bindCalls++;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      ingestBodies.push(JSON.parse(String(init?.body || "{}")));
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  commands.mode = "instant";
+  const sandbox = new MockSandbox("sess-refresh", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    await kit.executeCommand("echo ok", { timeoutMs: 10_000 });
+    const envs = commands.spawnOptions[0]?.envs || {};
+    assertEqual(bindCalls, 1, "runtime token is bound once to the sandbox");
+    assertEqual(
+      refreshCalls,
+      0,
+      "session-bound runtime token is not refreshed",
+    );
+    assertEqual(
+      envs.ANTHROPIC_API_KEY,
+      "evrt_session_token",
+      "command env uses provider runtime token",
+    );
+    assert(
+      String(envs.ANTHROPIC_CUSTOM_HEADERS || "").includes(
+        "x-evolve-provider-runtime-binding: evrb_session_binding",
+      ),
+      "command env includes provider runtime binding header",
+    );
+    assert(
+      !("EVOLVE_API_KEY" in envs),
+      "command env does not reintroduce Evolve API key",
+    );
+    assert(
+      ingestBodies.some((body) =>
+        (body.events ?? []).some(
+          (event) =>
+            Boolean(event) && typeof event === "object" && "_prompt" in event,
+        ),
+      ),
+      "BYOK executeCommand creates a Dashboard session row before command start",
+    );
+  } finally {
+    await kit.kill().catch(() => {});
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testProviderRuntimeTokenStaysBoundToSandbox(): Promise<void> {
+  console.log(
+    "\n[13] provider runtime token stays bound to the sandbox",
+  );
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  let createCalls = 0;
+  let refreshCalls = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      createCalls++;
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          provider: "anthropic",
+          token: `evrt_session_token_${createCalls}`,
+          bindingSecret: `evrb_session_binding_${createCalls}`,
+          baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
+          expiresAt: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      const body = JSON.parse(String(init.body));
+      if (body.action === "refresh") refreshCalls++;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  commands.mode = "instant";
+  const sandbox = new MockSandbox("sess-rotate", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    await kit.executeCommand("echo first", { timeoutMs: 10_000 });
+    await kit.executeCommand("echo second", { timeoutMs: 10_000 });
+
+    const firstEnvs = commands.spawnOptions[0]?.envs || {};
+    const secondEnvs = commands.spawnOptions[1]?.envs || {};
+    assertEqual(createCalls, 1, "BYOK sandbox mints one runtime token");
+    assertEqual(refreshCalls, 0, "sandbox-bound token is not refreshed");
+    assertEqual(
+      firstEnvs.ANTHROPIC_API_KEY,
+      "evrt_session_token_1",
+      "first command uses first token",
+    );
+    assertEqual(
+      secondEnvs.ANTHROPIC_API_KEY,
+      "evrt_session_token_1",
+      "second command reuses sandbox-bound token",
+    );
+    assert(
+      String(secondEnvs.ANTHROPIC_CUSTOM_HEADERS || "").includes(
+        "x-evolve-provider-runtime-binding: evrb_session_binding_1",
+      ),
+      "second command reuses sandbox-bound binding secret",
+    );
+  } finally {
+    await kit.kill().catch(() => {});
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testSetSessionRevokesProviderRuntimeToken(): Promise<void> {
+  console.log("\n[14] setSession() revokes provider runtime token");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  const deletedTokens: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          provider: "anthropic",
+          token: "evrt_session_token",
+          bindingSecret: "evrb_session_binding",
+          baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
+          expiresAt: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      const body = JSON.parse(String(init.body));
+      deletedTokens.push(String(body.token));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  commands.mode = "instant";
+  const sandbox = new MockSandbox("sess-switch", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "claude", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    await kit.executeCommand("echo before-switch", { timeoutMs: 10_000 });
+    await kit.setSession("sess-other");
+    assert(
+      deletedTokens.includes("evrt_session_token"),
+      "setSession() deletes cached provider runtime token",
+    );
+  } finally {
+    await kit.kill().catch(() => {});
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testCodexProviderRuntimeRoutesThroughDashboardProxy(): Promise<void> {
+  console.log("\n[15] Codex OpenAI BYOK routes through Dashboard proxy");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  const createBodies: Array<{ provider?: string; sessionTag?: string }> = [];
+  const deletedTokens: string[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      createBodies.push(JSON.parse(String(init.body)));
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          provider: "openai",
+          token: "evrt_openai_session_token",
+          bindingSecret: "evrb_openai_session_binding",
+          baseUrl: "https://dashboard.test/api/model-proxy/openai",
+          expiresAt: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      const body = JSON.parse(String(init.body));
+      deletedTokens.push(String(body.token));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  commands.mode = "instant";
+  const sandbox = new MockSandbox("sess-codex-byok", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "codex", apiKey: "evolve-key" })
+    .withSandbox(provider);
+
+  try {
+    await kit.run({ prompt: "hello", timeoutMs: 10_000 });
+
+    assertEqual(createBodies[0]?.provider, "openai", "runtime token request uses openai provider");
+    assertEqual(provider.createOptions?.envs?.OPENAI_API_KEY, "evrt_openai_session_token", "sandbox env uses OpenAI runtime token");
+    assertEqual(provider.createOptions?.envs?.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai", "sandbox env uses Dashboard OpenAI proxy");
+    assert(!provider.createOptions?.envs?.EVOLVE_API_KEY, "sandbox env does not expose Evolve API key");
+    assertEqual(provider.createOptions?.envs?.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_session_binding", "sandbox env includes binding secret env");
+
+    const codexConfig = sandbox.files.writes.get("/home/user/.codex/config.toml") || "";
+    assert(codexConfig.includes('base_url = "https://dashboard.test/api/model-proxy/openai"'), "Codex TOML uses Dashboard proxy base URL");
+    assert(codexConfig.includes("x-evolve-provider-runtime-binding"), "Codex TOML maps provider runtime binding header");
+    assert(codexConfig.includes("EVOLVE_PROVIDER_RUNTIME_BINDING"), "Codex TOML reads binding header from env");
+
+    const runEnvs = commands.spawnOptions[0]?.envs || {};
+    assertEqual(runEnvs.OPENAI_API_KEY, "evrt_openai_session_token", "run env uses OpenAI runtime token");
+    assertEqual(runEnvs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai", "run env uses Dashboard OpenAI proxy");
+    assertEqual(runEnvs.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_session_binding", "run env includes binding secret");
+
+    await kit.kill();
+    assert(
+      deletedTokens.includes("evrt_openai_session_token"),
+      "kill() revokes OpenAI provider runtime token",
+    );
+  } finally {
+    await kit.kill().catch(() => {});
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
 }
 
 async function main(): Promise<void> {
@@ -602,6 +1495,7 @@ async function main(): Promise<void> {
   try {
     await testStatusAndLifecycle();
     await testWithSecretsCannotOverrideEvolveApiKey();
+    await testKillFlushesSessionEnd();
     await testManagedBrowserLifecycle();
     await testManagedAgentBrowserLifecycle();
     await testInterrupt();
@@ -609,9 +1503,18 @@ async function main(): Promise<void> {
     await testPauseAndKillDoNotGetOverwritten();
     await testConcurrentRunFailsFast();
     await testSetSessionFailsWhenActiveCannotInterrupt();
+    await testProviderRuntimeEndpointMissingFallsBackToGatewayKey();
+    await testProviderRuntimeTokenServerErrorFailsClosed();
+    await testProviderRuntimeBindFailureKillsSandbox();
+    await testProviderRuntimeTokenDoesNotRefreshAndAddsCommandBindingEnv();
+    await testProviderRuntimeTokenStaysBoundToSandbox();
+    await testSetSessionRevokesProviderRuntimeToken();
+    await testCodexProviderRuntimeRoutesThroughDashboardProxy();
   } catch (error) {
     failed++;
-    console.log(`\n  ✗ Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    console.log(
+      `\n  ✗ Unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   console.log("\n============================================================");

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -25,12 +25,12 @@ Determine the language from (in priority order):
 Always read these three references **for the detected language** before writing any Evolve code:
 
 **TypeScript:**
-- [01-getting-started.md](references/typescript/01-getting-started.md) — Installation, authentication (Gateway/BYOK), core lifecycle, streaming basics, agent reference table
+- [01-getting-started.md](references/typescript/01-getting-started.md) — Installation, authentication (Gateway, managed BYO provider keys, direct provider-key mode), core lifecycle, streaming basics, agent reference table
 - [02-configuration.md](references/typescript/02-configuration.md) — Sandbox providers, full builder API, agent skills catalog, Managed integrations, MCP servers
 - [03-runtime.md](references/typescript/03-runtime.md) — run(), executeCommand(), upload/download files, session controls, workspace layout, structured output, session management, storage & checkpointing, StorageClient, sessions() client, cost tracking, observability, error handling
 
 **Python:**
-- [01-getting-started.md](references/python/01-getting-started.md) — Installation, authentication (Gateway/BYOK), core lifecycle, streaming basics, agent reference table
+- [01-getting-started.md](references/python/01-getting-started.md) — Installation, authentication (Gateway, managed BYO provider keys, direct provider-key mode), core lifecycle, streaming basics, agent reference table
 - [02-configuration.md](references/python/02-configuration.md) — Sandbox providers, full constructor API, agent skills catalog, Managed integrations, MCP servers
 - [03-runtime.md](references/python/03-runtime.md) — run(), execute_command(), upload/download files, session controls, workspace layout, structured output, session management, storage & checkpointing, StorageClient, sessions() client, cost tracking, observability, error handling
 
@@ -60,7 +60,7 @@ Read on demand when the user's task requires them:
 | Quick start (3 steps) | [TS](references/typescript/01-getting-started.md#quick-start) | [PY](references/python/01-getting-started.md#quick-start) |
 | Core lifecycle (run, output, kill) | [TS](references/typescript/01-getting-started.md#core-lifecycle) | [PY](references/python/01-getting-started.md#core-lifecycle) |
 | Streaming basics | [TS](references/typescript/01-getting-started.md#streaming) | [PY](references/python/01-getting-started.md#streaming) |
-| Gateway vs BYOK mode | [TS](references/typescript/01-getting-started.md#authentication) | [PY](references/python/01-getting-started.md#authentication) |
+| Gateway, managed BYO provider keys, and direct provider-key mode | [TS](references/typescript/01-getting-started.md#authentication) | [PY](references/python/01-getting-started.md#authentication) |
 | BYO subscriptions (Claude Max, Codex, Gemini) | [TS](references/typescript/01-getting-started.md#byo-claude-max-subscription) | [PY](references/python/01-getting-started.md#byo-claude-max-subscription) |
 | Supported agents, models & defaults | [TS](references/typescript/01-getting-started.md#agent-reference) | [PY](references/python/01-getting-started.md#agent-reference) |
 

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -104,12 +104,14 @@ When using `EVOLVE_API_KEY`:
 
 ## Authentication
 
-| | Gateway Mode | BYOK Mode |
-|---|---------|---------------|
-| Setup | `EVOLVE_API_KEY` | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
-| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
-| Billing | Evolving Machines | Your provider accounts |
+| | Gateway Mode | Managed BYO Provider Keys | Direct Provider Key Mode |
+|---|---------|---------------------------|--------------------------|
+| Setup | `EVOLVE_API_KEY` | `EVOLVE_API_KEY` + provider key saved in Dashboard → Secrets → BYO Provider Keys | Model provider keys + [`E2B_API_KEY`](https://e2b.dev) |
+| Provider key location | Evolve-managed | Encrypted Dashboard secret | Your local environment or app config |
+| Sandbox receives | Evolve gateway runtime config | Temporary `evrt_...` token and Dashboard proxy URL, not the raw provider key or `EVOLVE_API_KEY` for that provider route | Raw provider key environment variable |
+| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
+| Browser | `browser={'provider': 'agent-browser', 'remote': True}` is the default and recommended managed browser path with live view and replay. | Same as Gateway Mode | Self-managed browser runtime; no managed live/replay |
+| Model billing | Evolving Machines | Your provider account for enabled providers | Your provider accounts |
 
 ---
 
@@ -134,9 +136,21 @@ await evolve.run(prompt='Hello')
 
 ---
 
-### BYOK Mode
+### Managed BYO Provider Keys
 
-Use your own provider keys. Requires [`E2B_API_KEY`](https://e2b.dev) for sandbox.
+Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+
+1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
+2. Keep `EVOLVE_API_KEY` in your app.
+3. Run Claude or Codex normally.
+
+When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
+
+---
+
+### Direct Provider Key Mode (Local BYOK)
+
+Use this when you want to pass provider keys from your own local environment or app config. Requires [`E2B_API_KEY`](https://e2b.dev) for sandbox.
 
 ```bash
 # .env
@@ -270,7 +284,9 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 > **IMPORTANT: Only use the exact model names listed below.** The SDK will error on unrecognized model names. Do not invent or guess model identifiers.
 
-| type | models | default | Gateway | BYOK |
+The Direct key column applies to Direct Provider Key Mode. Managed BYO Provider Keys use Gateway Mode plus Dashboard-stored provider keys.
+
+| type | models | default | Gateway | Direct key |
 |------|--------|---------|---------|------|
 | `'claude'` | `'fable'` `'opus'` `'sonnet'` `'haiku'` `'opus[1m]'` `'sonnet[1m]'` | `'opus'` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `'codex'` | `'gpt-5.5'` `'gpt-5.4'` `'gpt-5.4-mini'` `'gpt-5.3-codex'` `'gpt-5.2'` | `'gpt-5.4'` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
@@ -298,7 +314,7 @@ For Claude Fable 5, use `model='fable'`. For OpenCode via OpenRouter, use `model
 
 #### Evolve-Provided Gateway Models
 
-These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. Direct provider keys do not apply.
 
 | Agent | Model | Use |
 |-------|-------|-----|

--- a/skills/evolve/references/python/02-configuration.md
+++ b/skills/evolve/references/python/02-configuration.md
@@ -2,7 +2,7 @@
 
 ## Sandbox Providers
 
-Works with both Gateway mode (`EVOLVE_API_KEY`) and BYOK mode (provider API keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
+Works with both Gateway mode (`EVOLVE_API_KEY`) and Direct Provider Key Mode (local BYOK provider keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
 
 All providers use the `evolve-all` image with pre-installed CLIs.
 
@@ -30,7 +30,7 @@ MODAL_TOKEN_SECRET=as-...
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode with E2B (auto-resolves to E2B)
+# .env - Direct Provider Key Mode with E2B (auto-resolves to E2B)
 ANTHROPIC_API_KEY=sk-ant-...
 E2B_API_KEY=e2b_...
 ```
@@ -56,9 +56,9 @@ Only use explicit provider creation (below) if you need custom settings like tim
 EVOLVE_API_KEY=sk-...
 E2B_API_KEY=e2b_...              # Optional with EVOLVE_API_KEY (auto-resolves)
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
-E2B_API_KEY=e2b_...              # Required in BYOK mode
+E2B_API_KEY=e2b_...              # Required in Direct Provider Key Mode
 ```
 
 ```python
@@ -78,7 +78,7 @@ EVOLVE_API_KEY=sk-...
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
@@ -103,7 +103,7 @@ sandbox = ModalProvider(
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 DAYTONA_API_KEY=...
 ```
@@ -146,7 +146,7 @@ evolve = Evolve(
         model='gpt-5.3-codex',               # (optional) Uses default if omitted. Use 'fable' for Claude Fable 5 or 'sonnet[1m]' / 'opus[1m]' for 1M context (Claude only)
         reasoning_effort='medium',           # (optional) Native reasoning/thinking control; valid values vary by agent/model
         api_key=os.getenv('EVOLVE_API_KEY'), # (optional) Gateway mode - auto-resolves from env
-        # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct mode (BYOK)
+        # provider_api_key=os.getenv('ANTHROPIC_API_KEY'), # (optional) Direct Provider Key Mode
         # oauth_token=os.getenv('CLAUDE_CODE_OAUTH_TOKEN'), # (optional) Claude Max subscription
     ),
 
@@ -390,7 +390,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - Use `browser={'provider': 'agent-browser', 'remote': True}`.
-- Not available with local browser mode, direct/BYOK provider mode, or existing sandbox sessions.
+- Not available with local browser mode, Direct Provider Key Mode, or existing sandbox sessions.
 
 Dashboard setup:
 

--- a/skills/evolve/references/python/03-runtime.md
+++ b/skills/evolve/references/python/03-runtime.md
@@ -783,7 +783,7 @@ replay = await session.browser_replay(
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
-This API is **gateway-only**. In BYOK/direct mode, historical traces remain
+This API is **gateway-only**. In Direct Provider Key Mode, historical traces remain
 available via local JSONL files in `~/.evolve-sdk/observability/sessions/`.
 
 ---

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -120,12 +120,14 @@ When using `EVOLVE_API_KEY`:
 
 ## Authentication
 
-| | Gateway Mode | BYOK Mode |
-|---|---------|---------------|
-| Setup | `EVOLVE_API_KEY` | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
-| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
-| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Self-managed browser runtime; no managed live/replay |
-| Billing | Evolving Machines | Your provider accounts |
+| | Gateway Mode | Managed BYO Provider Keys | Direct Provider Key Mode |
+|---|---------|---------------------------|--------------------------|
+| Setup | `EVOLVE_API_KEY` | `EVOLVE_API_KEY` + provider key saved in Dashboard → Secrets → BYO Provider Keys | [Model provider keys](#agent-reference) + [`E2B_API_KEY`](https://e2b.dev) |
+| Provider key location | Evolve-managed | Encrypted Dashboard secret | Your local environment or app config |
+| Sandbox receives | Evolve gateway runtime config | Temporary `evrt_...` token and Dashboard proxy URL, not the raw provider key or `EVOLVE_API_KEY` for that provider route | Raw provider key environment variable |
+| Observability | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | [dashboard.evolvingmachines.ai](https://dashboard.evolvingmachines.ai) | `~/.evolve-sdk/observability/` |
+| Browser | `.withBrowser()` is the default and recommended managed browser path with live view and replay. | Same as Gateway Mode | Self-managed browser runtime; no managed live/replay |
+| Model billing | Evolving Machines | Your provider account for enabled providers | Your provider accounts |
 
 ---
 
@@ -149,9 +151,21 @@ await evolve.run({ prompt: "Hello" });
 
 ---
 
-### BYOK Mode
+### Managed BYO Provider Keys
 
-Use your own provider keys. Requires [E2B API key](https://e2b.dev) for sandbox.
+Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+
+1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
+2. Keep `EVOLVE_API_KEY` in your app.
+3. Run Claude or Codex normally.
+
+When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
+
+---
+
+### Direct Provider Key Mode (Local BYOK)
+
+Use this when you want to pass provider keys from your own local environment or app config. Requires [E2B API key](https://e2b.dev) for sandbox.
 
 ```bash
 # .env
@@ -273,7 +287,9 @@ Set env vars and the SDK picks them up automatically — no need to pass explici
 
 > **IMPORTANT: Only use the exact model names listed below.** The SDK will error on unrecognized model names. Do not invent or guess model identifiers.
 
-| type | models | default | Gateway | BYOK |
+The Direct key column applies to Direct Provider Key Mode. Managed BYO Provider Keys use Gateway Mode plus Dashboard-stored provider keys.
+
+| type | models | default | Gateway | Direct key |
 |------|--------|---------|---------|------|
 | `"claude"` | `"fable"` `"opus"` `"sonnet"` `"haiku"` `"opus[1m]"` `"sonnet[1m]"` | `"opus"` | `EVOLVE_API_KEY` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` |
 | `"codex"` | `"gpt-5.5"` `"gpt-5.4"` `"gpt-5.4-mini"` `"gpt-5.3-codex"` `"gpt-5.2"` | `"gpt-5.4"` | `EVOLVE_API_KEY` | `OPENAI_API_KEY` or `CODEX_OAUTH_FILE_PATH` |
@@ -301,7 +317,7 @@ For Claude Fable 5, use `model: "fable"`. For OpenCode via OpenRouter, use `mode
 
 #### Evolve-Provided Gateway Models
 
-These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. BYOK provider keys do not apply.
+These models require Gateway mode (`EVOLVE_API_KEY`) and are routed by Evolve for latency-sensitive runs. Direct provider keys do not apply.
 
 | Agent | Model | Use |
 |-------|-------|-----|

--- a/skills/evolve/references/typescript/02-configuration.md
+++ b/skills/evolve/references/typescript/02-configuration.md
@@ -2,7 +2,7 @@
 
 ## Sandbox Providers
 
-Works with both Gateway mode (`EVOLVE_API_KEY`) and BYOK mode (provider API keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
+Works with both Gateway mode (`EVOLVE_API_KEY`) and Direct Provider Key Mode (local BYOK provider keys). With `EVOLVE_API_KEY` only, sandbox defaults to **E2B**. Add a sandbox provider key to auto-resolve to that provider.
 
 All providers use the `evolve-all` image with pre-installed CLIs.
 
@@ -30,7 +30,7 @@ MODAL_TOKEN_SECRET=as-...
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode with E2B (auto-resolves to E2B)
+# .env - Direct Provider Key Mode with E2B (auto-resolves to E2B)
 ANTHROPIC_API_KEY=sk-ant-...
 E2B_API_KEY=e2b_...
 ```
@@ -55,9 +55,9 @@ Only use explicit provider creation (below) if you need custom settings like tim
 EVOLVE_API_KEY=sk-...
 E2B_API_KEY=e2b_...              # Optional with EVOLVE_API_KEY (auto-resolves)
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
-E2B_API_KEY=e2b_...              # Required in BYOK mode
+E2B_API_KEY=e2b_...              # Required in Direct Provider Key Mode
 ```
 
 ```ts
@@ -77,7 +77,7 @@ EVOLVE_API_KEY=sk-...
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
@@ -102,7 +102,7 @@ const sandbox = createModalProvider({
 EVOLVE_API_KEY=sk-...
 DAYTONA_API_KEY=...
 
-# .env - BYOK mode
+# .env - Direct Provider Key Mode
 ANTHROPIC_API_KEY=sk-ant-...     # Or OPENAI_API_KEY, GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 DAYTONA_API_KEY=...
 ```
@@ -132,7 +132,7 @@ const evolve = new Evolve()
         model: "gpt-5.3-codex",               // (optional) Uses default if omitted. Use "fable" for Claude Fable 5 or "sonnet[1m]" / "opus[1m]" for 1M context (Claude only)
         reasoningEffort: "medium",            // (optional) Native reasoning/thinking control; valid values vary by agent/model
         apiKey: process.env.EVOLVE_API_KEY!, // (optional) Gateway mode - auto-resolves from env
-        // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct mode (BYOK)
+        // providerApiKey: process.env.ANTHROPIC_API_KEY!, // (optional) Direct Provider Key Mode
         // oauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN!, // (optional) Claude Max subscription
     })
 
@@ -392,7 +392,7 @@ Availability:
 
 - Requires Gateway mode and managed remote `agent-browser`.
 - `.withBrowser()` uses that recommended remote setup by default.
-- Not available with local browser mode, direct/BYOK provider mode, or `.withSession()`.
+- Not available with local browser mode, Direct Provider Key Mode, or `.withSession()`.
 
 Dashboard setup:
 

--- a/skills/evolve/references/typescript/03-runtime.md
+++ b/skills/evolve/references/typescript/03-runtime.md
@@ -745,7 +745,7 @@ const replay = await session.browserReplay(info.id, {
 For the full browser setup, live-view, cleanup, and replay flow, see
 [Configuration → Browser Automation](./02-configuration.md#browser-automation).
 
-Gateway-only — requires `EVOLVE_API_KEY`. In BYOK/direct mode, traces remain
+Gateway-only — requires `EVOLVE_API_KEY`. In Direct Provider Key Mode, traces remain
 available as local JSONL files in `~/.evolve-sdk/observability/sessions/`.
 
 ---


### PR DESCRIPTION
## Summary
- request Dashboard provider runtime tokens for managed Claude/Codex gateway sessions
- route managed BYO provider-key model calls through Dashboard proxy without exposing raw provider keys or the Evolve API key in the sandbox for that provider route
- bind/revoke runtime tokens with sandbox lifecycle and preserve direct/local provider-key mode
- clarify docs for the two BYO paths: Managed BYO Provider Keys vs Direct Provider Key Mode

## Testing
- npm run type-check --workspace packages/sdk-ts
- npm run test:unit --workspace packages/sdk-ts
- git diff --check
- stale BYOK terminology search across README/docs

## Note
- Full live integration test requires a reachable EVOLVE_DASHBOARD_URL for Claude/Codex provider routing preflight.