### PR TITLE
Route managed agents through runtime proxies

### DIFF
--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -115,6 +115,7 @@ export type {
 
 const DROID_SESSION_STATE_PATH = "/home/user/.factory/evolve-session.json";
 const PROVIDER_RUNTIME_BINDING_ENV = "EVOLVE_PROVIDER_RUNTIME_BINDING";
+const GEMINI_GATEWAY_AUTH_TYPE = "gemini-api-key";
 
 function providerRuntimeProviderForAgent(
   agentType: AgentType,
@@ -124,6 +125,16 @@ function providerRuntimeProviderForAgent(
       return "anthropic";
     case "codex":
       return "openai";
+    case "gemini":
+      return "gemini";
+    case "qwen":
+      return "dashscope";
+    case "kimi":
+      return "kimi";
+    case "opencode":
+      return "openrouter";
+    case "droid":
+      return "droid";
     default:
       return null;
   }
@@ -600,11 +611,17 @@ export class Agent {
       // Kimi Code gateway auth is written to ~/.kimi-code/config.toml per run.
       // The old KIMI_API_KEY/KIMI_BASE_URL envs are not read by Kimi Code.
     } else if (
+      !this.agentConfig.isDirectMode &&
+      providerRuntimeProviderForAgent(this.agentConfig.type)
+    ) {
+      // Managed gateway agents receive a session-scoped Dashboard model-proxy
+      // token below, not the account-level Evolve API key.
+    } else if (
       this.registry.skipApiKeyEnvInGateway &&
       !this.agentConfig.isDirectMode
     ) {
-      // Gateway mode for generated-settings agents (Droid): EVOLVE_API_KEY is
-      // injected below and referenced from the settings file, not provider env.
+      // Gateway mode for generated-settings agents (Droid): auth is injected
+      // below and referenced from the settings file, not provider env.
     } else if (this.registry.providerEnvMap && !this.agentConfig.isDirectMode) {
       // Multi-provider CLI in gateway mode (e.g., OpenCode): set ALL provider API keys
       // so any model prefix (anthropic/*, openai/*, google/*) can find its key
@@ -641,12 +658,13 @@ export class Agent {
       // Gateway mode: route through Evolve gateway
       const gatewayUrl = getGatewayUrl(this.registry.gatewayPath);
       const providerRuntime =
-        this.activeProviderRuntimeToken();
+        this.requireActiveProviderRuntimeToken();
 
       if (this.registry.gatewayConfigEnv) {
         // Session-level: only customer-id header. Per-run tag added in buildRunEnvs().
         envVars[this.registry.gatewayConfigEnv] = this.buildGatewayConfigJson({
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
+          ...this.providerRuntimeHeaderUpdates(),
         });
       } else {
         // Single-provider: set base URL env var
@@ -657,7 +675,12 @@ export class Agent {
       }
 
       if (providerRuntime) {
-        envVars[this.registry.apiKeyEnv] = providerRuntime.token;
+        if (this.shouldExposeProviderRuntimeTokenEnv()) {
+          envVars[this.registry.apiKeyEnv] = providerRuntime.token;
+        }
+        if (this.agentConfig.type === "gemini") {
+          envVars.GEMINI_DEFAULT_AUTH_TYPE = GEMINI_GATEWAY_AUTH_TYPE;
+        }
         if (this.registry.spendTrackingEnvs) {
           envVars[PROVIDER_RUNTIME_BINDING_ENV] =
             providerRuntime.bindingSecret;
@@ -873,7 +896,10 @@ export class Agent {
    * Source-verified: model.headers → provider.ts:1061 → llm.ts:221 → HTTP request.
    */
   private buildGatewayConfigJson(headers: Record<string, string>): string {
-    const gatewayUrl = getGatewayUrl(this.registry.gatewayPath);
+    const providerRuntime = this.requireActiveProviderRuntimeToken();
+    const baseUrl =
+      providerRuntime?.baseUrl ??
+      withOpenAiV1Path(getGatewayUrl(this.registry.gatewayPath));
     const selectedModel = this.resolveCommandModel(
       this.agentConfig.model || this.registry.defaultModel,
     );
@@ -914,8 +940,8 @@ export class Agent {
         npm: "@ai-sdk/openai-compatible",
         options: {
           ...existingOptions,
-          baseURL: `${gatewayUrl}/v1`,
-          apiKey: this.agentConfig.apiKey,
+          baseURL: baseUrl,
+          apiKey: providerRuntime?.token ?? this.agentConfig.apiKey,
         },
         models: {
           ...existingModels,
@@ -947,6 +973,18 @@ export class Agent {
     return provider && this.providerRuntimeToken?.provider === provider
       ? this.providerRuntimeToken
       : undefined;
+  }
+
+  private requireActiveProviderRuntimeToken():
+    ProviderRuntimeToken | undefined {
+    const provider = providerRuntimeProviderForAgent(this.agentConfig.type);
+    const token = this.activeProviderRuntimeToken();
+    if (!this.agentConfig.isDirectMode && provider && !token) {
+      throw new Error(
+        `${this.agentConfig.type} gateway mode requires a Dashboard runtime token before sandbox setup`,
+      );
+    }
+    return token;
   }
 
   private ensureSessionLogger(sandbox: SandboxInstance): void {
@@ -991,13 +1029,24 @@ export class Agent {
       : {};
   }
 
+  private shouldExposeProviderRuntimeTokenEnv(): boolean {
+    return (
+      this.agentConfig.type !== "kimi" &&
+      !this.registry.gatewayConfigEnv
+    );
+  }
+
   private buildProviderRuntimeProcessEnvs(): Record<string, string> {
     const providerRuntime = this.activeProviderRuntimeToken();
     if (!providerRuntime) return {};
-    const envs: Record<string, string> = {
-      [this.registry.apiKeyEnv]: providerRuntime.token,
-    };
-    if (this.registry.baseUrlEnv) {
+    const envs: Record<string, string> = {};
+    if (this.shouldExposeProviderRuntimeTokenEnv()) {
+      envs[this.registry.apiKeyEnv] = providerRuntime.token;
+    }
+    if (this.agentConfig.type === "gemini") {
+      envs.GEMINI_DEFAULT_AUTH_TYPE = GEMINI_GATEWAY_AUTH_TYPE;
+    }
+    if (this.registry.baseUrlEnv && this.shouldExposeProviderRuntimeTokenEnv()) {
       envs[this.registry.baseUrlEnv] = providerRuntime.baseUrl;
     }
     if (this.registry.spendTrackingEnvs) {
@@ -1060,6 +1109,7 @@ export class Agent {
         [this.registry.gatewayConfigEnv]: this.buildGatewayConfigJson({
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
           [LITELLM_TAGS_HEADER]: `${RUN_TAG_PREFIX}${runId}`,
+          ...this.providerRuntimeHeaderUpdates(),
         }),
       };
     }
@@ -1186,12 +1236,62 @@ export class Agent {
       );
       return;
     }
+    if (
+      this.agentConfig.type === "gemini" &&
+      !this.agentConfig.isDirectMode
+    ) {
+      await this.writeGeminiGatewayAuthSettings(sandbox);
+    }
     // Default: run setup command (e.g., "codex login --with-api-key")
     if (this.registry.setupCommand) {
       await sandbox.commands.run(this.registry.setupCommand, {
         timeoutMs: 30000,
       });
     }
+  }
+
+  private async writeGeminiGatewayAuthSettings(
+    sandbox: SandboxInstance,
+  ): Promise<void> {
+    const settingsDir = this.registry.mcpConfig.settingsDir.replace(
+      /^~/,
+      "/home/user",
+    );
+    const settingsPath = `${settingsDir}/${this.registry.mcpConfig.filename}`;
+
+    await sandbox.files.makeDir(settingsDir);
+
+    let settings: Record<string, unknown> = {};
+    try {
+      const existing = await sandbox.files.read(settingsPath);
+      if (typeof existing === "string" && existing.trim()) {
+        settings = JSON.parse(existing);
+      }
+    } catch (error) {
+      const message = (error as Error).message || "";
+      if (!/not found|no such file|does not exist/i.test(message)) {
+        throw error;
+      }
+    }
+
+    const security =
+      typeof settings.security === "object" && settings.security !== null
+        ? (settings.security as Record<string, unknown>)
+        : {};
+    const auth =
+      typeof security.auth === "object" && security.auth !== null
+        ? (security.auth as Record<string, unknown>)
+        : {};
+
+    settings.security = {
+      ...security,
+      auth: {
+        ...auth,
+        selectedType: GEMINI_GATEWAY_AUTH_TYPE,
+      },
+    };
+
+    await sandbox.files.write(settingsPath, JSON.stringify(settings, null, 2));
   }
 
   private async setupAgentPlugins(sandbox: SandboxInstance): Promise<void> {
@@ -1350,7 +1450,10 @@ export class Agent {
         sandbox,
         this.agentConfig.type as "qwen",
         this.registry.spendTrackingJsonConfig.headersPath,
-        { [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag },
+        {
+          [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
+          ...this.providerRuntimeHeaderUpdates(),
+        },
       );
     }
 
@@ -1652,6 +1755,7 @@ export class Agent {
         {
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
           [LITELLM_TAGS_HEADER]: `${RUN_TAG_PREFIX}${runId}`,
+          ...this.providerRuntimeHeaderUpdates(),
         },
       );
     }
@@ -1669,16 +1773,21 @@ export class Agent {
       !this.agentConfig.isDirectMode &&
       this.registry.spendTrackingTomlProvider
     ) {
+      const providerRuntime = this.requireActiveProviderRuntimeToken();
       await writeKimiSpendConfig(
         sandbox,
         this.registry.spendTrackingTomlProvider,
         {
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
           [LITELLM_TAGS_HEADER]: `${RUN_TAG_PREFIX}${runId}`,
+          ...this.providerRuntimeHeaderUpdates(),
         },
         {
-          baseUrl: withOpenAiV1Path(getGatewayUrl(this.registry.gatewayPath)),
-          apiKey: this.agentConfig.apiKey,
+          baseUrl: withOpenAiV1Path(
+            providerRuntime?.baseUrl ??
+              getGatewayUrl(this.registry.gatewayPath),
+          ),
+          apiKey: providerRuntime?.token ?? this.agentConfig.apiKey,
           model: this.resolveCommandModel(
             this.agentConfig.model || this.registry.defaultModel,
           ),
@@ -1693,6 +1802,7 @@ export class Agent {
     // Per-run Droid gateway settings: Droid custom models read extraHeaders from
     // settings at startup, so rewrite the Evolve-owned settings file each run.
     if (!this.agentConfig.isDirectMode && this.registry.droidGatewaySettings) {
+      const providerRuntime = this.requireActiveProviderRuntimeToken();
       await writeDroidGatewaySettings(
         sandbox,
         {
@@ -1700,12 +1810,13 @@ export class Agent {
           model: this.resolveCommandModel(
             this.agentConfig.model || this.registry.defaultModel,
           ),
-          baseUrl: `${getGatewayUrl()}/v1`,
-          apiKeyEnv: "EVOLVE_API_KEY",
+          baseUrl: withOpenAiV1Path(providerRuntime?.baseUrl ?? getGatewayUrl()),
+          apiKeyEnv: this.registry.apiKeyEnv,
         },
         {
           [LITELLM_CUSTOMER_ID_HEADER]: this.sessionTag,
           [LITELLM_TAGS_HEADER]: `${RUN_TAG_PREFIX}${runId}`,
+          ...this.providerRuntimeHeaderUpdates(),
         },
       );
     }

--- a/packages/sdk-ts/src/provider-secrets.ts
+++ b/packages/sdk-ts/src/provider-secrets.ts
@@ -1,7 +1,14 @@
 import { DEFAULT_DASHBOARD_URL } from "./constants";
 
 export type ProviderRuntimeToken = {
-  provider: "anthropic" | "openai";
+  provider:
+    | "anthropic"
+    | "openai"
+    | "gemini"
+    | "dashscope"
+    | "kimi"
+    | "openrouter"
+    | "droid";
   credentialMode: "provider_key" | "evolve_key";
   token: string;
   bindingSecret: string;
@@ -78,7 +85,15 @@ function isRuntimeTokenResponse(value: unknown): value is ProviderRuntimeToken {
   const record = value as Record<string, unknown>;
   return (
     record.enabled === true &&
-    (record.provider === "anthropic" || record.provider === "openai") &&
+    (
+      record.provider === "anthropic" ||
+      record.provider === "openai" ||
+      record.provider === "gemini" ||
+      record.provider === "dashscope" ||
+      record.provider === "kimi" ||
+      record.provider === "openrouter" ||
+      record.provider === "droid"
+    ) &&
     (record.credentialMode === "provider_key" ||
       record.credentialMode === "evolve_key") &&
     typeof record.token === "string" &&
@@ -94,7 +109,7 @@ function isRuntimeTokenResponse(value: unknown): value is ProviderRuntimeToken {
 
 export async function createProviderRuntimeToken(
   config: ProviderRuntimeTokenClientConfig,
-  input: { provider: "anthropic" | "openai"; sessionTag: string },
+  input: { provider: ProviderRuntimeToken["provider"]; sessionTag: string },
 ): Promise<ProviderRuntimeToken> {
   const result = await requestJson<unknown>(
     config,

--- a/packages/sdk-ts/src/registry.ts
+++ b/packages/sdk-ts/src/registry.ts
@@ -293,7 +293,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
     gatewayPath: "/gemini",
     buildCommand: ({ prompt, model, isResume }) => {
       const resumeFlag = isResume ? "--resume latest " : "";
-      return `gemini "${prompt}" ${resumeFlag}--model ${model} --yolo --output-format stream-json`;
+      return `gemini ${resumeFlag}--prompt ${shellSingleQuote(prompt)} --model ${model} --yolo --output-format stream-json`;
     },
   },
 

--- a/packages/sdk-ts/tests/unit/cost-api.test.ts
+++ b/packages/sdk-ts/tests/unit/cost-api.test.ts
@@ -54,6 +54,21 @@ function createAgent(): Agent {
   return new Agent(config as any, {});
 }
 
+function attachProviderRuntimeToken(
+  agent: Agent,
+  provider: string,
+  baseUrl = `https://dashboard.test/api/model-proxy/${provider}`,
+): void {
+  (agent as any).providerRuntimeToken = {
+    provider,
+    credentialMode: "evolve_key",
+    token: `evrt_${provider}_runtime_token`,
+    bindingSecret: `evrb_${provider}_binding_secret`,
+    baseUrl,
+    expiresAt: new Date(Date.now() + 60000).toISOString(),
+  };
+}
+
 async function testClaudeBuildCommandUsesReasoningEffort(): Promise<void> {
   console.log("\n[0] Claude buildCommand passes reasoning effort");
   const defaultAgent = createAgent();
@@ -396,6 +411,7 @@ async function testGeminiBuildRunEnvsCommaFormat(): Promise<void> {
     isDirectMode: false,
   };
   const agent = new Agent(config as any, {});
+  attachProviderRuntimeToken(agent, "gemini");
   (agent as any).sessionTag = "evolve-gemini-session";
 
   const envs = (agent as any).buildRunEnvs("run-gem-456") as Record<string, string> | undefined;
@@ -407,6 +423,9 @@ async function testGeminiBuildRunEnvsCommaFormat(): Promise<void> {
   assert(!headers.includes("\n"), "no newlines in comma format");
   assert(headers.includes("x-litellm-customer-id: evolve-gemini-session"), "has customer-id");
   assert(headers.includes("x-litellm-tags: run:run-gem-456"), "has run tag");
+  assert(headers.includes("x-evolve-provider-runtime-binding: evrb_gemini_binding_secret"), "has provider runtime binding header");
+  assertEqual(envs!.GEMINI_API_KEY, "evrt_gemini_runtime_token", "Gemini env uses runtime token");
+  assertEqual(envs!.GEMINI_DEFAULT_AUTH_TYPE, "gemini-api-key", "Gemini run env pins API-key auth");
 
   // Verify it does NOT set ANTHROPIC_CUSTOM_HEADERS
   assert(!envs?.ANTHROPIC_CUSTOM_HEADERS, "no ANTHROPIC_CUSTOM_HEADERS for gemini");
@@ -424,6 +443,7 @@ async function testGeminiCommaFormatPreservesUserHeaders(): Promise<void> {
       GEMINI_CLI_CUSTOM_HEADERS: "x-custom-one: foo, x-custom-two: bar",
     },
   });
+  attachProviderRuntimeToken(agent, "gemini");
   (agent as any).sessionTag = "evolve-gemini-session";
 
   const envs = (agent as any).buildRunEnvs("run-gem-789") as Record<string, string> | undefined;
@@ -450,6 +470,7 @@ async function testGeminiCommaFormatOverwritesTags(): Promise<void> {
       GEMINI_CLI_CUSTOM_HEADERS: "x-litellm-tags: project-acme, x-custom: keep",
     },
   });
+  attachProviderRuntimeToken(agent, "gemini");
   (agent as any).sessionTag = "evolve-gemini-session";
 
   const envs = (agent as any).buildRunEnvs("run-gem-overwrite") as Record<string, string> | undefined;
@@ -491,6 +512,7 @@ async function testGeminiRoundTripThroughParser(): Promise<void> {
 
   // Case 1: basic run envs (no user headers)
   const agent1 = new Agent(config as any, {});
+  attachProviderRuntimeToken(agent1, "gemini");
   (agent1 as any).sessionTag = "evolve-session-rt";
   const envs1 = (agent1 as any).buildRunEnvs("run-rt-001") as Record<string, string>;
   const parsed1 = parseAsGeminiCli(envs1.GEMINI_CLI_CUSTOM_HEADERS);
@@ -504,6 +526,7 @@ async function testGeminiRoundTripThroughParser(): Promise<void> {
       GEMINI_CLI_CUSTOM_HEADERS: "x-litellm-tags: user-tag, x-custom: val",
     },
   });
+  attachProviderRuntimeToken(agent2, "gemini");
   (agent2 as any).sessionTag = "evolve-session-rt2";
   const envs2 = (agent2 as any).buildRunEnvs("run-rt-002") as Record<string, string>;
   const parsed2 = parseAsGeminiCli(envs2.GEMINI_CLI_CUSTOM_HEADERS);
@@ -527,12 +550,74 @@ async function testGeminiBuildEnvVarsSessionLevel(): Promise<void> {
     isDirectMode: false,
   };
   const agent = new Agent(config as any, {});
+  attachProviderRuntimeToken(agent, "gemini");
   (agent as any).sessionTag = "evolve-gemini-session";
 
   const envs = (agent as any).buildEnvironmentVariables() as Record<string, string>;
   assert(!!envs.GEMINI_CLI_CUSTOM_HEADERS, "sets GEMINI_CLI_CUSTOM_HEADERS at session level");
   assert(envs.GEMINI_CLI_CUSTOM_HEADERS.includes("x-litellm-customer-id: evolve-gemini-session"), "session-level customer-id");
+  assert(envs.GEMINI_CLI_CUSTOM_HEADERS.includes("x-evolve-provider-runtime-binding: evrb_gemini_binding_secret"), "session-level provider runtime binding header");
+  assertEqual(envs.GEMINI_API_KEY, "evrt_gemini_runtime_token", "session env uses runtime token");
+  assertEqual(envs.GEMINI_DEFAULT_AUTH_TYPE, "gemini-api-key", "session env pins Gemini API-key auth");
+  assert(!("EVOLVE_API_KEY" in envs), "does not expose Evolve gateway key");
   assert(!envs.GEMINI_CLI_CUSTOM_HEADERS.includes("\n"), "comma format at session level");
+}
+
+async function testGeminiGatewayAuthSettings(): Promise<void> {
+  console.log("\n[16b] setupAgentAuth() pins Gemini gateway auth mode in settings.json");
+  const config = {
+    type: "gemini",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+  };
+  const agent = new Agent(config as any, {});
+  const existing = JSON.stringify({
+    mcpServers: { existing: { url: "https://mcp.example.com", type: "http" } },
+    security: { auth: { selectedType: "gateway", other: true } },
+  });
+  const { sandbox, written } = createFakeSandbox(existing);
+
+  await (agent as any).setupAgentAuth(sandbox);
+
+  assertEqual(written.length, 1, "writes Gemini settings file");
+  assertEqual(written[0].path, "/home/user/.gemini/settings.json", "writes .gemini/settings.json");
+  const settings = JSON.parse(written[0].content);
+  assertEqual(settings.security.auth.selectedType, "gemini-api-key", "pins selectedType to gemini-api-key");
+  assertEqual(settings.security.auth.other, true, "preserves existing auth fields");
+  assertEqual(settings.mcpServers.existing.url, "https://mcp.example.com", "preserves existing settings");
+
+  const missingWrites: { path: string; content: string }[] = [];
+  const missingSandbox = {
+    files: {
+      makeDir: async () => {},
+      read: async () => {
+        throw new Error("path '/home/user/.gemini/settings.json' does not exist");
+      },
+      write: async (path: string, content: string) => {
+        missingWrites.push({ path, content });
+      },
+    },
+  };
+  await (agent as any).setupAgentAuth(missingSandbox);
+  const missingSettings = JSON.parse(missingWrites[0].content);
+  assertEqual(missingSettings.security.auth.selectedType, "gemini-api-key", "handles E2B missing-file error text");
+}
+
+async function testGeminiBuildCommandUsesPromptFlag(): Promise<void> {
+  console.log("\n[16a] Gemini buildCommand() uses headless prompt mode");
+  const config = {
+    type: "gemini",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+    model: "gemini-2.5-flash-lite",
+  };
+  const agent = new Agent(config as any, {});
+
+  const command = (agent as any).buildCommand("say 'ok'") as string;
+  assert(command.includes("--prompt 'say '\\''ok'\\'''"), "uses --prompt with shell-escaped prompt");
+  assert(command.includes("--model gemini-2.5-flash-lite"), "passes selected Gemini model");
+  assert(command.includes("--output-format stream-json"), "keeps stream-json output");
+  assert(!command.startsWith('gemini "'), "does not use positional prompt interactive mode");
 }
 
 async function testGeminiDirectModeSkipsHeaders(): Promise<void> {
@@ -646,6 +731,25 @@ async function testQwenBuildRunEnvsReturnsUndefined(): Promise<void> {
   // Qwen has no customHeadersEnv and no spendTrackingEnvs, so buildRunEnvs returns undefined.
   // Per-run tracking is done via config file write in run(), not via env overrides.
   assertEqual(envs, undefined, "no env overrides for qwen (uses config file)");
+}
+
+async function testQwenGatewayEnvironmentUsesRuntimeToken(): Promise<void> {
+  console.log("\n[21b] Qwen gateway env uses DashScope runtime token");
+  const agent = new Agent({
+    type: "qwen",
+    apiKey: "test-gateway-key",
+    isDirectMode: false,
+  } as any, {});
+  attachProviderRuntimeToken(
+    agent,
+    "dashscope",
+    "https://dashboard.test/api/model-proxy/dashscope/v1",
+  );
+
+  const envs = (agent as any).buildEnvironmentVariables() as Record<string, string>;
+  assertEqual(envs.OPENAI_API_KEY, "evrt_dashscope_runtime_token", "Qwen env uses runtime token");
+  assertEqual(envs.OPENAI_BASE_URL, "https://dashboard.test/api/model-proxy/dashscope/v1", "Qwen base URL uses DashScope proxy");
+  assert(!("EVOLVE_API_KEY" in envs), "does not expose Evolve gateway key");
 }
 
 async function testQwenDirectModeSkipsHeaders(): Promise<void> {
@@ -881,8 +985,13 @@ async function testKimiEnvironmentVariables(): Promise<void> {
     apiKey: "test-gateway-key",
     isDirectMode: false,
   } as any, {});
+  attachProviderRuntimeToken(
+    gatewayAgent,
+    "kimi",
+    "https://dashboard.test/api/model-proxy/kimi/v1",
+  );
   const gatewayEnvs = (gatewayAgent as any).buildEnvironmentVariables() as Record<string, string>;
-  assertEqual(gatewayEnvs.EVOLVE_API_KEY, "test-gateway-key", "gateway exposes EVOLVE_API_KEY");
+  assert(!("EVOLVE_API_KEY" in gatewayEnvs), "gateway does not expose EVOLVE_API_KEY");
   assert(!("KIMI_API_KEY" in gatewayEnvs), "gateway omits old KIMI_API_KEY");
   assert(!("KIMI_BASE_URL" in gatewayEnvs), "gateway omits old KIMI_BASE_URL");
   assert(!("KIMI_MODEL_NAME" in gatewayEnvs), "gateway lets config.toml select model");
@@ -1104,6 +1213,11 @@ async function testOpenCodeBuildRunEnvsIncludesHeaders(): Promise<void> {
     isDirectMode: false,
   };
   const agent = new Agent(config as any, {});
+  attachProviderRuntimeToken(
+    agent,
+    "openrouter",
+    "https://dashboard.test/api/model-proxy/openrouter/v1",
+  );
   (agent as any).sessionTag = "evolve-opencode-session";
 
   const envs = (agent as any).buildRunEnvs("run-oc-001") as Record<string, string> | undefined;
@@ -1113,7 +1227,8 @@ async function testOpenCodeBuildRunEnvsIncludesHeaders(): Promise<void> {
   const parsed = JSON.parse(envs!.OPENCODE_CONFIG_CONTENT);
   const litellm = parsed?.provider?.litellm;
   assert(litellm !== undefined, "has litellm provider");
-  assert(litellm.options?.baseURL?.includes("/v1"), "has gateway base URL");
+  assertEqual(litellm.options?.baseURL, "https://dashboard.test/api/model-proxy/openrouter/v1", "has model proxy base URL");
+  assertEqual(litellm.options?.apiKey, "evrt_openrouter_runtime_token", "uses provider runtime token");
 
   // Find the model entry (key is the model string)
   const modelKeys = Object.keys(litellm.models || {});
@@ -1121,7 +1236,10 @@ async function testOpenCodeBuildRunEnvsIncludesHeaders(): Promise<void> {
   const modelEntry = litellm.models[modelKeys[0]];
   assertEqual(modelEntry.headers?.["x-litellm-customer-id"], "evolve-opencode-session", "session tag in headers");
   assert(modelEntry.headers?.["x-litellm-tags"]?.includes("run:run-oc-001"), "run tag in headers");
+  assertEqual(modelEntry.headers?.["x-evolve-provider-runtime-binding"], "evrb_openrouter_binding_secret", "binding header in model config");
   assertEqual(modelEntry.variants?.medium?.reasoningEffort, "medium", "default variant sets medium reasoning effort");
+  assert(!("EVOLVE_API_KEY" in envs!), "does not expose Evolve gateway key");
+  assert(!("OPENROUTER_API_KEY" in envs!), "does not expose OpenRouter env for config-file auth");
 }
 
 async function testOpenCodeBuildRunEnvsPerRunOverwrite(): Promise<void> {
@@ -1132,6 +1250,11 @@ async function testOpenCodeBuildRunEnvsPerRunOverwrite(): Promise<void> {
     isDirectMode: false,
   };
   const agent = new Agent(config as any, {});
+  attachProviderRuntimeToken(
+    agent,
+    "openrouter",
+    "https://dashboard.test/api/model-proxy/openrouter/v1",
+  );
   (agent as any).sessionTag = "evolve-opencode-session";
 
   const envs1 = (agent as any).buildRunEnvs("run-001") as Record<string, string>;
@@ -1185,6 +1308,11 @@ async function testOpenCodeMergesUserSecrets(): Promise<void> {
   const agent = new Agent(config as any, {
     secrets: { OPENCODE_CONFIG_CONTENT: JSON.stringify(userConfig) },
   });
+  attachProviderRuntimeToken(
+    agent,
+    "openrouter",
+    "https://dashboard.test/api/model-proxy/openrouter/v1",
+  );
   (agent as any).sessionTag = "evolve-oc-merge";
 
   const envs = (agent as any).buildRunEnvs("run-merge-001") as Record<string, string>;
@@ -1202,11 +1330,12 @@ async function testOpenCodeMergesUserSecrets(): Promise<void> {
   assertEqual(model.headers["x-user-header"], "keep-me", "user model header preserved");
   assertEqual(model.headers["x-litellm-customer-id"], "evolve-oc-merge", "spend session header injected");
   assert(model.headers["x-litellm-tags"]?.includes("run:run-merge-001"), "spend run tag injected");
+  assertEqual(model.headers["x-evolve-provider-runtime-binding"], "evrb_openrouter_binding_secret", "provider runtime binding injected");
   assertEqual(model.variants?.medium?.reasoningEffort, "medium", "reasoning variant injected");
 
-  // SDK overrides litellm options (gateway URL + API key)
-  assert(parsed.provider.litellm.options.baseURL.includes("/v1"), "gateway baseURL set");
-  assertEqual(parsed.provider.litellm.options.apiKey, "test-gateway-key", "gateway apiKey set");
+  // SDK overrides litellm options (proxy URL + runtime token)
+  assertEqual(parsed.provider.litellm.options.baseURL, "https://dashboard.test/api/model-proxy/openrouter/v1", "model proxy baseURL set");
+  assertEqual(parsed.provider.litellm.options.apiKey, "evrt_openrouter_runtime_token", "runtime token set");
 }
 
 async function testOpenCodeReasoningFlags(): Promise<void> {
@@ -1232,6 +1361,11 @@ async function testOpenCodeReasoningFlags(): Promise<void> {
     isDirectMode: false,
     reasoningEffort: "xhigh",
   } as any, {});
+  attachProviderRuntimeToken(
+    xhighAgent,
+    "openrouter",
+    "https://dashboard.test/api/model-proxy/openrouter/v1",
+  );
   const xhighCmd = (xhighAgent as any).buildCommand("hello") as string;
   assert(xhighCmd.includes("--variant max"), "xhigh maps to max variant");
   const envs = (xhighAgent as any).buildRunEnvs("run-opencode-xhigh") as Record<string, string>;
@@ -1245,17 +1379,22 @@ async function testOpenCodeReasoningFlags(): Promise<void> {
 // =============================================================================
 
 async function testDroidBuildEnvironmentVariablesGateway(): Promise<void> {
-  console.log("\n[34] Droid gateway env uses EVOLVE_API_KEY without FACTORY_API_KEY");
+  console.log("\n[34] Droid gateway env uses FACTORY_API_KEY runtime token without EVOLVE_API_KEY");
   const config = {
     type: "droid",
     apiKey: "test-gateway-key",
     isDirectMode: false,
   };
   const agent = new Agent(config as any, {});
+  attachProviderRuntimeToken(
+    agent,
+    "droid",
+    "https://dashboard.test/api/model-proxy/droid/v1",
+  );
 
   const envs = (agent as any).buildEnvironmentVariables() as Record<string, string>;
-  assertEqual(envs.EVOLVE_API_KEY, "test-gateway-key", "sets EVOLVE_API_KEY for settings env expansion");
-  assert(!("FACTORY_API_KEY" in envs), "does not set FACTORY_API_KEY in gateway mode");
+  assertEqual(envs.FACTORY_API_KEY, "evrt_droid_runtime_token", "sets FACTORY_API_KEY to runtime token for settings env expansion");
+  assert(!("EVOLVE_API_KEY" in envs), "does not expose EVOLVE_API_KEY in gateway mode");
 }
 
 async function testDroidBuildEnvironmentVariablesDirect(): Promise<void> {
@@ -1283,11 +1422,15 @@ async function testDroidWriteGatewaySettings(): Promise<void> {
       displayName: "Evolve Gateway",
       model: "gpt-5.5",
       baseUrl: "https://gateway.example.com/v1",
-      apiKeyEnv: "EVOLVE_API_KEY",
+      apiKeyEnv: "FACTORY_API_KEY",
       provider: "generic-chat-completion-api",
       maxOutputTokens: 32768,
     },
-    { "x-litellm-customer-id": "session-abc", "x-litellm-tags": "run:run-001" },
+    {
+      "x-litellm-customer-id": "session-abc",
+      "x-litellm-tags": "run:run-001",
+      "x-evolve-provider-runtime-binding": "evrb_droid_binding_secret",
+    },
   );
 
   assertEqual(written[0].path, "/home/user/.factory/evolve-settings.json", "writes dedicated Droid settings file");
@@ -1297,10 +1440,11 @@ async function testDroidWriteGatewaySettings(): Promise<void> {
   assertEqual(model.model, "gpt-5.5", "sets underlying gateway model");
   assertEqual(model.displayName, "Evolve Gateway", "sets stable custom model display name");
   assertEqual(model.baseUrl, "https://gateway.example.com/v1", "sets gateway base URL");
-  assertEqual(model.apiKey, "${EVOLVE_API_KEY}", "uses EVOLVE_API_KEY env reference");
+  assertEqual(model.apiKey, "${FACTORY_API_KEY}", "uses runtime token env reference");
   assertEqual(model.provider, "generic-chat-completion-api", "uses provider-compatible gateway calls");
   assertEqual(model.extraHeaders["x-litellm-customer-id"], "session-abc", "sets session header");
   assertEqual(model.extraHeaders["x-litellm-tags"], "run:run-001", "sets run header");
+  assertEqual(model.extraHeaders["x-evolve-provider-runtime-binding"], "evrb_droid_binding_secret", "sets provider runtime binding header");
 }
 
 async function testDroidBuildCommand(): Promise<void> {
@@ -1442,11 +1586,14 @@ async function main(): Promise<void> {
   await testGeminiCommaFormatPreservesUserHeaders();
   await testGeminiCommaFormatOverwritesTags();
   await testGeminiBuildEnvVarsSessionLevel();
+  await testGeminiBuildCommandUsesPromptFlag();
+  await testGeminiGatewayAuthSettings();
   await testGeminiDirectModeSkipsHeaders();
   await testGeminiRoundTripThroughParser();
   await testQwenWriteJsonSpendHeaders();
   await testQwenWriteJsonPreservesExistingConfig();
   await testQwenBuildRunEnvsReturnsUndefined();
+  await testQwenGatewayEnvironmentUsesRuntimeToken();
   await testQwenDirectModeSkipsHeaders();
   await testQwenBuildCommandUsesModelAliases();
   await testQwenWriteJsonOverwritesPreviousHeaders();

--- a/packages/sdk-ts/tests/unit/session-runtime.test.ts
+++ b/packages/sdk-ts/tests/unit/session-runtime.test.ts
@@ -66,11 +66,25 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function runtimeTokenResponse(provider: "anthropic" | "openai" = "anthropic") {
-  const baseUrl =
-    provider === "openai"
-      ? "https://dashboard.test/api/model-proxy/openai/v1"
-      : "https://dashboard.test/api/model-proxy/anthropic";
+type RuntimeProvider =
+  | "anthropic"
+  | "openai"
+  | "gemini"
+  | "dashscope"
+  | "kimi"
+  | "openrouter"
+  | "droid";
+
+function runtimeTokenResponse(provider: RuntimeProvider = "anthropic") {
+  const openAiCompatible = new Set<RuntimeProvider>([
+    "openai",
+    "dashscope",
+    "kimi",
+    "openrouter",
+    "droid",
+  ]);
+  const suffix = openAiCompatible.has(provider) ? "/v1" : "";
+  const baseUrl = `https://dashboard.test/api/model-proxy/${provider}${suffix}`;
   return {
     enabled: true,
     provider,
@@ -1620,6 +1634,153 @@ async function testCodexConnectedSessionReassertsDashboardProxy(): Promise<void>
   }
 }
 
+async function testManagedGatewayAgentsUseRuntimeProxyLifecycle(): Promise<void> {
+  console.log("\n[17] all managed gateway agents use runtime proxy lifecycle");
+  const previousFetch = globalThis.fetch;
+  const previousDashboardUrl = process.env.EVOLVE_DASHBOARD_URL;
+  process.env.EVOLVE_DASHBOARD_URL = "https://dashboard.test";
+
+  const createBodies: Array<{ provider?: RuntimeProvider; sessionTag?: string }> = [];
+  const bindBodies: Array<{ token?: string; sandboxId?: string }> = [];
+  const deletedTokens: string[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "POST"
+    ) {
+      const body = JSON.parse(String(init.body)) as {
+        provider?: RuntimeProvider;
+        sessionTag?: string;
+      };
+      if (!body.provider) throw new Error("missing provider");
+      createBodies.push(body);
+      return new Response(JSON.stringify(runtimeTokenResponse(body.provider)), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "PATCH"
+    ) {
+      bindBodies.push(JSON.parse(String(init.body)));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url === "https://dashboard.test/api/provider-secrets/runtime-token" &&
+      init?.method === "DELETE"
+    ) {
+      const body = JSON.parse(String(init.body));
+      deletedTokens.push(String(body.token));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url === "https://dashboard.test/api/sessions/ingest") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const cases: Array<{
+    agentType: string;
+    provider: RuntimeProvider;
+    tokenMustBeInSandboxConfig: boolean;
+  }> = [
+    { agentType: "claude", provider: "anthropic", tokenMustBeInSandboxConfig: true },
+    { agentType: "codex", provider: "openai", tokenMustBeInSandboxConfig: true },
+    { agentType: "gemini", provider: "gemini", tokenMustBeInSandboxConfig: true },
+    { agentType: "qwen", provider: "dashscope", tokenMustBeInSandboxConfig: true },
+    { agentType: "kimi", provider: "kimi", tokenMustBeInSandboxConfig: true },
+    { agentType: "opencode", provider: "openrouter", tokenMustBeInSandboxConfig: true },
+    { agentType: "droid", provider: "droid", tokenMustBeInSandboxConfig: true },
+  ];
+
+  try {
+    for (const item of cases) {
+      const startCreate = createBodies.length;
+      const startBind = bindBodies.length;
+      const commands = new MockCommands();
+      commands.mode = "instant";
+      const sandbox = new MockSandbox(`sess-managed-${item.agentType}`, commands);
+      const provider = new MockProvider(sandbox);
+      const kit = new Evolve()
+        .withAgent({ type: item.agentType, apiKey: "evolve-key" } as any)
+        .withSandbox(provider);
+
+      await kit.run({ prompt: "managed proxy lifecycle probe", timeoutMs: 10_000 });
+      await kit.kill();
+
+      const createBody = createBodies[startCreate];
+      const bindBody = bindBodies[startBind];
+      const envs = provider.createOptions?.envs ?? {};
+      const sandboxConfig = JSON.stringify({
+        envs,
+        runEnvs: commands.spawnOptions[0]?.envs ?? {},
+        writes: Object.fromEntries(sandbox.files.writes),
+      });
+      const expectedToken = `evrt_${item.provider}`;
+      const expectedBinding = `evrb_${item.provider}`;
+
+      assertEqual(
+        createBody?.provider,
+        item.provider,
+        `${item.agentType} requests ${item.provider} runtime token`,
+      );
+      assertEqual(
+        bindBody?.sandboxId,
+        sandbox.sandboxId,
+        `${item.agentType} binds runtime token to sandbox`,
+      );
+      assertEqual(
+        bindBody?.token,
+        expectedToken,
+        `${item.agentType} binds the minted runtime token`,
+      );
+      assert(
+        deletedTokens.includes(expectedToken),
+        `${item.agentType} kill() revokes runtime token`,
+      );
+      assert(
+        !Object.prototype.hasOwnProperty.call(envs, "EVOLVE_API_KEY"),
+        `${item.agentType} sandbox env omits EVOLVE_API_KEY`,
+      );
+      assert(
+        !sandboxConfig.includes("evolve-key"),
+        `${item.agentType} sandbox config does not contain raw Evolve API key`,
+      );
+      assert(
+        sandboxConfig.includes(expectedBinding),
+        `${item.agentType} sandbox config includes runtime binding secret`,
+      );
+      if (item.tokenMustBeInSandboxConfig) {
+        assert(
+          sandboxConfig.includes(expectedToken),
+          `${item.agentType} sandbox config uses provider runtime token`,
+        );
+      }
+      assert(
+        sandboxConfig.includes(`/api/model-proxy/${item.provider}`),
+        `${item.agentType} sandbox config routes through Dashboard model proxy`,
+      );
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousDashboardUrl === undefined)
+      delete process.env.EVOLVE_DASHBOARD_URL;
+    else process.env.EVOLVE_DASHBOARD_URL = previousDashboardUrl;
+  }
+}
+
 async function main(): Promise<void> {
   console.log("\n============================================================");
   console.log("Session Runtime Unit Tests");
@@ -1644,6 +1805,7 @@ async function main(): Promise<void> {
     await testSetSessionRevokesProviderRuntimeToken();
     await testCodexProviderRuntimeRoutesThroughDashboardProxy();
     await testCodexConnectedSessionReassertsDashboardProxy();
+    await testManagedGatewayAgentsUseRuntimeProxyLifecycle();
   } catch (error) {
     failed++;
     console.log(


### PR DESCRIPTION
## Summary
- extend managed runtime-token proxy support to Gemini, Qwen, Kimi, OpenCode, and Droid
- keep raw EVOLVE_API_KEY out of managed agent sandboxes
- pin Gemini API-key auth mode and use headless prompt execution
- add all-agent lifecycle coverage for runtime token create/bind/kill

## Verification
- npm run test:ts:unit
- live prod sweep: 7/7 managed agents completed with raw EVOLVE_API_KEY absent

## Notes
- checkpointing behavior is unchanged
