### PR TITLE
Use Dashboard runtime tokens for Claude and Codex gateway mode

### DIFF
--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -271,7 +271,6 @@ export class Agent {
   private droidSessionId?: string;
   private managedBrowserSession?: ManagedBrowserSession;
   private providerRuntimeToken?: ProviderRuntimeToken;
-  private providerRuntimeRoutingUnavailable = false;
 
   // Skills storage
   private readonly skills?: SkillName[];
@@ -665,9 +664,14 @@ export class Agent {
         }
       }
 
-      // BYOK provider routing uses a run-scoped proxy token instead of exposing
-      // the account gateway key to the sandbox.
+      // Dashboard model proxy routing uses a session-scoped token instead of
+      // exposing the account gateway key to the sandbox.
       if (!providerRuntime) {
+        if (providerRuntimeProviderForAgent(this.agentConfig.type)) {
+          throw new Error(
+            `${this.agentConfig.type} gateway mode requires a Dashboard runtime token before sandbox setup`,
+          );
+        }
         envVars[ENV_EVOLVE_API_KEY] = this.agentConfig.apiKey;
       }
     }
@@ -759,13 +763,10 @@ export class Agent {
     const provider = providerRuntimeProviderForAgent(this.agentConfig.type);
     if (this.agentConfig.isDirectMode || !provider) return;
     if (!this.options.providerRouting) return;
-    if (this.providerRuntimeRoutingUnavailable && !this.providerRuntimeToken) {
-      return;
-    }
 
     if (this.providerRuntimeToken) return;
 
-    let token: ProviderRuntimeToken | null;
+    let token: ProviderRuntimeToken;
     try {
       token = await createProviderRuntimeToken(this.options.providerRouting, {
         provider,
@@ -773,17 +774,14 @@ export class Agent {
       });
     } catch (error) {
       if (isProviderRuntimeTokenEndpointMissing(error)) {
-        this.providerRuntimeRoutingUnavailable = true;
-        console.warn(
-          `[Evolve] ${provider} BYOK provider routing endpoint is not available; falling back to Evolve gateway key: ${(error as Error).message}`,
+        throw new Error(
+          `${provider} runtime token endpoint is required in gateway mode: ${(error as Error).message}`,
         );
-        return;
       }
       throw error;
     }
 
-    this.providerRuntimeRoutingUnavailable = token === null;
-    this.providerRuntimeToken = token ?? undefined;
+    this.providerRuntimeToken = token;
     if (this.providerRuntimeToken && this.sandbox?.sandboxId) {
       await this.bindProviderRuntimeToken(this.sandbox.sandboxId);
     }
@@ -834,15 +832,32 @@ export class Agent {
   private async closeProviderRuntimeToken(): Promise<void> {
     if (!this.providerRuntimeToken || !this.options.providerRouting) return;
     const token = this.providerRuntimeToken;
-    this.providerRuntimeToken = undefined;
+    let lastError: unknown;
     try {
-      await revokeProviderRuntimeTokenRequest(this.options.providerRouting, {
-        token: token.token,
-      });
-    } catch (error) {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const ok = await revokeProviderRuntimeTokenRequest(
+            this.options.providerRouting,
+            {
+              token: token.token,
+            },
+          );
+          if (!ok) throw new Error("Dashboard returned ok=false");
+          return;
+        } catch (error) {
+          lastError = error;
+          if (attempt < 2) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, 100 * (attempt + 1)),
+            );
+          }
+        }
+      }
       console.warn(
-        `[Evolve] Provider runtime token cleanup failed: ${(error as Error).message}`,
+        `[Evolve] Provider runtime token cleanup failed: ${(lastError as Error).message}`,
       );
+    } finally {
+      this.providerRuntimeToken = undefined;
     }
   }
 
@@ -1052,6 +1067,28 @@ export class Agent {
     return Object.keys(envs).length > 0 ? envs : undefined;
   }
 
+  private async writeCodexGatewayProviderConfig(
+    sandbox: SandboxInstance,
+  ): Promise<void> {
+    if (
+      this.agentConfig.isDirectMode ||
+      !this.registry.spendTrackingEnvs ||
+      this.agentConfig.type !== "codex"
+    ) {
+      return;
+    }
+    await writeCodexSpendProvider(
+      sandbox,
+      this.activeProviderRuntimeToken()?.baseUrl ||
+        this.agentConfig.baseUrl ||
+        getGatewayUrl(),
+      this.registry.spendTrackingEnvs,
+      this.activeProviderRuntimeToken()
+        ? { [PROVIDER_RUNTIME_BINDING_HEADER]: PROVIDER_RUNTIME_BINDING_ENV }
+        : undefined,
+    );
+  }
+
   private captureDroidSession(
     rawLine: string,
     events: OutputEvent[] | null,
@@ -1174,7 +1211,7 @@ export class Agent {
       for (const value of Object.values(config.headers || {})) {
         if (value.includes(gatewayKey)) {
           throw new Error(
-            `MCP server "${name}" would expose the Evolve API key inside a provider BYOK sandbox. Use managed agent-browser or remove this gateway-authenticated MCP server.`,
+            `MCP server "${name}" would expose the Evolve API key inside the sandbox. Use managed agent-browser or remove this gateway-authenticated MCP server.`,
           );
         }
       }
@@ -1299,16 +1336,7 @@ export class Agent {
       this.registry.spendTrackingEnvs &&
       this.agentConfig.type === "codex"
     ) {
-      await writeCodexSpendProvider(
-        sandbox,
-        this.activeProviderRuntimeToken()?.baseUrl ||
-          this.agentConfig.baseUrl ||
-          getGatewayUrl(),
-        this.registry.spendTrackingEnvs,
-        this.activeProviderRuntimeToken()
-          ? { [PROVIDER_RUNTIME_BINDING_HEADER]: PROVIDER_RUNTIME_BINDING_ENV }
-          : undefined,
-      );
+      await this.writeCodexGatewayProviderConfig(sandbox);
     }
 
     // Spend tracking: write customHeaders to JSON settings file for agents that read
@@ -1607,6 +1635,8 @@ export class Agent {
     const command = this.buildCommand(prompt);
     const runId = randomUUID();
     const runEnvs = this.buildRunEnvs(runId);
+
+    await this.writeCodexGatewayProviderConfig(sandbox);
 
     // Per-run config-file spend tracking (Qwen): write both session + run headers
     // to settings.json before spawning. Each run gets a fresh file write because
@@ -2173,7 +2203,6 @@ export class Agent {
     this.agentState = "idle";
     // Assume existing sandbox may have prior runs - use continue command
     this.hasRun = true;
-    this.providerRuntimeRoutingUnavailable = false;
     // Reset lineage — switching sandbox breaks checkpoint chain
     this.lastCheckpointId = undefined;
   }
@@ -2302,7 +2331,6 @@ export class Agent {
     this.sandboxState = "stopped";
     this.agentState = "idle";
     this.hasRun = false;
-    this.providerRuntimeRoutingUnavailable = false;
     this.lastCheckpointId = undefined;
     this.emitLifecycle(callbacks, "sandbox_killed");
   }

--- a/packages/sdk-ts/src/provider-secrets.ts
+++ b/packages/sdk-ts/src/provider-secrets.ts
@@ -2,6 +2,7 @@ import { DEFAULT_DASHBOARD_URL } from "./constants";
 
 export type ProviderRuntimeToken = {
   provider: "anthropic" | "openai";
+  credentialMode: "provider_key" | "evolve_key";
   token: string;
   bindingSecret: string;
   baseUrl: string;
@@ -70,25 +71,46 @@ async function requestJson<T>(
   return (await response.json()) as T;
 }
 
+function isRuntimeTokenResponse(value: unknown): value is ProviderRuntimeToken {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.enabled === true &&
+    (record.provider === "anthropic" || record.provider === "openai") &&
+    (record.credentialMode === "provider_key" ||
+      record.credentialMode === "evolve_key") &&
+    typeof record.token === "string" &&
+    record.token.length > 0 &&
+    typeof record.bindingSecret === "string" &&
+    record.bindingSecret.length > 0 &&
+    typeof record.baseUrl === "string" &&
+    record.baseUrl.length > 0 &&
+    typeof record.expiresAt === "string" &&
+    record.expiresAt.length > 0
+  );
+}
+
 export async function createProviderRuntimeToken(
   config: ProviderRuntimeTokenClientConfig,
   input: { provider: "anthropic" | "openai"; sessionTag: string },
-): Promise<ProviderRuntimeToken | null> {
-  const result = await requestJson<
-    | { enabled: false; provider: "anthropic" | "openai" }
-    | {
-        enabled: true;
-        provider: "anthropic" | "openai";
-        token: string;
-        bindingSecret: string;
-        baseUrl: string;
-        expiresAt: string;
-      }
-  >(config, "/api/provider-secrets/runtime-token", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
-  return result.enabled ? result : null;
+): Promise<ProviderRuntimeToken> {
+  const result = await requestJson<unknown>(
+    config,
+    "/api/provider-secrets/runtime-token",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
+  if (!isRuntimeTokenResponse(result)) {
+    throw new ProviderRuntimeTokenRequestError(
+      502,
+      "Provider runtime token response was invalid",
+    );
+  }
+  return result;
 }
 
 export async function bindProviderRuntimeToken(

--- a/packages/sdk-ts/tests/unit/browser-config.test.ts
+++ b/packages/sdk-ts/tests/unit/browser-config.test.ts
@@ -46,6 +46,17 @@ async function getInitializedAgentOptions(kit: Evolve): Promise<Record<string, a
   return ((kit as any).agent as any).options ?? {};
 }
 
+function installAnthropicRuntimeToken(agent: any): void {
+  agent.providerRuntimeToken = {
+    provider: "anthropic",
+    credentialMode: "evolve_key",
+    token: "evrt_anthropic",
+    bindingSecret: "evrb_anthropic",
+    baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
+    expiresAt: "9999-12-31T23:59:59.999Z",
+  };
+}
+
 async function testBrowserUseNotInjectedByDefault(): Promise<void> {
   console.log("\n[1] Gateway mode: browser-use is not injected by default");
 
@@ -286,6 +297,7 @@ async function testManagedActionbookConfigUsesProxyOnly(): Promise<void> {
     cdpUrl: "wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token",
     liveUrl: "https://dashboard.test/browser-sessions/browser_123/live?token=view-token",
   };
+  installAnthropicRuntimeToken(agent);
   const envs = agent.buildEnvironmentVariables();
   assert(!("ACTIONBOOK_BROWSER_MODE" in envs), "Actionbook mode is not passed through env");
   assert(!("ACTIONBOOK_BROWSER_CDP_ENDPOINT" in envs), "Actionbook CDP endpoint is not passed through env");
@@ -332,6 +344,7 @@ async function testManagedAgentBrowserConfigUsesProxyOnly(): Promise<void> {
     cdpUrl: "wss://dashboard.test/api/browser-sessions/browser_123/cdp?token=proxy-token",
     liveUrl: "https://dashboard.test/browser-sessions/browser_123/live?token=view-token",
   };
+  installAnthropicRuntimeToken(agent);
 
   const envs = agent.buildEnvironmentVariables();
   assertEqual(

--- a/packages/sdk-ts/tests/unit/cost-api.test.ts
+++ b/packages/sdk-ts/tests/unit/cost-api.test.ts
@@ -941,6 +941,7 @@ async function testClaudeProviderRuntimeEnvIsolation(): Promise<void> {
   } as any, {});
   (agent as any).providerRuntimeToken = {
     provider: "anthropic",
+    credentialMode: "evolve_key",
     token: "evrt_runtime_token",
     bindingSecret: "evrb_binding_secret",
     baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
@@ -963,6 +964,7 @@ async function testCodexProviderRuntimeEnvIsolation(): Promise<void> {
   } as any, {});
   (agent as any).providerRuntimeToken = {
     provider: "openai",
+    credentialMode: "evolve_key",
     token: "evrt_openai_runtime_token",
     bindingSecret: "evrb_openai_binding_secret",
     baseUrl: "https://dashboard.test/api/model-proxy/openai",
@@ -1003,6 +1005,25 @@ async function testGatewaySecretsCannotOverrideManagedProviderEnv(): Promise<voi
     assert(message.includes("ANTHROPIC_API_KEY is reserved"), "throws clear reserved env error");
   }
   assertEqual(threw, true, "rejects provider key override");
+}
+
+async function testClaudeGatewayRequiresRuntimeToken(): Promise<void> {
+  console.log("\n[30c] Claude gateway mode requires runtime token before sandbox env");
+  const agent = new Agent({
+    type: "claude",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+  } as any, {});
+
+  let threw = false;
+  try {
+    (agent as any).buildEnvironmentVariables();
+  } catch (error) {
+    threw = true;
+    const message = error instanceof Error ? error.message : String(error);
+    assert(message.includes("requires a Dashboard runtime token"), "throws clear runtime token guard");
+  }
+  assertEqual(threw, true, "does not expose raw gateway key without runtime token");
 }
 
 async function testQwenWriteJsonPreservesUserDefinedHeaders(): Promise<void> {
@@ -1440,6 +1461,7 @@ async function main(): Promise<void> {
   await testClaudeProviderRuntimeEnvIsolation();
   await testCodexProviderRuntimeEnvIsolation();
   await testGatewaySecretsCannotOverrideManagedProviderEnv();
+  await testClaudeGatewayRequiresRuntimeToken();
   await testOpenCodeBuildRunEnvsIncludesHeaders();
   await testOpenCodeBuildRunEnvsPerRunOverwrite();
   await testOpenCodeDirectModeSkipsHeaders();

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -66,6 +66,22 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function runtimeTokenResponse(provider: "anthropic" | "openai" = "anthropic") {
+  const baseUrl =
+    provider === "openai"
+      ? "https://dashboard.test/api/model-proxy/openai/v1"
+      : "https://dashboard.test/api/model-proxy/anthropic";
+  return {
+    enabled: true,
+    provider,
+    credentialMode: "evolve_key",
+    token: `evrt_${provider}`,
+    bindingSecret: `evrb_${provider}`,
+    baseUrl,
+    expiresAt: "9999-12-31T23:59:59.999Z",
+  };
+}
+
 class MockFiles implements SandboxFiles {
   public writes = new Map<string, string>();
   public dirs: string[] = [];
@@ -314,12 +330,21 @@ async function testKillFlushesSessionEnd(): Promise<void> {
       init?.method === "POST"
     ) {
       return new Response(
-        JSON.stringify({ enabled: false, provider: "anthropic" }),
+        JSON.stringify(runtimeTokenResponse()),
         {
           status: 200,
           headers: { "content-type": "application/json" },
         },
       );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      (init?.method === "PATCH" || init?.method === "DELETE")
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     if (url === "https://dashboard.test/api/sessions/ingest") {
       ingestBodies.push(JSON.parse(String(init?.body || "{}")));
@@ -376,12 +401,21 @@ async function testManagedBrowserLifecycle(): Promise<void> {
       init?.method === "POST"
     ) {
       return new Response(
-        JSON.stringify({ enabled: false, provider: "anthropic" }),
+        JSON.stringify(runtimeTokenResponse()),
         {
           status: 200,
           headers: { "content-type": "application/json" },
         },
       );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      (init?.method === "PATCH" || init?.method === "DELETE")
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     if (
       url === "https://dashboard.test/api/browser-sessions" &&
@@ -531,12 +565,21 @@ async function testManagedAgentBrowserLifecycle(): Promise<void> {
       init?.method === "POST"
     ) {
       return new Response(
-        JSON.stringify({ enabled: false, provider: "anthropic" }),
+        JSON.stringify(runtimeTokenResponse()),
         {
           status: 200,
           headers: { "content-type": "application/json" },
         },
       );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      (init?.method === "PATCH" || init?.method === "DELETE")
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     if (
       url === "https://dashboard.test/api/browser-sessions" &&
@@ -896,9 +939,9 @@ async function testSetSessionFailsWhenActiveCannotInterrupt(): Promise<void> {
   await firstRun;
 }
 
-async function testProviderRuntimeEndpointMissingFallsBackToGatewayKey(): Promise<void> {
+async function testProviderRuntimeEndpointMissingFailsClosed(): Promise<void> {
   console.log(
-    "\n[10] missing provider runtime token endpoint preserves gateway path",
+    "\n[10] missing provider runtime token endpoint fails closed",
   );
   const previousFetch = globalThis.fetch;
   const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
@@ -916,12 +959,6 @@ async function testProviderRuntimeEndpointMissingFallsBackToGatewayKey(): Promis
         headers: { "content-type": "application/json" },
       });
     }
-    if (url === "https://dashboard.test/api/sessions/ingest") {
-      return new Response("{}", {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }
     throw new Error(`unexpected fetch: ${url}`);
   }) as typeof fetch;
 
@@ -933,23 +970,24 @@ async function testProviderRuntimeEndpointMissingFallsBackToGatewayKey(): Promis
     .withSandbox(provider);
 
   try {
-    await kit.run({ prompt: "test", timeoutMs: 10_000 });
+    let threw = false;
+    try {
+      await kit.run({ prompt: "test", timeoutMs: 10_000 });
+    } catch (error) {
+      threw = true;
+      const message = error instanceof Error ? error.message : String(error);
+      assert(
+        message.includes("runtime token endpoint is required"),
+        "missing runtime-token endpoint throws clear fail-closed error",
+      );
+    }
+    assertEqual(threw, true, "run() rejects before sandbox creation");
     assertEqual(
       runtimeTokenCalls,
       1,
-      "missing runtime-token endpoint is cached for the session",
+      "missing runtime-token endpoint is requested once",
     );
-    assertEqual(provider.createCalls, 1, "sandbox is still created");
-    assertEqual(
-      provider.createOptions?.envs?.EVOLVE_API_KEY,
-      "evolve-key",
-      "gateway key remains available for old path",
-    );
-    assertEqual(
-      provider.createOptions?.envs?.ANTHROPIC_API_KEY,
-      "evolve-key",
-      "Anthropic gateway env keeps using Evolve key",
-    );
+    assertEqual(provider.createCalls, 0, "sandbox is not created");
   } finally {
     globalThis.fetch = previousFetch;
     if (previousDashboardUrl === undefined)
@@ -1025,6 +1063,7 @@ async function testProviderRuntimeBindFailureKillsSandbox(): Promise<void> {
         JSON.stringify({
           enabled: true,
           provider: "anthropic",
+          credentialMode: "evolve_key",
           token: "evrt_token",
           bindingSecret: "evrb_binding",
           baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
@@ -1112,6 +1151,7 @@ async function testProviderRuntimeTokenDoesNotRefreshAndAddsCommandBindingEnv():
         JSON.stringify({
           enabled: true,
           provider: "anthropic",
+          credentialMode: "evolve_key",
           token: "evrt_session_token",
           bindingSecret: "evrb_session_binding",
           baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
@@ -1229,6 +1269,7 @@ async function testProviderRuntimeTokenStaysBoundToSandbox(): Promise<void> {
         JSON.stringify({
           enabled: true,
           provider: "anthropic",
+          credentialMode: "evolve_key",
           token: `evrt_session_token_${createCalls}`,
           bindingSecret: `evrb_session_binding_${createCalls}`,
           baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
@@ -1325,6 +1366,7 @@ async function testSetSessionRevokesProviderRuntimeToken(): Promise<void> {
         JSON.stringify({
           enabled: true,
           provider: "anthropic",
+          credentialMode: "evolve_key",
           token: "evrt_session_token",
           bindingSecret: "evrb_session_binding",
           baseUrl: "https://dashboard.test/api/model-proxy/anthropic",
@@ -1407,9 +1449,10 @@ async function testCodexProviderRuntimeRoutesThroughDashboardProxy(): Promise<vo
         JSON.stringify({
           enabled: true,
           provider: "openai",
+          credentialMode: "evolve_key",
           token: "evrt_openai_session_token",
           bindingSecret: "evrb_openai_session_binding",
-          baseUrl: "https://dashboard.test/api/model-proxy/openai",
+          baseUrl: "https://dashboard.test/api/model-proxy/openai/v1",
           expiresAt: new Date(
             Date.now() + 30 * 24 * 60 * 60 * 1000,
           ).toISOString(),
@@ -1459,18 +1502,18 @@ async function testCodexProviderRuntimeRoutesThroughDashboardProxy(): Promise<vo
 
     assertEqual(createBodies[0]?.provider, "openai", "runtime token request uses openai provider");
     assertEqual(provider.createOptions?.envs?.OPENAI_API_KEY, "evrt_openai_session_token", "sandbox env uses OpenAI runtime token");
-    assertEqual(provider.createOptions?.envs?.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai", "sandbox env uses Dashboard OpenAI proxy");
+    assertEqual(provider.createOptions?.envs?.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai/v1", "sandbox env uses Dashboard OpenAI proxy");
     assert(!provider.createOptions?.envs?.EVOLVE_API_KEY, "sandbox env does not expose Evolve API key");
     assertEqual(provider.createOptions?.envs?.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_session_binding", "sandbox env includes binding secret env");
 
     const codexConfig = sandbox.files.writes.get("/home/user/.codex/config.toml") || "";
-    assert(codexConfig.includes('base_url = "https://dashboard.test/api/model-proxy/openai"'), "Codex TOML uses Dashboard proxy base URL");
+    assert(codexConfig.includes('base_url = "https://dashboard.test/api/model-proxy/openai/v1"'), "Codex TOML uses Dashboard proxy base URL");
     assert(codexConfig.includes("x-evolve-provider-runtime-binding"), "Codex TOML maps provider runtime binding header");
     assert(codexConfig.includes("EVOLVE_PROVIDER_RUNTIME_BINDING"), "Codex TOML reads binding header from env");
 
     const runEnvs = commands.spawnOptions[0]?.envs || {};
     assertEqual(runEnvs.OPENAI_API_KEY, "evrt_openai_session_token", "run env uses OpenAI runtime token");
-    assertEqual(runEnvs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai", "run env uses Dashboard OpenAI proxy");
+    assertEqual(runEnvs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai/v1", "run env uses Dashboard OpenAI proxy");
     assertEqual(runEnvs.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_session_binding", "run env includes binding secret");
 
     await kit.kill();
@@ -1478,6 +1521,96 @@ async function testCodexProviderRuntimeRoutesThroughDashboardProxy(): Promise<vo
       deletedTokens.includes("evrt_openai_session_token"),
       "kill() revokes OpenAI provider runtime token",
     );
+  } finally {
+    await kit.kill().catch(() => {});
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
+async function testCodexConnectedSessionReassertsDashboardProxy(): Promise<void> {
+  console.log("\n[16] Codex withSession reasserts Dashboard proxy config");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+  const createBodies: Array<{ provider?: string; sessionTag?: string }> = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      createBodies.push(JSON.parse(String(init.body)));
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          provider: "openai",
+          credentialMode: "evolve_key",
+          token: "evrt_openai_existing_session",
+          bindingSecret: "evrb_openai_existing_session",
+          baseUrl: "https://dashboard.test/api/model-proxy/openai/v1",
+          expiresAt: new Date(
+            Date.now() + 30 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const commands = new MockCommands();
+  commands.mode = "instant";
+  const sandbox = new MockSandbox("sess-codex-existing", commands);
+  const provider = new MockProvider(sandbox);
+  const kit = new Evolve()
+    .withAgent({ type: "codex", apiKey: "evolve-key" })
+    .withSandbox(provider)
+    .withSession("sess-codex-existing");
+
+  try {
+    await kit.run({ prompt: "hello", timeoutMs: 10_000 });
+
+    assertEqual(provider.connectCalls, 1, "existing sandbox is connected");
+    assertEqual(provider.createCalls, 0, "existing sandbox is not recreated");
+    assertEqual(createBodies[0]?.provider, "openai", "runtime token request uses openai provider");
+
+    const codexConfig = sandbox.files.writes.get("/home/user/.codex/config.toml") || "";
+    assert(codexConfig.includes('base_url = "https://dashboard.test/api/model-proxy/openai/v1"'), "connected Codex session writes Dashboard proxy base URL");
+    assert(codexConfig.includes("x-evolve-provider-runtime-binding"), "connected Codex session maps provider runtime binding header");
+    assert(codexConfig.includes("EVOLVE_PROVIDER_RUNTIME_BINDING"), "connected Codex session reads binding header from env");
+
+    const runEnvs = commands.spawnOptions[0]?.envs || {};
+    assertEqual(runEnvs.OPENAI_API_KEY, "evrt_openai_existing_session", "connected Codex run env uses runtime token");
+    assertEqual(runEnvs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/openai/v1", "connected Codex run env uses Dashboard proxy");
+    assertEqual(runEnvs.EVOLVE_PROVIDER_RUNTIME_BINDING, "evrb_openai_existing_session", "connected Codex run env includes binding secret");
   } finally {
     await kit.kill().catch(() => {});
     globalThis.fetch = previousFetch;
@@ -1503,13 +1636,14 @@ async function main(): Promise<void> {
     await testPauseAndKillDoNotGetOverwritten();
     await testConcurrentRunFailsFast();
     await testSetSessionFailsWhenActiveCannotInterrupt();
-    await testProviderRuntimeEndpointMissingFallsBackToGatewayKey();
+    await testProviderRuntimeEndpointMissingFailsClosed();
     await testProviderRuntimeTokenServerErrorFailsClosed();
     await testProviderRuntimeBindFailureKillsSandbox();
     await testProviderRuntimeTokenDoesNotRefreshAndAddsCommandBindingEnv();
     await testProviderRuntimeTokenStaysBoundToSandbox();
     await testSetSessionRevokesProviderRuntimeToken();
     await testCodexProviderRuntimeRoutesThroughDashboardProxy();
+    await testCodexConnectedSessionReassertsDashboardProxy();
   } catch (error) {
     failed++;
     console.log(


### PR DESCRIPTION
## Summary

- require Dashboard runtime tokens for Claude/Codex gateway sandboxes instead of injecting raw EVOLVE_API_KEY
- validate runtime-token responses and fail closed on stale/invalid Dashboard contracts
- retry runtime-token revocation and reassert Codex proxy config for attached sessions
- update unit coverage for runtime token lifecycle, Codex proxy env/TOML, and fail-closed behavior

## Testing

- npm run type-check
- npm run build
- npm run test:unit
- npm exec -- tsx tests/unit/session-runtime.test.ts