### PR TITLE
Update managed provider key docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Get your Evolve API key at [dashboard.evolvingmachines.ai](https://dashboard.evo
 EVOLVE_API_KEY=sk-...
 ```
 
-To bring your own provider billing while keeping gateway features, save Anthropic/OpenAI keys in Dashboard → Secrets → BYO Provider Keys. Your app still uses only `EVOLVE_API_KEY`.
+To bring your own provider billing while keeping gateway features, save supported provider keys (Anthropic, OpenAI, Gemini, DashScope, Kimi, OpenRouter, or Droid/Factory) in Dashboard → Secrets → BYO Provider Keys. Your app still uses only `EVOLVE_API_KEY`.
 
 For fully local direct provider keys:
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Get your Evolve API key at [dashboard.evolvingmachines.ai](https://dashboard.evo
 EVOLVE_API_KEY=sk-...
 ```
 
-To bring your own provider billing while keeping gateway features, save Anthropic/OpenAI keys in Dashboard → Secrets → BYO Provider Keys. Your app still uses only `EVOLVE_API_KEY`.
+To bring your own provider billing while keeping gateway features, save supported provider keys (Anthropic, OpenAI, Gemini, DashScope, Kimi, OpenRouter, or Droid/Factory) in Dashboard → Secrets → BYO Provider Keys. Your app still uses only `EVOLVE_API_KEY`.
 
 For fully local direct provider keys:
 ```bash

--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -138,11 +138,13 @@ await evolve.run(prompt='Hello')
 
 ### Managed BYO Provider Keys
 
-Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+Use this when you want supported provider usage billed to your provider account while keeping gateway features.
 
 1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
 2. Keep `EVOLVE_API_KEY` in your app.
-3. Run Claude or Codex normally.
+3. Run any supported agent normally.
+
+Supported managed provider routes include Anthropic, OpenAI, Gemini, DashScope, Kimi, OpenRouter, and Droid/Factory.
 
 When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
 

--- a/docs/typescript/01-getting-started.md
+++ b/docs/typescript/01-getting-started.md
@@ -153,11 +153,13 @@ await evolve.run({ prompt: "Hello" });
 
 ### Managed BYO Provider Keys
 
-Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+Use this when you want supported provider usage billed to your provider account while keeping gateway features.
 
 1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
 2. Keep `EVOLVE_API_KEY` in your app.
-3. Run Claude or Codex normally.
+3. Run any supported agent normally.
+
+Supported managed provider routes include Anthropic, OpenAI, Gemini, DashScope, Kimi, OpenRouter, and Droid/Factory.
 
 When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
 

--- a/skills/evolve/references/python/01-getting-started.md
+++ b/skills/evolve/references/python/01-getting-started.md
@@ -138,11 +138,13 @@ await evolve.run(prompt='Hello')
 
 ### Managed BYO Provider Keys
 
-Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+Use this when you want supported provider usage billed to your provider account while keeping gateway features.
 
 1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
 2. Keep `EVOLVE_API_KEY` in your app.
-3. Run Claude or Codex normally.
+3. Run any supported agent normally.
+
+Supported managed provider routes include Anthropic, OpenAI, Gemini, DashScope, Kimi, OpenRouter, and Droid/Factory.
 
 When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
 

--- a/skills/evolve/references/typescript/01-getting-started.md
+++ b/skills/evolve/references/typescript/01-getting-started.md
@@ -153,11 +153,13 @@ await evolve.run({ prompt: "Hello" });
 
 ### Managed BYO Provider Keys
 
-Use this when you want Anthropic or OpenAI usage billed to your provider account while keeping gateway features.
+Use this when you want supported provider usage billed to your provider account while keeping gateway features.
 
 1. Save your provider key in Dashboard → Secrets → BYO Provider Keys.
 2. Keep `EVOLVE_API_KEY` in your app.
-3. Run Claude or Codex normally.
+3. Run any supported agent normally.
+
+Supported managed provider routes include Anthropic, OpenAI, Gemini, DashScope, Kimi, OpenRouter, and Droid/Factory.
 
 When enabled, Evolve routes supported provider calls through a sandbox-bound `evrt_...` runtime token. The SDK does not receive the raw provider key, and the sandbox does not receive `EVOLVE_API_KEY` for that provider route. If no managed key is enabled for that provider, gateway mode falls back to Evolve-managed model routing.
 


### PR DESCRIPTION
## Summary
- replace Claude/Codex-only Managed BYO Provider Keys wording with supported-provider wording
- list current managed provider routes across root docs, TS docs, Python docs, and skill mirrors

## Verification
- `rg -n "Anthropic/OpenAI|Anthropic or OpenAI|Run Claude or Codex|Claude or Codex|Claude/Codex" README.md docs skills/evolve/references packages/sdk-py/README.md -S` returned no matches

## Notes
- docs-only
