### PR TITLE
feat: harbor-job-upload skill — ship only what ingest stores, sized for the analyzer

### DIFF
--- a/.claude/skills/harbor-job-upload/ISSUES.md
+++ b/.claude/skills/harbor-job-upload/ISSUES.md
@@ -1,0 +1,228 @@
+# Why this skill exists
+
+Every problem below was hit while porting the Terminal-Bench 4 leaderboard
+corpus (3,300 trials across 10 rows) onto the platform. They are recorded here
+because **all but one of them fail silently** — the upload returns a job id, the
+job lists its trials, and the damage only surfaces later when an analysis reads
+a trace that is empty, truncated, or missing.
+
+Each entry states the symptom first, because that is what you will actually
+have in front of you.
+
+---
+
+## 1. The upload dies with no error and no job
+
+**Symptom.** `evolve upload` on a 4.41 GB job directory produced a zero-byte
+log, no error, and no job.
+
+**What was believed at the time.** That the SDK tarred the whole directory into
+one in-memory Node buffer and was OOM-killed. The corpus was pruned by hand from
+4.41 GB to 1.52 GB to get under it.
+
+**What is actually true now.** That diagnosis is **stale**. The SDK streams:
+`hosted/tar.ts` packs entries from disk into a segmented gzip writer that holds
+one block at a time, and `hosted/upload.ts` posts the archive over raw
+`node:http` with per-chunk backpressure — measured at ~2 MB resident for a
+300 MB file. The module header records the incident it was written to fix: a
+7.7 GB corpus once cost ~10x its size in RSS and crashed the machine.
+
+**The real constraint is server-side.** `413 upload_too_large` against a
+published cap. Nothing on the client bounds the archive.
+
+**Fix.** None needed in the client. What was needed was knowing where the cap
+actually lives, which is [references/limits.md](references/limits.md).
+
+---
+
+## 2. Trials upload "successfully" and carry an empty trace
+
+**Symptom.** `evolve upload` returns a job id. `evolve job trials` lists every
+trial. The trace viewer shows nothing.
+
+**Cause.** The trajectory was stored gzipped as `agent/trajectory.json.gz`.
+Ingest maps a fixed set of per-trial paths to native slots, and
+`agent/trajectory.json.gz` matches none of them, so it is unpacked and
+discarded. The trial is otherwise valid, so nothing errors.
+
+**How common.** 12 such files had already shipped into previously built job
+directories before this was noticed, and **all 20 trials** in the corpus used to
+validate this skill were gzipped.
+
+**Fix.** `compress_job.py` accepts a `.gz` twin for any ingest slot and writes
+the decompressed bytes. `check_job.py` treats a surviving `.gz` under `agent/`
+as an error, not a warning.
+
+---
+
+## 3. Some files never arrive, and nothing says so
+
+**Symptom.** A job directory assembled by symlinking large files uploads with
+`result.json` and essentially nothing else.
+
+**Cause.** The packer skips symlinks outright — it neither follows them nor
+emits them (`tar.ts`, `listFiles`). A tree built by a script that symlinks its
+large files ships as a shell.
+
+**Fix.** Everything is hard-linked (`os.link`, free on one volume, with a
+`copy2` fallback across devices) or written outright; source symlinks are
+resolved to their target before linking. `check_job.py` flags any symlink under
+a trial.
+
+---
+
+## 4. A whole trial vanishes from the corpus
+
+**Symptom.** A row's trial count silently drops. In one case 20 of a row's
+trials disappeared between download and upload.
+
+**Cause.** The hub sanitises some numeric fields to a bare `[REDACTED]` token
+where a number belongs. That is not valid JSON. Any pipeline that reads
+trajectories inside a broad `try/except` drops the trial rather than crashing on
+it. Roughly 11% of trials in this corpus carry one.
+
+**Fix.** Every JSON read in this skill goes through a repairing loader that
+rewrites `: [REDACTED]` to `: null` before parsing. `check_job.py` reports an
+unparseable trajectory as an error and names `[REDACTED]` as the likely cause.
+
+---
+
+## 5. The trace is mangled part-way through analysis
+
+**Symptom.** The analyzer reasons correctly about the start of a trajectory and
+then behaves as if the rest does not exist.
+
+**Cause.** **The upload cap and the analysis cap are different numbers.** A file
+is refused at 32 MiB by ingest, but the analyzer head-truncates every input at
+**24 MiB** with only an in-band marker. A 30 MiB trajectory therefore uploads
+clean, stores clean, and is quietly cut when analyzed. Nothing errors at any
+stage.
+
+This is the single most expensive gap on the path, because the artifact looks
+healthy right up until the verdict is wrong.
+
+**Fix.** `compress_job.py` defaults `--target-bytes` to the 24 MiB analyzer
+ceiling, not the 32 MiB upload cap. `check_job.py` warns on any file in the gap
+between the two and says explicitly what will happen to it.
+
+---
+
+## 6. Compression shrank the readable copy and left the duplicate
+
+**Symptom.** Trajectories that had been "compressed" were still enormous, and
+the observation text a reader needed had been truncated while the file stayed
+large.
+
+**Cause.** In ATIF trajectories from harnesses that emit it,
+`observation.results[].extra` restates the observation's own `content`, often
+twice (`tool_result_metadata.tool_use_result.stdout` and
+`raw_tool_result.content`), and `tool_calls[].extra.raw_arguments` restates
+`arguments`. The previous clipper truncated only `results[].content` — so it
+cut the copy a human or analyzer reads and left the byte-identical duplicate at
+full size.
+
+**Fix.** A deduplication pass runs **before** any truncation, and removes a
+string only when it is a **substring of the content beside it** — the proof it
+carries nothing new. An unfamiliar harness therefore cannot lose data here.
+
+**Measured on real rows** (5 trials each), which also shows why this must be
+substring-proven rather than assumed:
+
+| Row | Harness | Removed |
+|---|---|---|
+| `09-claude-code__sonnet-5` | claude-code | **48.0%** |
+| `07-grok-build__grok-4-6` | grok-build | 2.3% |
+| `09-grok-build__grok-4-5` | grok-build | 2.5% |
+| `08-codex__gpt-5-6-luna` | codex | 0.9% |
+
+The duplication is harness-shaped. **A codex row that suddenly shrinks a lot
+means the deduplicator is deleting something real** — treat it as a bug.
+
+Losslessness is asserted, not assumed: across all 20 trials, every step
+`message`, every tool call, and every observation `content` is byte-identical
+before and after, while the claude-code row still lost 48% of its bytes.
+
+---
+
+## 7. Truncation destroyed the evidence the rubric needed
+
+**Symptom.** A uniformly truncated trace loses the end of the run, which is
+exactly where a failure is adjudicated.
+
+**Cause.** Flat truncation treats the first command and the final verification
+as equally important. They are not: 703 of 738 failures in this corpus are
+`agent_declared_done`, so the question a rubric asks is *why did it believe it
+was done* — and the answer is in the last few observations.
+
+**Fix.** Clipping is per-observation head+tail down a budget ladder
+(20k → 400 chars), the last 8 observations get 4x budget, and a step's `message`
+is never touched and no step is ever dropped. Verified at a deliberately harsh
+1 MiB budget: the ladder settled at the 8,000-char rung, no head observation
+exceeded its budget, all 8 tail observations came through untouched, and the
+final observation ended byte-identically.
+
+---
+
+## 8. There was no way to know before shipping
+
+**Symptom.** Every constraint above was discovered after a long upload, or after
+an analysis produced a bad verdict.
+
+**Cause.** `evolve upload` takes one flag (`-d/--dataset`). No dry run, no
+exclude, no size preflight. The published caps are also not static — the dataset
+door's source default is 512 MiB and production serves 8 GiB, so any tool that
+hardcodes them eventually lies.
+
+**Fix.** `check_job.py` runs every check before a byte moves. Archive size is
+**measured** — the directory is tarred and gzipped to a temp file exactly as the
+SDK does — because the compression ratio ranges from 1.0x on blobs to 5.0x on
+JSON and an estimate is worthless near a cap. Caps are read live from
+`GET /api/meta`, and the output states whether they came from the server or from
+frozen defaults.
+
+---
+
+## What was verified, and what was not
+
+Built four jobs (the bottom four TB4 leaderboard rows, 5 trials each, 20 trials
+total) and uploaded them.
+
+Confirmed:
+
+- All 20 trials landed with **non-empty traces**, 68–630 events each, scaling
+  consistently with local step counts per harness.
+- All four job dirs passed every cap check, with caps read live from the API.
+- Compression is byte-lossless on every analyzer-visible field across all 20.
+- The truncation ladder and its tail protection behave as described.
+- Three analyses completed and produced substantive, trajectory-grounded
+  verdicts (13 rubric checks each) citing detail from deep inside compressed
+  traces — `no_harness_error=pass` on all three.
+
+Not confirmed:
+
+- 7 of 10 analysis runs failed with `phase: stopped — the analyzer box was
+  killed`. This is **infrastructure, not input**: the failures land in a
+  6-second window spanning an unrelated job, and across 200 recent
+  platform-wide analyses (118 failed) **not one failure of any kind was an
+  inputs failure**. The compressed trees were never rejected. But the full
+  5-of-5 analysis pass has not been observed.
+
+---
+
+## Open follow-ups, deliberately not in this change
+
+- **Raising the job archive cap.** `EVAL_MAX_JOB_UPLOAD_BYTES` on the web task.
+  This is a proven path, not a theoretical one — the dataset door has the same
+  512 MiB source default and serves 8 GiB in production. It must move together
+  with the hardcoded 2 GiB decompressed cap, which otherwise binds first at
+  around 1.1 GiB compressed.
+- **A resumable job upload.** `datasets().publish()` passes a resumable
+  threshold and gets a chunked door that resumes from the last acknowledged
+  chunk; `jobs().upload()` does not, so a link that drops at 90% restarts from
+  zero. Wiring it is a one-line client change **and a server door that does not
+  exist yet for jobs** — it would not raise the cap, only remove the
+  restart-from-zero failure. Its own PR.
+- **An `exclude` hook in the packer.** `SKIP` in `tar.ts` is a module-level
+  three-name constant with no seam. An exclude option on `uploadDirectory` would
+  let callers drop `artifacts/**` at pack time instead of pre-pruning the tree,
+  which is what this skill does by hand.

--- a/.claude/skills/harbor-job-upload/SKILL.md
+++ b/.claude/skills/harbor-job-upload/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: harbor-job-upload
+description: "Prepare and upload a Harbor job directory to the Evolve platform with `evolve upload`. Use when a job directory is too large to upload, when an upload is refused (413 upload_too_large, 422 invalid_trial, 400 not_a_job_dir, 400 invalid_archive, 409 job_already_uploaded), when trials upload successfully but their traces are empty or truncated in the trace viewer or analyzer, or when compressing / pruning / shrinking agent trajectories before shipping a trial corpus."
+---
+
+# Uploading a Harbor job to Evolve
+
+`evolve upload <job_dir> -d <dataset>` ports a Harbor job to the platform;
+`evolve analyze <job-id> -r <rubric>` then runs a rubric server-side. Uploading
+is where corpora go wrong, and **the expensive failures are silent** — a job
+that lands with an empty trace looks exactly like a job that worked.
+
+## The one thing to get right
+
+Ship **only what ingest stores**, and size the trajectory against the
+**analyzer's** ceiling, not the upload cap.
+
+The upload cap and the analysis cap are different numbers, and the gap between
+them is a trap: a 30 MiB trajectory is under the 32 MiB per-file upload cap, so
+it uploads clean — and is then **head-truncated at 24 MiB when analyzed**, with
+only an in-band marker to say so. Nothing errors. Target 24 MiB.
+
+See [references/ingest-contract.md](references/ingest-contract.md) for the exact
+keep/drop map and [references/limits.md](references/limits.md) for every cap and
+which of them can be raised. [ISSUES.md](ISSUES.md) records each failure this
+skill exists to prevent, how it was diagnosed, and what was measured.
+
+## Workflow
+
+```bash
+S=<this-skill>/scripts
+
+# 1. Build a compressed job dir from trial dirs. --dry-run reports and writes nothing.
+python3 $S/compress_job.py --out jobs/my-job --trial path/to/trial1 --trial path/to/trial2 \
+        --report out/compress_my-job.json --dry-run
+
+# 2. Build it for real, then check it against every cap before shipping.
+python3 $S/compress_job.py --out jobs/my-job --from-list trials.txt --report out/compress_my-job.json
+python3 $S/check_job.py jobs/my-job          # exit 1 on any violation
+
+# 3. Upload, then verify the trace actually landed.
+evolve upload jobs/my-job -d my-dataset@1.0 --json
+evolve trial trace <trial-id> --limit 1000 | head
+```
+
+**Never skip step 3's trace check.** `evolve upload` returning a job id proves
+the archive was accepted, not that the trials carry a readable trace.
+
+## The silent failures, and what handles each
+
+| Symptom | Cause | Handled by |
+|---|---|---|
+| Trial uploads, trace is empty | `agent/trajectory.json.gz` — the `.gz` name maps to no ingest slot | `compress_job.py` decompresses on the way in; `check_job.py` refuses any surviving `.gz` |
+| Some trials missing entirely, no error | a symlinked file — the packer skips symlinks and never follows them | everything is hard-linked or written; `check_job.py` flags symlinks |
+| A whole trial vanishes from the corpus | a `[REDACTED]` token where a number belongs — not valid JSON, so a broad `except` drops it | repaired on every read |
+| Trace is mangled mid-way through analysis | trajectory between 24 and 32 MiB — accepted, then head-truncated by the analyzer | the default `--target-bytes` is the 24 MiB analyzer ceiling |
+| `413 upload_too_large` | archive over the published cap | chunk the trials across several jobs; see limits.md before asking for a raise |
+| `409 job_already_uploaded` | the job id is content-addressed over the trial set; re-uploading the same trials is refused | change the trial set, or pass `--job-id-seed` |
+
+## How the trajectory shrinks
+
+Three transforms, in order. The first two are **lossless** for anything that
+reads the trace and run unconditionally; the third is the only lossy one and
+runs only if the file is still over budget.
+
+1. **Deduplicate.** `observation.results[].extra` restates the observation's own
+   `content`, and `tool_calls[].extra.raw_arguments` restates `arguments`. A
+   string is removed only when it is a **substring of the content beside it** —
+   that is the proof it carries nothing new, so an unfamiliar harness cannot
+   lose data here.
+2. **Strip base64.** Inline image payloads, replaced by a byte count.
+3. **Clip observations.** Per-observation head+tail truncation down a budget
+   ladder, with the last 8 observations at 4x budget. It never touches a step's
+   `message` and never drops a step, so the reasoning and the action sequence
+   survive intact; a failure's evidence is concentrated in the final
+   verification command and its output, which is why the tail is protected.
+
+**Expect wildly different yields by harness.** The duplication in step 1 is
+claude-code-shaped. Measured on real TB4 rows: **48% removed** on a
+claude-code row, **~1%** on a codex row, **~2-5%** on grok-build. A codex row
+that suddenly shrinks a lot means the deduplicator is removing something real —
+treat it as a bug, not a win.
+
+## Reading the report
+
+`--report` writes per-trial numbers: bytes in and out, how many duplicate
+strings and base64 fields went, which ladder rung fired, what was dropped and
+why. Two fields matter most:
+
+- `lossy_trials` — the trials where clipping fired. Empty is the good case.
+- `reduction_vs_source_dir_pct` — against the **whole** trial directory with
+  `.gz` members counted decompressed. Content against content: measuring a
+  gzipped input against plain-JSON output makes decompressing a trajectory look
+  like a 300% regression.
+
+## Ordering constraint
+
+If you also blind a job (stripping verdicts for an unbiased analysis), **compress
+first, then blind.** A blinding pass that hard-links trajectories through will
+carry an uncompressed trace into the blind job.

--- a/.claude/skills/harbor-job-upload/references/ingest-contract.md
+++ b/.claude/skills/harbor-job-upload/references/ingest-contract.md
@@ -1,0 +1,77 @@
+# What the platform actually stores, and what it reads
+
+Two different questions with two different answers, and conflating them is how
+job directories end up 50x larger than they need to be.
+
+1. **Ingest** reads the uploaded archive and stores a fixed set of per-trial
+   files. Anything outside that set is uploaded, unpacked, and discarded.
+2. **The analyzer never reads your archive at all.** It rebuilds a tree from the
+   database and the trace store. So a file that ingest does not store cannot
+   reach analysis no matter how it is named.
+
+Verify both against the server's own source before trusting this page:
+`lib/evaluations/job-upload.ts` (the ingest, and its deviation ledger in the
+module header) and `lib/evaluations/worker/analysis-inputs.ts` (the analyzer's
+input tree).
+
+## Per-trial: what ingest stores
+
+| Path | Notes |
+|---|---|
+| `result.json` | **Required.** A record file, capped at 8 MiB. Carries the verdict, `agent_info`, and `config.agent.{name,model_name}`. |
+| `config.json` | **Required.** Record file, same 8 MiB cap. |
+| `agent/trajectory.json` | The trace. The one file worth compressing. |
+| `agent/stdout.log` | Skipped if empty. |
+| `agent/stderr.log` | Skipped if empty. |
+| `verifier/test-stdout.txt` | Skipped if empty. |
+| `verifier/reward.txt` | Two bytes. Free. |
+| `agent/sessions/**` | Ingested **complete**, under a 128 MiB per-trial cap. Served as the native session home by the trace viewer. The **analyzer never reads it** — dead weight for a rubric run, which is why it is opt-in behind `--keep-sessions`. |
+| `agent/<harness>.txt` | The stdout slot's **fallback**, used only when `agent/stdout.log` is absent. Hub archives carry these (`claude-code.txt`, `codex.txt`). |
+
+The job directory also needs `result.json` **and** `config.json` at its **root**.
+A job dir is not merely a directory of trial dirs; the client refuses before
+packing if either is missing, with the same sentence Harbor's CLI uses.
+
+The root `result.json`'s `id` is the server's **dedup key**. Content-address it
+over the trial set — keying it on a label alone lets a smoke test collide with
+the real job, and lets a re-run create a twin instead of being refused.
+
+## Per-trial: what is never ingested
+
+`artifacts/**` · `steps/**` · `lock.json` · `trial.log` ·
+`verifier/reward.json` · `verifier/ctrf.json` · `evolve.json` ·
+any prior `analysis.json` / `analysis.md` · any other file under `agent/`
+mapping to no native slot.
+
+Two of these are worth calling out:
+
+- **`artifacts/`** is agent *output* — model weights, database dumps, tarballs.
+  On a raw Harbor corpus it is routinely the majority of the bytes and it
+  carries no reasoning signal. Dropping it is free.
+- **A prior analysis is never imported.** This is deliberate: the analyzer must
+  not read its own previous verdict.
+
+## What the analyzer reads
+
+Rebuilt server-side from the database, not from your archive:
+
+`result.json` (synthesized lean, from DB rows) · `exception.txt` (only when the
+trial recorded an exception) · `agent/trajectory.json` · `agent/stdout.log` ·
+`agent/stderr.log` · `verifier/test-stdout.txt` · plus the task's byte-sacred
+content from the retained dataset package.
+
+**Every one of those is head-truncated at 24 MiB** with an in-band marker. It is
+not a refusal, so nothing tells you it happened except the marker inside the
+file. This is the number to compress against.
+
+If the task content cannot be resolved from a dataset package, analysis still
+runs — it takes the "task definition is not available" branch, which is Harbor's
+own fallback. Passing `-d <dataset>@<version>` at upload is what avoids that.
+
+## The label leak
+
+`verifier/test-stdout.txt` is ingested and handed to the analyzer whole, and
+`result.json` carries `verifier_result` and the score. If you are inducing or
+validating a rubric, the analyzer is **not blind** — its length alone is a strong
+predictor of the verdict. Strip the verdict fields and drop `verifier/` for a
+blind run, and do that **after** compression, not before.

--- a/.claude/skills/harbor-job-upload/references/limits.md
+++ b/.claude/skills/harbor-job-upload/references/limits.md
@@ -1,0 +1,101 @@
+# Every cap on the job-upload path
+
+## Read them live, do not trust this page
+
+The caps move. The dataset door's source default is 512 MiB and production
+serves **8 GiB** — raised by an environment variable with no client change. Any
+document that hardcodes these numbers will eventually lie.
+
+```bash
+curl -s -H "Authorization: Bearer $EVOLVE_API_KEY" \
+  https://dashboard.evolvingmachines.ai/api/meta | jq .limits.uploads
+```
+
+`check_job.py` does this for you and says which source it used; `--offline`
+falls back to frozen defaults and labels them as such.
+
+## Published caps (`limits.uploads`)
+
+Values observed 2026-09-02. Treat as a snapshot.
+
+| Field | Value | Refusal |
+|---|---|---|
+| `job_archive_bytes` | 512 MiB | `413 upload_too_large` |
+| `job_trials` | 2000 | `400 job_too_large` |
+| `job_trial_file_bytes` | 32 MiB | `422 invalid_trial` |
+| `job_trial_session_bytes` | 128 MiB | `422 invalid_trial` |
+| `dataset_archive_bytes` | 8 GiB | `413 import_too_large` |
+
+## Unpublished server caps
+
+Not in `/api/meta`; found by reading the ingest.
+
+| Cap | Value | Refusal | Raisable |
+|---|---|---|---|
+| Decompressed footprint | 2 GiB | `413 upload_too_large` | No — hardcoded |
+| Tar entries | 200,000 | `400 invalid_archive` | No |
+| Record file (`result.json`/`config.json`) | 8 MiB | `400 not_a_job_dir` | No |
+
+**The 2 GiB decompressed cap is the real ceiling.** At the ~1.8x ratio JSON
+corpora compress at, a 512 MiB archive expands to roughly 920 MB — comfortably
+under. But raising the compressed cap past about **1.1 GiB** buys nothing,
+because the decompressed cap bites first. The two have to move together.
+
+## Analyzer ceilings — truncate, never refuse
+
+| Cap | Value | Behaviour |
+|---|---|---|
+| Per input file | 24 MiB | head-truncated with an in-band marker |
+| Whole input tree | 96 MiB | typed inputs failure |
+
+**This is the gap that catches people.** The per-file upload cap (32 MiB) sits
+*above* the analyzer's ceiling (24 MiB) deliberately, so nothing accepted is
+outright unusable — but a trajectory in between is stored whole and then cut at
+analysis time. Compress to 24 MiB, not 32.
+
+## Raising the job archive cap
+
+Ranked by cost:
+
+1. **Set `EVAL_MAX_JOB_UPLOAD_BYTES` on the web task.** An environment variable,
+   no code deploy. This is exactly what was already done for the dataset door,
+   which is why it serves 8 GiB against the same 512 MiB source default — so the
+   mechanism is proven in production, not theoretical. Ceiling: ~1.1 GiB before
+   the decompressed cap.
+2. **Move `MAX_EXTRACTED_BYTES` (2 GiB) with it** for anything beyond that. A
+   code change, and it needs care: ingest runs **synchronously inside one
+   request** on a small web task under a 900 s load-balancer idle timeout. The
+   trial-count cap exists for the same reason. Raising the byte caps without
+   addressing that trades a clean 413 for a timeout partway through ingest.
+3. **Just chunk the job.** Several jobs of N trials each upload fine and analyze
+   independently. This needs nothing from the platform and is usually the right
+   answer.
+
+## Client-side: not the bottleneck
+
+Worth knowing, because it used to be and the folklore persists.
+
+The SDK **streams**. The archive is tarred and gzipped to a temp file, then sent
+over raw `node:http` with per-chunk backpressure — a few MB resident regardless
+of archive size. The older collect-everything-into-one-Buffer path is gone; it
+is what the streaming rewrite was written to fix. If you read a note anywhere
+saying job uploads are buffered in memory as one request body, it is stale.
+
+Two client-side details that still matter:
+
+- **A 600 s inactivity timeout**, re-armed on every flushed chunk. It measures
+  stalls, not total duration.
+- **Job upload is one POST.** The resumable chunked door exists in the SDK but
+  only the dataset publish surface passes the threshold that switches to it, so
+  a job upload that drops at 90% restarts from zero. Wiring it into job upload
+  would not raise any cap; it would remove that failure mode.
+
+## Reading a refusal
+
+Ingest decides in this order, so the first thing that is wrong is what you hear
+about: `invalid_archive` → `upload_too_large` (decompressed) → `not_a_job_dir` →
+`job_already_uploaded` → dataset resolution → `job_too_large` →
+`invalid_trial`.
+
+A `413` on `Content-Length` arrives before any bytes are read, so a too-large
+archive fails fast rather than after a long transfer.

--- a/.claude/skills/harbor-job-upload/scripts/check_job.py
+++ b/.claude/skills/harbor-job-upload/scripts/check_job.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check a job directory against every cap `evolve upload` will apply.
+
+Answers the question the CLI cannot answer until after a long transfer: will
+this be accepted, and once accepted will the analyzer actually read it?
+
+The archive size is MEASURED, not estimated — the directory is tarred and
+gzipped to a temp file exactly as the SDK does, so the number reported is the
+number the server will see. Compression ratio varies from ~1.0x on blobs to
+~1.8x on JSON, so an estimate is not good enough to trust near a cap.
+
+Beyond the caps it looks for the three failures that produce a SUCCESSFUL
+upload carrying an unreadable trial:
+
+  * a symlink              -> skipped by the packer, never followed
+  * agent/trajectory.json.gz -> maps to no ingest slot; empty trace
+  * a trajectory over the analyzer ceiling -> stored whole, then head-truncated
+                                              at analysis time
+
+Exit codes: 0 clean, 1 violations found, 2 not a job directory.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import pathlib
+import sys
+import tarfile
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import jobspec  # noqa: E402
+
+
+def measure_archive(job: pathlib.Path) -> tuple[int, int, int]:
+    """(compressed, decompressed, entries), by actually packing it."""
+    with tempfile.TemporaryDirectory(prefix="harbor-job-check-") as tmp:
+        path = pathlib.Path(tmp) / "job.tar.gz"
+        entries = raw = 0
+        with tarfile.open(path, "w:gz") as tar:
+            for cur, dirs, files in os.walk(job):
+                dirs[:] = [d for d in dirs if d not in (".git", ".venv")]
+                for f in sorted(files):
+                    if f == ".DS_Store":
+                        continue
+                    p = pathlib.Path(cur) / f
+                    if p.is_symlink() or not p.is_file():
+                        continue
+                    tar.add(p, arcname=str(p.relative_to(job)))
+                    entries += 1
+                    raw += p.stat().st_size
+        return path.stat().st_size, raw, entries
+
+
+def check(job: pathlib.Path, caps: dict, live: bool, target: int) -> list[dict]:
+    findings: list[dict] = []
+
+    def bad(level, what, detail):
+        findings.append({"level": level, "what": what, "detail": detail})
+
+    for rel in jobspec.RECORD_FILES:
+        if not (job / rel).is_file():
+            bad("error", "not_a_job_dir",
+                f"{job}/{rel} is missing — the client refuses before packing")
+
+    trials = sorted(d for d in job.iterdir() if d.is_dir())
+    if len(trials) > caps["job_trials"]:
+        bad("error", "job_too_large",
+            f"{len(trials)} trials, cap is {caps['job_trials']}")
+
+    for t in trials:
+        for cur, _dirs, files in os.walk(t):
+            for f in files:
+                p = pathlib.Path(cur) / f
+                rel = p.relative_to(job)
+                if p.is_symlink():
+                    bad("error", "symlink",
+                        f"{rel} is a symlink — the packer skips it silently")
+                    continue
+                if not p.is_file():
+                    continue
+                size = p.stat().st_size
+                trial_rel = str(p.relative_to(t))
+                if trial_rel in jobspec.RECORD_FILES and size > jobspec.MAX_RECORD_FILE_BYTES:
+                    bad("error", "not_a_job_dir",
+                        f"{rel} is {jobspec.human(size)}, record cap is 8.0 MiB")
+                elif size > caps["job_trial_file_bytes"]:
+                    bad("error", "invalid_trial",
+                        f"{rel} is {jobspec.human(size)}, per-file cap is "
+                        f"{jobspec.human(caps['job_trial_file_bytes'])}")
+                elif size > target:
+                    bad("warn", "analyzer_truncation",
+                        f"{rel} is {jobspec.human(size)}, over the "
+                        f"{jobspec.human(target)} analyzer ceiling — it uploads "
+                        f"clean and is then head-truncated at analysis time")
+
+        if (t / "agent" / "trajectory.json.gz").exists():
+            bad("error", "empty_trace",
+                f"{t.name}/agent/trajectory.json.gz maps to no ingest slot — "
+                f"the trial will upload with no trace")
+        traj = t / "agent" / "trajectory.json"
+        if not traj.is_file():
+            bad("warn", "no_trajectory", f"{t.name} has no agent/trajectory.json")
+        else:
+            try:
+                json.loads(traj.read_text(errors="replace"))
+            except json.JSONDecodeError as e:
+                bad("error", "invalid_trajectory",
+                    f"{t.name}/agent/trajectory.json is not valid JSON ({e.msg}) — "
+                    f"an unrepaired [REDACTED] token does this")
+
+        sess = t / "agent" / "sessions"
+        if sess.is_dir():
+            total = sum(p.stat().st_size for p in sess.rglob("*") if p.is_file())
+            if total > caps["job_trial_session_bytes"]:
+                bad("error", "invalid_trial",
+                    f"{t.name} session tree is {jobspec.human(total)}, cap is "
+                    f"{jobspec.human(caps['job_trial_session_bytes'])}")
+
+    compressed, raw, entries = measure_archive(job)
+    if compressed > caps["job_archive_bytes"]:
+        bad("error", "upload_too_large",
+            f"archive is {jobspec.human(compressed)}, cap is "
+            f"{jobspec.human(caps['job_archive_bytes'])}")
+    if raw > jobspec.MAX_DECOMPRESSED_BYTES:
+        bad("error", "upload_too_large",
+            f"decompressed footprint is {jobspec.human(raw)}, cap is "
+            f"{jobspec.human(jobspec.MAX_DECOMPRESSED_BYTES)}")
+    if entries > jobspec.MAX_ARCHIVE_ENTRIES:
+        bad("error", "invalid_archive",
+            f"{entries:,} entries, cap is {jobspec.MAX_ARCHIVE_ENTRIES:,}")
+
+    ratio = raw / compressed if compressed else 0
+    print(f"{job.name}")
+    print(f"  trials       {len(trials)} / {caps['job_trials']}")
+    print(f"  archive      {jobspec.human(compressed)} / "
+          f"{jobspec.human(caps['job_archive_bytes'])}   (measured, {ratio:.2f}x)")
+    print(f"  decompressed {jobspec.human(raw)} / "
+          f"{jobspec.human(jobspec.MAX_DECOMPRESSED_BYTES)}")
+    print(f"  entries      {entries:,} / {jobspec.MAX_ARCHIVE_ENTRIES:,}")
+    print(f"  caps from    {'GET /api/meta (live)' if live else 'frozen defaults — server unreachable'}")
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("job", nargs="+", help="job directory")
+    ap.add_argument("--target-bytes", type=int, default=jobspec.ANALYZER_FILE_BYTES,
+                    help="the analyzer ceiling to warn against (default 24 MiB)")
+    ap.add_argument("--offline", action="store_true",
+                    help="do not query /api/meta; use the frozen defaults")
+    ap.add_argument("--json", action="store_true", help="machine-readable findings")
+    args = ap.parse_args()
+
+    caps, live = jobspec.resolve_caps(offline=args.offline)
+    all_findings = {}
+    rc = 0
+    for j in args.job:
+        job = pathlib.Path(j)
+        if not job.is_dir():
+            print(f"{j}: not a directory", file=sys.stderr)
+            return 2
+        findings = check(job, caps, live, args.target_bytes)
+        all_findings[str(job)] = findings
+        errors = [f for f in findings if f["level"] == "error"]
+        warns = [f for f in findings if f["level"] == "warn"]
+        for f in errors + warns:
+            print(f"  {f['level'].upper():5s} {f['what']}: {f['detail']}")
+        if not findings:
+            print("  OK — every cap satisfied")
+        if errors:
+            rc = 1
+        print()
+
+    if args.json:
+        print(json.dumps(all_findings, indent=1))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/harbor-job-upload/scripts/compress_job.py
+++ b/.claude/skills/harbor-job-upload/scripts/compress_job.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Build an uploadable Harbor job directory from a set of trial directories.
+
+Keeps exactly what the platform ingests, drops what it never reads, and
+shrinks `agent/trajectory.json` to fit the ANALYZER's budget rather than the
+upload cap — a file between the two is accepted and then silently truncated
+at analysis time, which looks like a successful upload and reads like a
+mangled trace.
+
+Three failure modes this exists to prevent, each of which is silent:
+
+  * a symlinked file            -> the packer skips symlinks without following
+                                   them, so the trial ships without its trace.
+                                   Everything here is hard-linked or written.
+  * agent/trajectory.json.gz    -> maps to no ingest slot, so the trial lands
+                                   with an empty trace. Decompressed on the way in.
+  * a [REDACTED] token in JSON  -> not valid JSON; a broad except drops the
+                                   trial. Repaired on read.
+
+Usage:
+  compress_job.py --out JOB_DIR --trial DIR [--trial DIR ...]
+  compress_job.py --out JOB_DIR --from-list paths.txt --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import pathlib
+import shutil
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import jobspec  # noqa: E402
+import trajectory as traj_mod  # noqa: E402
+
+LOG_CLIP_MARKER = "\n... [{n:,} characters clipped to fit the upload budget] ...\n"
+
+
+def read_json(path: pathlib.Path):
+    """Repairing read. Returns None when the file is absent or unparseable."""
+    if not path.is_file():
+        return None
+    try:
+        return traj_mod.loads(path.read_text(errors="replace"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def source_of(trial: pathlib.Path, rel: str) -> pathlib.Path | None:
+    """The real file for an ingest slot, accepting a .gz twin.
+
+    Symlinks are resolved here rather than linked through: the packer skips a
+    symlink silently, so one that survives into the job dir is a file that
+    quietly does not upload.
+    """
+    for cand in (trial / rel, trial / (rel + ".gz")):
+        real = cand.resolve() if cand.is_symlink() else cand
+        if real.is_file():
+            return real
+    return None
+
+
+def read_bytes(path: pathlib.Path) -> bytes:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rb") as fh:
+            return fh.read()
+    return path.read_bytes()
+
+
+def uncompressed_size(path: pathlib.Path) -> int:
+    """Size of a file's content — for a .gz, what it expands to.
+
+    gzip records ISIZE (mod 2^32) in its last four bytes; every file here is
+    far under 4 GiB, so the trailer is exact and costs one seek instead of a
+    full decompression.
+    """
+    if path.suffix != ".gz":
+        return path.stat().st_size
+    try:
+        with path.open("rb") as fh:
+            fh.seek(-4, os.SEEK_END)
+            return int.from_bytes(fh.read(4), "little")
+    except OSError:
+        return path.stat().st_size
+
+
+def place(src: pathlib.Path, dst: pathlib.Path) -> None:
+    """Hard-link when possible (free on one volume), copy across devices."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def clip_text(data: bytes, budget: int) -> tuple[bytes, bool]:
+    if len(data) <= budget:
+        return data, False
+    text = data.decode(errors="replace")
+    head = budget * 2 // 3
+    out = text[:head] + LOG_CLIP_MARKER.format(n=len(text) - budget) + text[-(budget - head):]
+    return out.encode(), True
+
+
+def trial_name(trial: pathlib.Path, result: dict | None) -> str:
+    if result:
+        if result.get("trial_name"):
+            return str(result["trial_name"])
+        task = str(result.get("task_name") or "").split("/")[-1]
+        if task:
+            return f"{task}__{trial.name[:8]}"
+    return trial.name
+
+
+def build_trial(trial: pathlib.Path, dest: pathlib.Path, args) -> dict:
+    """Materialise one trial into the job dir. Returns its report."""
+    result = read_json(trial / "result.json")
+    rep = {
+        "source": str(trial),
+        "name": dest.name,
+        "kept": [],
+        "dropped": [],
+        "bytes_in": 0,
+        "bytes_out": 0,
+    }
+
+    # Record files. Required by ingest; both are small by contract, and a
+    # record over the record cap is a refusal, so it is reported not clipped.
+    for rel in jobspec.RECORD_FILES:
+        src = source_of(trial, rel)
+        if src is None:
+            rep["dropped"].append({"path": rel, "why": "missing"})
+            continue
+        data = read_bytes(src)
+        rep["bytes_in"] += len(data)
+        if len(data) > jobspec.MAX_RECORD_FILE_BYTES:
+            rep["dropped"].append(
+                {"path": rel, "why": "over the 8 MiB record cap", "bytes": len(data)})
+            continue
+        if src.suffix == ".gz":
+            (dest / rel).parent.mkdir(parents=True, exist_ok=True)
+            (dest / rel).write_bytes(data)
+        else:
+            place(src, dest / rel)
+        rep["bytes_out"] += len(data)
+        rep["kept"].append(rel)
+
+    have_stdout = source_of(trial, "agent/stdout.log") is not None
+
+    for rel in jobspec.TRIAL_ARTIFACT_FILES:
+        src = source_of(trial, rel)
+        if src is None:
+            continue
+        data = read_bytes(src)
+        rep["bytes_in"] += len(data)
+
+        if rel == "agent/trajectory.json":
+            out, treport = traj_mod.compress(data.decode(errors="replace"),
+                                             args.target_bytes)
+            rep["trajectory"] = treport
+        else:
+            out, clipped = clip_text(data, args.target_bytes)
+            if clipped:
+                rep.setdefault("clipped_logs", []).append(rel)
+
+        (dest / rel).parent.mkdir(parents=True, exist_ok=True)
+        if len(out) == len(data) and src.suffix != ".gz" and rel != "agent/trajectory.json":
+            place(src, dest / rel)      # untouched: link it, do not rewrite
+        else:
+            (dest / rel).write_bytes(out)
+        rep["bytes_out"] += len(out)
+        rep["kept"].append(rel)
+
+    # The stdout slot's fallback, used only when agent/stdout.log is absent.
+    if not have_stdout and not args.no_harness_log:
+        agent_dir = trial / "agent"
+        if agent_dir.is_dir():
+            for cand in sorted(agent_dir.glob(f"*{jobspec.HARNESS_LOG_SUFFIX}")):
+                if not cand.is_file():
+                    continue
+                data = read_bytes(cand)
+                rep["bytes_in"] += len(data)
+                out, clipped = clip_text(data, args.target_bytes)
+                (dest / "agent" / cand.name).write_bytes(out)
+                rep["bytes_out"] += len(out)
+                rep["kept"].append(f"agent/{cand.name}")
+                if clipped:
+                    rep.setdefault("clipped_logs", []).append(f"agent/{cand.name}")
+                break
+
+    if args.keep_sessions:
+        sess = trial / "agent" / "sessions"
+        total = 0
+        for cur, _dirs, files in os.walk(sess):
+            for f in files:
+                s = pathlib.Path(cur) / f
+                real = s.resolve() if s.is_symlink() else s
+                if not real.is_file() or real.stat().st_size > jobspec.MAX_TRIAL_FILE_BYTES:
+                    rep["dropped"].append({"path": str(s.relative_to(trial)),
+                                           "why": "over the per-file cap"})
+                    continue
+                total += real.stat().st_size
+                place(real, dest / s.relative_to(trial))
+        if total:
+            rep["session_bytes"] = total
+            rep["bytes_in"] += total
+            rep["bytes_out"] += total
+
+    if args.keep_artifacts:
+        for cur, _dirs, files in os.walk(trial / "artifacts"):
+            for f in files:
+                s = pathlib.Path(cur) / f
+                real = s.resolve() if s.is_symlink() else s
+                if not real.is_file() or real.stat().st_size > jobspec.MAX_TRIAL_FILE_BYTES:
+                    continue
+                place(real, dest / s.relative_to(trial))
+
+    # The honest denominator: everything the trial dir holds, not just the
+    # slots we ship. Without it a report can claim "1% removed" for a trial
+    # whose artifacts/ tree was the actual 90%.
+    #
+    # A .gz member is counted at its DECOMPRESSED size. The comparison has to
+    # be content against content: our output is plain JSON that the uploader
+    # gzips on the way out, so measuring a gzipped input against it makes
+    # decompressing a trajectory look like a 300% regression.
+    rep["source_dir_bytes"] = sum(
+        uncompressed_size(p) for p in trial.rglob("*")
+        if p.is_file() and not p.is_symlink())
+    rep["result"] = result
+    return rep
+
+
+def write_job_meta(job: pathlib.Path, reports: list[dict], args) -> str:
+    """The job-level result.json + config.json the client and server require.
+
+    The id is content-addressed over the trial set: the server dedupes on it,
+    so keying it on a label alone lets a smoke run collide with the real job
+    and lets a re-run create a twin.
+    """
+    names = sorted(r["name"] for r in reports)
+    results = [r.get("result") or {} for r in reports]
+    seed = args.job_id_seed or (args.name + "/" + ",".join(names))
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
+
+    rewards, tasks, agents = [], set(), {}
+    for res in results:
+        rw = ((res.get("verifier_result") or {}).get("rewards") or {}).get("reward")
+        rewards.append(rw)
+        task = str(res.get("task_name") or "").split("/")[-1]
+        if task:
+            tasks.add(task)
+        ag = (res.get("config") or {}).get("agent") or {}
+        if ag.get("name"):
+            agents[(ag["name"], ag.get("model_name"))] = True
+
+    if args.agent or args.model:
+        agents = {(args.agent or "unknown", args.model): True}
+    if not agents:
+        agents = {("unknown", None): True}
+
+    (job / "result.json").write_text(json.dumps({
+        "id": job_id,
+        "n_total_trials": len(reports),
+        "stats": {
+            "n_trials": len(reports),
+            "n_errors": 0,
+            "n_resolved": sum(1 for r in rewards if r and r > 0),
+            "n_unresolved": sum(1 for r in rewards if not r),
+        },
+        "source": args.source,
+        "provenance": {
+            "note": "Assembled by the harbor-job-upload skill",
+            "job_name": args.name,
+            "trials": len(reports),
+        },
+    }, indent=1))
+
+    (job / "config.json").write_text(json.dumps({
+        "job_name": args.name,
+        "jobs_dir": "jobs",
+        "n_attempts": 1,
+        "timeout_multiplier": 1.0,
+        "debug": False,
+        "agents": [{"name": n, "import_path": None, "model_name": m}
+                   for (n, m) in agents],
+        "datasets": [{"name": args.dataset_name, "version": args.dataset_version,
+                      "task_names": sorted(tasks)}],
+        "tasks": [],
+        "metrics": [],
+    }, indent=1))
+    return job_id
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", required=True, help="job directory to create")
+    ap.add_argument("--trial", action="append", default=[],
+                    help="a trial directory; repeatable")
+    ap.add_argument("--from-list", help="file of trial directory paths, one per line")
+    ap.add_argument("--target-bytes", type=int, default=jobspec.ANALYZER_FILE_BYTES,
+                    help="per-file budget (default: the 24 MiB analyzer ceiling, "
+                         "NOT the 32 MiB upload cap)")
+    ap.add_argument("--keep-sessions", action="store_true",
+                    help="keep agent/sessions/ (ingested and served, but the "
+                         "analyzer never reads it)")
+    ap.add_argument("--keep-artifacts", action="store_true",
+                    help="keep artifacts/ (never ingested; for local parity only)")
+    ap.add_argument("--no-harness-log", action="store_true",
+                    help="drop agent/<harness>.txt, the stdout-slot fallback")
+    ap.add_argument("--name", help="job name (default: the --out basename)")
+    ap.add_argument("--job-id-seed", help="override the content-addressed id seed")
+    ap.add_argument("--agent", help="override the agent name in config.json")
+    ap.add_argument("--model", help="override the model name in config.json")
+    ap.add_argument("--source", default="harbor-job-upload")
+    ap.add_argument("--dataset-name", default="terminal-bench")
+    ap.add_argument("--dataset-version", default="4.0.0")
+    ap.add_argument("--report", help="write the JSON report here")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report only; write nothing")
+    args = ap.parse_args()
+
+    trials = [pathlib.Path(t) for t in args.trial]
+    if args.from_list:
+        trials += [pathlib.Path(l.strip())
+                   for l in pathlib.Path(args.from_list).read_text().splitlines()
+                   if l.strip() and not l.startswith("#")]
+    missing = [t for t in trials if not t.is_dir()]
+    if missing:
+        print("not a directory:\n  " + "\n  ".join(map(str, missing)), file=sys.stderr)
+        return 2
+    if not trials:
+        print("no trials given (--trial / --from-list)", file=sys.stderr)
+        return 2
+
+    job = pathlib.Path(args.out)
+    args.name = args.name or job.name
+    stage = job.with_name(job.name + ".building") if not args.dry_run else None
+
+    if args.dry_run:
+        import tempfile
+        tmp = tempfile.mkdtemp(prefix="harbor-job-dry-")
+        stage = pathlib.Path(tmp) / job.name
+
+    if stage.exists():
+        shutil.rmtree(stage)
+    stage.mkdir(parents=True)
+
+    reports = []
+    for t in trials:
+        res = read_json(t / "result.json")
+        name = trial_name(t, res)
+        reports.append(build_trial(t, stage / name, args))
+        reports[-1]["name"] = name
+
+    job_id = write_job_meta(stage, reports, args)
+
+    bytes_in = sum(r["bytes_in"] for r in reports)
+    bytes_out = sum(r["bytes_out"] for r in reports)
+    src_bytes = sum(r["source_dir_bytes"] for r in reports)
+    report = {
+        "job": args.name,
+        "job_id": job_id,
+        "trials": len(reports),
+        "target_bytes": args.target_bytes,
+        "source_dir_bytes": src_bytes,
+        "bytes_in": bytes_in,
+        "bytes_out": bytes_out,
+        "reduction_pct": round(100 * (1 - bytes_out / bytes_in), 1) if bytes_in else 0.0,
+        "reduction_vs_source_dir_pct": (
+            round(100 * (1 - bytes_out / src_bytes), 1) if src_bytes else 0.0),
+        "lossy_trials": [r["name"] for r in reports
+                         if (r.get("trajectory") or {}).get("lossy")],
+        "per_trial": [{k: v for k, v in r.items() if k != "result"} for r in reports],
+    }
+
+    if args.dry_run:
+        shutil.rmtree(stage.parent)
+    else:
+        if job.exists():
+            shutil.rmtree(job)
+        stage.rename(job)
+
+    print(f"{args.name}: {len(reports)} trials  id={job_id}")
+    print(f"  ingested slots  {jobspec.human(bytes_in)} -> {jobspec.human(bytes_out)}"
+          f"  ({report['reduction_pct']}% removed by compression)")
+    print(f"  whole trial dirs {jobspec.human(src_bytes)} -> {jobspec.human(bytes_out)}"
+          f"  ({report['reduction_vs_source_dir_pct']}% removed overall, "
+          f"content-for-content)")
+    if report["lossy_trials"]:
+        print(f"  lossy (observation clipping fired): {len(report['lossy_trials'])} "
+              f"of {len(reports)}")
+    if args.dry_run:
+        print("  dry run — nothing written")
+
+    if args.report:
+        pathlib.Path(args.report).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(args.report).write_text(json.dumps(report, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/harbor-job-upload/scripts/jobspec.py
+++ b/.claude/skills/harbor-job-upload/scripts/jobspec.py
@@ -1,0 +1,120 @@
+"""The platform's job-upload contract, in one place.
+
+Every constant here is a published server limit or a documented ingest rule.
+Sources are cited so a reader can re-verify rather than trust this file:
+
+  - Caps are published live at `GET /api/meta` under `limits.uploads`. Read
+    them with `evolve_limits()` rather than trusting the frozen defaults; the
+    defaults exist only so the tools still run offline.
+  - The per-trial ingest whitelist is the server's own `TRIAL_ARTIFACT_FILES`
+    plus the two record files.
+  - The analyzer's input ceiling is NOT an upload cap. A file between the
+    analyzer ceiling and the upload cap is accepted, stored, and then
+    head-truncated at analysis time with only an in-band marker. That is why
+    the compressor targets the analyzer ceiling, not the upload cap.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+MiB = 1024 * 1024
+GiB = 1024 * MiB
+
+# --- Published upload caps (defaults; prefer evolve_limits() at runtime) -----
+MAX_JOB_ARCHIVE_BYTES = 512 * MiB       # limits.uploads.job_archive_bytes
+MAX_JOB_TRIALS = 2000                   # limits.uploads.job_trials
+MAX_TRIAL_FILE_BYTES = 32 * MiB         # limits.uploads.job_trial_file_bytes
+MAX_TRIAL_SESSION_BYTES = 128 * MiB     # limits.uploads.job_trial_session_bytes
+
+# --- Server-side caps that are NOT published, and are not raisable by env ----
+MAX_DECOMPRESSED_BYTES = 2 * GiB        # the real wall behind the 512 MiB one
+MAX_ARCHIVE_ENTRIES = 200_000
+MAX_RECORD_FILE_BYTES = 8 * MiB         # result.json / config.json per trial
+
+# --- The analyzer's own ceilings (truncate silently; never refuse) -----------
+ANALYZER_FILE_BYTES = 24 * MiB
+ANALYZER_TREE_BYTES = 96 * MiB
+
+# --- What ingest stores, per trial ------------------------------------------
+# The server's TRIAL_ARTIFACT_FILES, verbatim.
+TRIAL_ARTIFACT_FILES = (
+    "agent/trajectory.json",
+    "agent/stdout.log",
+    "agent/stderr.log",
+    "verifier/test-stdout.txt",
+    "verifier/reward.txt",
+)
+# Required at the root of a trial dir, and at the root of the job dir. The
+# client refuses before packing if either is missing from the JOB root.
+RECORD_FILES = ("result.json", "config.json")
+
+# Ingested as a tree, under its own cap. Dead weight for rubric analysis (the
+# analyzer never reads it), but it is what the trace viewer serves as the
+# native session home — hence a flag, not an unconditional drop.
+SESSION_PREFIX = "agent/sessions/"
+
+# The stdout slot's fallback: a harness CLI log directly under agent/, used
+# only when agent/stdout.log is absent. Hub archives carry these.
+HARNESS_LOG_SUFFIX = ".txt"
+
+# Never ingested. Listed so tools can explain a drop rather than just do it.
+NEVER_INGESTED = (
+    "artifacts/**", "steps/**", "lock.json", "trial.log",
+    "analysis.json", "analysis.md", "verifier/reward.json",
+    "verifier/ctrf.json", "evolve.json",
+)
+
+DEFAULT_DASHBOARD_URL = "https://dashboard.evolvingmachines.ai"
+
+
+def evolve_limits(base_url: str | None = None, api_key: str | None = None,
+                  timeout: float = 20.0) -> dict | None:
+    """Live `limits.uploads` from GET /api/meta, or None if unreachable.
+
+    The caps move — the dataset door was raised 16x above its source default
+    without any client change — so a tool that hardcodes them will eventually
+    lie. Falling back to the frozen defaults is fine; silently reporting a
+    stale cap as if it were live is not, so the caller is told which it got.
+    """
+    base = (base_url or os.environ.get("EVOLVE_DASHBOARD_URL")
+            or DEFAULT_DASHBOARD_URL).rstrip("/")
+    key = api_key or os.environ.get("EVOLVE_API_KEY")
+    req = urllib.request.Request(f"{base}/api/meta")
+    if key:
+        req.add_header("Authorization", f"Bearer {key}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return (json.load(r).get("limits") or {}).get("uploads")
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def resolve_caps(base_url: str | None = None, api_key: str | None = None,
+                 offline: bool = False) -> tuple[dict, bool]:
+    """(caps, live) — published caps, preferring the server's own numbers."""
+    caps = {
+        "job_archive_bytes": MAX_JOB_ARCHIVE_BYTES,
+        "job_trials": MAX_JOB_TRIALS,
+        "job_trial_file_bytes": MAX_TRIAL_FILE_BYTES,
+        "job_trial_session_bytes": MAX_TRIAL_SESSION_BYTES,
+    }
+    if offline:
+        return caps, False
+    live = evolve_limits(base_url, api_key)
+    if not live:
+        return caps, False
+    for k in caps:
+        if isinstance(live.get(k), int):
+            caps[k] = live[k]
+    return caps, True
+
+
+def human(n: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if abs(n) < 1024 or unit == "GiB":
+            return f"{n:.1f} {unit}" if unit != "B" else f"{int(n)} B"
+        n /= 1024
+    return f"{n:.1f} GiB"

--- a/.claude/skills/harbor-job-upload/scripts/trajectory.py
+++ b/.claude/skills/harbor-job-upload/scripts/trajectory.py
@@ -1,0 +1,179 @@
+"""Read, repair, and shrink an ATIF trajectory without lying about the trace.
+
+Four transforms, applied in increasing order of cost to the reader:
+
+  1. repair    - the hub sanitises some numeric fields to a bare [REDACTED]
+                 token, which is not valid JSON. A plain json.load raises and,
+                 in every pipeline that catches broadly, silently drops the
+                 trial. Repair first, always.
+  2. dedup     - `observation.results[].extra` re-states the observation's own
+                 `content` (often twice), and `tool_calls[].extra.raw_arguments`
+                 re-states `arguments`. Removing a string that is provably
+                 recoverable from a sibling field costs the reader nothing.
+  3. base64    - inline image payloads. Bytes, not reasoning.
+  4. clip      - the only lossy step: per-observation head+tail truncation,
+                 walked down a ladder until the file fits. Never touches a
+                 step's `message` (the agent's reasoning) and never drops a
+                 step, so the action sequence stays intact end to end.
+
+Steps 1-3 are lossless for anything that reads the trace, so they run
+unconditionally. Step 4 runs only if the file is still over budget.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterator
+
+# Ladder and tail protection are inherited from the corpus normaliser, so a
+# clipped upload and a locally rendered trace agree on what got elided.
+BUDGET_LADDER = (20_000, 8_000, 4_000, 2_000, 1_000, 400)
+TAIL_PROTECT_OBS = 8
+TAIL_BUDGET_MULTIPLIER = 4
+
+BASE64_KEYS = ("base64", "data")
+BASE64_MIN_CHARS = 100_000
+# Below this, a duplicated string is not worth a marker that says so.
+DUP_MIN_CHARS = 200
+
+_REDACTED = re.compile(r":\s*\[REDACTED\]")
+
+
+def loads(text: str) -> Any:
+    """json.loads with the [REDACTED] repair. Raises if it is still not JSON."""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return json.loads(_REDACTED.sub(": null", text))
+
+
+def observations(traj: Any) -> Iterator[dict]:
+    """Each observation result dict, in trace order."""
+    for step in traj.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        for r in (step.get("observation") or {}).get("results") or []:
+            if isinstance(r, dict):
+                yield r
+
+
+def strip_duplicate_extra(traj: Any) -> dict:
+    """Remove restatements of a sibling field. Provably lossless.
+
+    A string under `extra` is removed only when it is a SUBSTRING of the
+    content it sits beside — that is the proof it carries nothing new. A
+    payload that merely looks redundant is left alone, so an unfamiliar
+    harness cannot lose data here.
+    """
+    n_obs = n_args = 0
+    freed = 0
+
+    def prune(node: Any, content: str) -> Any:
+        nonlocal n_obs, freed
+        if isinstance(node, dict):
+            return {k: prune(v, content) for k, v in node.items()}
+        if isinstance(node, list):
+            return [prune(v, content) for v in node]
+        if isinstance(node, str) and len(node) >= DUP_MIN_CHARS and node in content:
+            n_obs += 1
+            freed += len(node)
+            return f"[{len(node):,} chars identical to observation content, removed for upload]"
+        return node
+
+    for step in traj.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        for tc in step.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            extra = tc.get("extra")
+            if (isinstance(extra, dict) and "raw_arguments" in extra
+                    and extra["raw_arguments"] == tc.get("arguments")):
+                freed += len(json.dumps(extra.pop("raw_arguments")))
+                n_args += 1
+
+    for r in observations(traj):
+        content, extra = r.get("content"), r.get("extra")
+        if isinstance(content, str) and content and extra is not None:
+            r["extra"] = prune(extra, content)
+
+    return {"observation_strings": n_obs, "raw_arguments": n_args,
+            "chars_freed": freed}
+
+
+def strip_base64(traj: Any) -> dict:
+    """Replace inline base64 payloads with a byte count."""
+    n = 0
+    freed = 0
+
+    def walk(o: Any) -> None:
+        nonlocal n, freed
+        if isinstance(o, dict):
+            for k, v in list(o.items()):
+                if k in BASE64_KEYS and isinstance(v, str) and len(v) > BASE64_MIN_CHARS:
+                    o[k] = f"[{len(v):,} bytes of base64 stripped for upload]"
+                    n += 1
+                    freed += len(v)
+                else:
+                    walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+
+    walk(traj)
+    return {"fields": n, "chars_freed": freed}
+
+
+def _clip(text: str, budget: int, marker: str) -> str:
+    if len(text) <= budget:
+        return text
+    head = budget * 2 // 3
+    return text[:head] + marker.format(n=len(text) - budget) + text[-(budget - head):]
+
+
+def clip_observations(traj: Any, target_bytes: int) -> int | None:
+    """Walk the ladder until the encoded trajectory fits. Returns the rung used.
+
+    Truncation is per observation and always head+tail, so the command that
+    produced an observation and the verdict at its end both survive. The last
+    TAIL_PROTECT_OBS observations get a larger budget because a failure's
+    evidence is concentrated in the final verification and its output.
+    """
+    if len(json.dumps(traj).encode()) <= target_bytes:
+        return None
+    marker = ("\n... [{n:,} characters clipped to fit the "
+              f"{target_bytes // (1024 * 1024)} MiB analysis budget] ...\n")
+    obs = list(observations(traj))
+    originals = [r.get("content") if isinstance(r.get("content"), str) else None
+                 for r in obs]
+    tail_from = max(0, len(obs) - TAIL_PROTECT_OBS)
+    used = None
+    for budget in BUDGET_LADDER:
+        for i, (r, orig) in enumerate(zip(obs, originals)):
+            if orig is None:
+                continue
+            b = budget * TAIL_BUDGET_MULTIPLIER if i >= tail_from else budget
+            r["content"] = _clip(orig, b, marker)
+        used = budget
+        if len(json.dumps(traj).encode()) <= target_bytes:
+            break
+    return used
+
+
+def compress(text: str, target_bytes: int) -> tuple[bytes, dict]:
+    """Full pipeline. Returns (encoded trajectory, report)."""
+    traj = loads(text)
+    report = {"original_bytes": len(text.encode())}
+
+    report["dedup"] = strip_duplicate_extra(traj)
+    report["after_dedup_bytes"] = len(json.dumps(traj).encode())
+
+    report["base64"] = strip_base64(traj)
+    report["after_base64_bytes"] = len(json.dumps(traj).encode())
+
+    report["obs_budget_chars"] = clip_observations(traj, target_bytes)
+
+    out = json.dumps(traj).encode()
+    report["final_bytes"] = len(out)
+    report["lossy"] = report["obs_budget_chars"] is not None
+    return out, report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ evolve/
 │   ├── docker/                  # Docker image (Dockerfile, build.ts)
 │   ├── build.sh                 # Master build script
 │   └── README.md
-├── skills/                      # Agent skills (41 total) — CI-OWNED MIRROR of docs/
+├── skills/                      # Agent skills — `evolve/` is a CI-owned mirror of docs/; others are hand-written
 │   ├── pdf, docx, pptx, xlsx   # Document processing
 │   ├── agent-browser, dev-browser, webapp-testing  # Browser automation
 │   ├── frontend-design, shadcn-webapp-design, web-design-guidelines  # Design
@@ -63,6 +63,7 @@ evolve/
 │   ├── skill-creator, skill-share, template-skill  # Skill tooling
 │   ├── remotion, slides-as-code, canvas-design  # Media & presentations
 │   ├── mcp-builder              # MCP server builder
+│   ├── harbor-job-upload        # Compress + upload a Harbor job (hand-written)
 │   └── ...                      # content-research, lead-research, invoice, image-enhancer, etc.
 ├── cookbooks/                   # Example applications
 │   ├── typescript/
@@ -107,5 +108,5 @@ EVOLVE_OPENAPI_SPEC_PATH=/path/to/swarm_dashboard/spec/openapi.yaml npm run test
 
 ### Documentation rules
 
-- **`docs/` is the only place documentation is edited.** `skills/` and `.claude/skills/` are mirrors regenerated on push by `.github/workflows/sync-docs-to-skill.yml`. Hand-editing a mirror gets overwritten and loses the change.
+- **`docs/` is the only place the `evolve` skill's documentation is edited.** `skills/evolve/` and `.claude/skills/evolve/` are mirrors regenerated on push by `.github/workflows/sync-docs-to-skill.yml`. Hand-editing either gets overwritten and loses the change. The workflow copies **only** into those two directories — a hand-written skill in its own directory (e.g. `skills/harbor-job-upload/`) is never touched, and is edited in place.
 - **`docs/typescript/` and `docs/python/` are exact mirrors of each other.** Same sections, same order, same facts, same caveats — only the code differs. A change to one chapter is not finished until the other says the same thing.

--- a/skills/harbor-job-upload/ISSUES.md
+++ b/skills/harbor-job-upload/ISSUES.md
@@ -1,0 +1,228 @@
+# Why this skill exists
+
+Every problem below was hit while porting the Terminal-Bench 4 leaderboard
+corpus (3,300 trials across 10 rows) onto the platform. They are recorded here
+because **all but one of them fail silently** — the upload returns a job id, the
+job lists its trials, and the damage only surfaces later when an analysis reads
+a trace that is empty, truncated, or missing.
+
+Each entry states the symptom first, because that is what you will actually
+have in front of you.
+
+---
+
+## 1. The upload dies with no error and no job
+
+**Symptom.** `evolve upload` on a 4.41 GB job directory produced a zero-byte
+log, no error, and no job.
+
+**What was believed at the time.** That the SDK tarred the whole directory into
+one in-memory Node buffer and was OOM-killed. The corpus was pruned by hand from
+4.41 GB to 1.52 GB to get under it.
+
+**What is actually true now.** That diagnosis is **stale**. The SDK streams:
+`hosted/tar.ts` packs entries from disk into a segmented gzip writer that holds
+one block at a time, and `hosted/upload.ts` posts the archive over raw
+`node:http` with per-chunk backpressure — measured at ~2 MB resident for a
+300 MB file. The module header records the incident it was written to fix: a
+7.7 GB corpus once cost ~10x its size in RSS and crashed the machine.
+
+**The real constraint is server-side.** `413 upload_too_large` against a
+published cap. Nothing on the client bounds the archive.
+
+**Fix.** None needed in the client. What was needed was knowing where the cap
+actually lives, which is [references/limits.md](references/limits.md).
+
+---
+
+## 2. Trials upload "successfully" and carry an empty trace
+
+**Symptom.** `evolve upload` returns a job id. `evolve job trials` lists every
+trial. The trace viewer shows nothing.
+
+**Cause.** The trajectory was stored gzipped as `agent/trajectory.json.gz`.
+Ingest maps a fixed set of per-trial paths to native slots, and
+`agent/trajectory.json.gz` matches none of them, so it is unpacked and
+discarded. The trial is otherwise valid, so nothing errors.
+
+**How common.** 12 such files had already shipped into previously built job
+directories before this was noticed, and **all 20 trials** in the corpus used to
+validate this skill were gzipped.
+
+**Fix.** `compress_job.py` accepts a `.gz` twin for any ingest slot and writes
+the decompressed bytes. `check_job.py` treats a surviving `.gz` under `agent/`
+as an error, not a warning.
+
+---
+
+## 3. Some files never arrive, and nothing says so
+
+**Symptom.** A job directory assembled by symlinking large files uploads with
+`result.json` and essentially nothing else.
+
+**Cause.** The packer skips symlinks outright — it neither follows them nor
+emits them (`tar.ts`, `listFiles`). A tree built by a script that symlinks its
+large files ships as a shell.
+
+**Fix.** Everything is hard-linked (`os.link`, free on one volume, with a
+`copy2` fallback across devices) or written outright; source symlinks are
+resolved to their target before linking. `check_job.py` flags any symlink under
+a trial.
+
+---
+
+## 4. A whole trial vanishes from the corpus
+
+**Symptom.** A row's trial count silently drops. In one case 20 of a row's
+trials disappeared between download and upload.
+
+**Cause.** The hub sanitises some numeric fields to a bare `[REDACTED]` token
+where a number belongs. That is not valid JSON. Any pipeline that reads
+trajectories inside a broad `try/except` drops the trial rather than crashing on
+it. Roughly 11% of trials in this corpus carry one.
+
+**Fix.** Every JSON read in this skill goes through a repairing loader that
+rewrites `: [REDACTED]` to `: null` before parsing. `check_job.py` reports an
+unparseable trajectory as an error and names `[REDACTED]` as the likely cause.
+
+---
+
+## 5. The trace is mangled part-way through analysis
+
+**Symptom.** The analyzer reasons correctly about the start of a trajectory and
+then behaves as if the rest does not exist.
+
+**Cause.** **The upload cap and the analysis cap are different numbers.** A file
+is refused at 32 MiB by ingest, but the analyzer head-truncates every input at
+**24 MiB** with only an in-band marker. A 30 MiB trajectory therefore uploads
+clean, stores clean, and is quietly cut when analyzed. Nothing errors at any
+stage.
+
+This is the single most expensive gap on the path, because the artifact looks
+healthy right up until the verdict is wrong.
+
+**Fix.** `compress_job.py` defaults `--target-bytes` to the 24 MiB analyzer
+ceiling, not the 32 MiB upload cap. `check_job.py` warns on any file in the gap
+between the two and says explicitly what will happen to it.
+
+---
+
+## 6. Compression shrank the readable copy and left the duplicate
+
+**Symptom.** Trajectories that had been "compressed" were still enormous, and
+the observation text a reader needed had been truncated while the file stayed
+large.
+
+**Cause.** In ATIF trajectories from harnesses that emit it,
+`observation.results[].extra` restates the observation's own `content`, often
+twice (`tool_result_metadata.tool_use_result.stdout` and
+`raw_tool_result.content`), and `tool_calls[].extra.raw_arguments` restates
+`arguments`. The previous clipper truncated only `results[].content` — so it
+cut the copy a human or analyzer reads and left the byte-identical duplicate at
+full size.
+
+**Fix.** A deduplication pass runs **before** any truncation, and removes a
+string only when it is a **substring of the content beside it** — the proof it
+carries nothing new. An unfamiliar harness therefore cannot lose data here.
+
+**Measured on real rows** (5 trials each), which also shows why this must be
+substring-proven rather than assumed:
+
+| Row | Harness | Removed |
+|---|---|---|
+| `09-claude-code__sonnet-5` | claude-code | **48.0%** |
+| `07-grok-build__grok-4-6` | grok-build | 2.3% |
+| `09-grok-build__grok-4-5` | grok-build | 2.5% |
+| `08-codex__gpt-5-6-luna` | codex | 0.9% |
+
+The duplication is harness-shaped. **A codex row that suddenly shrinks a lot
+means the deduplicator is deleting something real** — treat it as a bug.
+
+Losslessness is asserted, not assumed: across all 20 trials, every step
+`message`, every tool call, and every observation `content` is byte-identical
+before and after, while the claude-code row still lost 48% of its bytes.
+
+---
+
+## 7. Truncation destroyed the evidence the rubric needed
+
+**Symptom.** A uniformly truncated trace loses the end of the run, which is
+exactly where a failure is adjudicated.
+
+**Cause.** Flat truncation treats the first command and the final verification
+as equally important. They are not: 703 of 738 failures in this corpus are
+`agent_declared_done`, so the question a rubric asks is *why did it believe it
+was done* — and the answer is in the last few observations.
+
+**Fix.** Clipping is per-observation head+tail down a budget ladder
+(20k → 400 chars), the last 8 observations get 4x budget, and a step's `message`
+is never touched and no step is ever dropped. Verified at a deliberately harsh
+1 MiB budget: the ladder settled at the 8,000-char rung, no head observation
+exceeded its budget, all 8 tail observations came through untouched, and the
+final observation ended byte-identically.
+
+---
+
+## 8. There was no way to know before shipping
+
+**Symptom.** Every constraint above was discovered after a long upload, or after
+an analysis produced a bad verdict.
+
+**Cause.** `evolve upload` takes one flag (`-d/--dataset`). No dry run, no
+exclude, no size preflight. The published caps are also not static — the dataset
+door's source default is 512 MiB and production serves 8 GiB, so any tool that
+hardcodes them eventually lies.
+
+**Fix.** `check_job.py` runs every check before a byte moves. Archive size is
+**measured** — the directory is tarred and gzipped to a temp file exactly as the
+SDK does — because the compression ratio ranges from 1.0x on blobs to 5.0x on
+JSON and an estimate is worthless near a cap. Caps are read live from
+`GET /api/meta`, and the output states whether they came from the server or from
+frozen defaults.
+
+---
+
+## What was verified, and what was not
+
+Built four jobs (the bottom four TB4 leaderboard rows, 5 trials each, 20 trials
+total) and uploaded them.
+
+Confirmed:
+
+- All 20 trials landed with **non-empty traces**, 68–630 events each, scaling
+  consistently with local step counts per harness.
+- All four job dirs passed every cap check, with caps read live from the API.
+- Compression is byte-lossless on every analyzer-visible field across all 20.
+- The truncation ladder and its tail protection behave as described.
+- Three analyses completed and produced substantive, trajectory-grounded
+  verdicts (13 rubric checks each) citing detail from deep inside compressed
+  traces — `no_harness_error=pass` on all three.
+
+Not confirmed:
+
+- 7 of 10 analysis runs failed with `phase: stopped — the analyzer box was
+  killed`. This is **infrastructure, not input**: the failures land in a
+  6-second window spanning an unrelated job, and across 200 recent
+  platform-wide analyses (118 failed) **not one failure of any kind was an
+  inputs failure**. The compressed trees were never rejected. But the full
+  5-of-5 analysis pass has not been observed.
+
+---
+
+## Open follow-ups, deliberately not in this change
+
+- **Raising the job archive cap.** `EVAL_MAX_JOB_UPLOAD_BYTES` on the web task.
+  This is a proven path, not a theoretical one — the dataset door has the same
+  512 MiB source default and serves 8 GiB in production. It must move together
+  with the hardcoded 2 GiB decompressed cap, which otherwise binds first at
+  around 1.1 GiB compressed.
+- **A resumable job upload.** `datasets().publish()` passes a resumable
+  threshold and gets a chunked door that resumes from the last acknowledged
+  chunk; `jobs().upload()` does not, so a link that drops at 90% restarts from
+  zero. Wiring it is a one-line client change **and a server door that does not
+  exist yet for jobs** — it would not raise the cap, only remove the
+  restart-from-zero failure. Its own PR.
+- **An `exclude` hook in the packer.** `SKIP` in `tar.ts` is a module-level
+  three-name constant with no seam. An exclude option on `uploadDirectory` would
+  let callers drop `artifacts/**` at pack time instead of pre-pruning the tree,
+  which is what this skill does by hand.

--- a/skills/harbor-job-upload/SKILL.md
+++ b/skills/harbor-job-upload/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: harbor-job-upload
+description: "Prepare and upload a Harbor job directory to the Evolve platform with `evolve upload`. Use when a job directory is too large to upload, when an upload is refused (413 upload_too_large, 422 invalid_trial, 400 not_a_job_dir, 400 invalid_archive, 409 job_already_uploaded), when trials upload successfully but their traces are empty or truncated in the trace viewer or analyzer, or when compressing / pruning / shrinking agent trajectories before shipping a trial corpus."
+---
+
+# Uploading a Harbor job to Evolve
+
+`evolve upload <job_dir> -d <dataset>` ports a Harbor job to the platform;
+`evolve analyze <job-id> -r <rubric>` then runs a rubric server-side. Uploading
+is where corpora go wrong, and **the expensive failures are silent** — a job
+that lands with an empty trace looks exactly like a job that worked.
+
+## The one thing to get right
+
+Ship **only what ingest stores**, and size the trajectory against the
+**analyzer's** ceiling, not the upload cap.
+
+The upload cap and the analysis cap are different numbers, and the gap between
+them is a trap: a 30 MiB trajectory is under the 32 MiB per-file upload cap, so
+it uploads clean — and is then **head-truncated at 24 MiB when analyzed**, with
+only an in-band marker to say so. Nothing errors. Target 24 MiB.
+
+See [references/ingest-contract.md](references/ingest-contract.md) for the exact
+keep/drop map and [references/limits.md](references/limits.md) for every cap and
+which of them can be raised. [ISSUES.md](ISSUES.md) records each failure this
+skill exists to prevent, how it was diagnosed, and what was measured.
+
+## Workflow
+
+```bash
+S=<this-skill>/scripts
+
+# 1. Build a compressed job dir from trial dirs. --dry-run reports and writes nothing.
+python3 $S/compress_job.py --out jobs/my-job --trial path/to/trial1 --trial path/to/trial2 \
+        --report out/compress_my-job.json --dry-run
+
+# 2. Build it for real, then check it against every cap before shipping.
+python3 $S/compress_job.py --out jobs/my-job --from-list trials.txt --report out/compress_my-job.json
+python3 $S/check_job.py jobs/my-job          # exit 1 on any violation
+
+# 3. Upload, then verify the trace actually landed.
+evolve upload jobs/my-job -d my-dataset@1.0 --json
+evolve trial trace <trial-id> --limit 1000 | head
+```
+
+**Never skip step 3's trace check.** `evolve upload` returning a job id proves
+the archive was accepted, not that the trials carry a readable trace.
+
+## The silent failures, and what handles each
+
+| Symptom | Cause | Handled by |
+|---|---|---|
+| Trial uploads, trace is empty | `agent/trajectory.json.gz` — the `.gz` name maps to no ingest slot | `compress_job.py` decompresses on the way in; `check_job.py` refuses any surviving `.gz` |
+| Some trials missing entirely, no error | a symlinked file — the packer skips symlinks and never follows them | everything is hard-linked or written; `check_job.py` flags symlinks |
+| A whole trial vanishes from the corpus | a `[REDACTED]` token where a number belongs — not valid JSON, so a broad `except` drops it | repaired on every read |
+| Trace is mangled mid-way through analysis | trajectory between 24 and 32 MiB — accepted, then head-truncated by the analyzer | the default `--target-bytes` is the 24 MiB analyzer ceiling |
+| `413 upload_too_large` | archive over the published cap | chunk the trials across several jobs; see limits.md before asking for a raise |
+| `409 job_already_uploaded` | the job id is content-addressed over the trial set; re-uploading the same trials is refused | change the trial set, or pass `--job-id-seed` |
+
+## How the trajectory shrinks
+
+Three transforms, in order. The first two are **lossless** for anything that
+reads the trace and run unconditionally; the third is the only lossy one and
+runs only if the file is still over budget.
+
+1. **Deduplicate.** `observation.results[].extra` restates the observation's own
+   `content`, and `tool_calls[].extra.raw_arguments` restates `arguments`. A
+   string is removed only when it is a **substring of the content beside it** —
+   that is the proof it carries nothing new, so an unfamiliar harness cannot
+   lose data here.
+2. **Strip base64.** Inline image payloads, replaced by a byte count.
+3. **Clip observations.** Per-observation head+tail truncation down a budget
+   ladder, with the last 8 observations at 4x budget. It never touches a step's
+   `message` and never drops a step, so the reasoning and the action sequence
+   survive intact; a failure's evidence is concentrated in the final
+   verification command and its output, which is why the tail is protected.
+
+**Expect wildly different yields by harness.** The duplication in step 1 is
+claude-code-shaped. Measured on real TB4 rows: **48% removed** on a
+claude-code row, **~1%** on a codex row, **~2-5%** on grok-build. A codex row
+that suddenly shrinks a lot means the deduplicator is removing something real —
+treat it as a bug, not a win.
+
+## Reading the report
+
+`--report` writes per-trial numbers: bytes in and out, how many duplicate
+strings and base64 fields went, which ladder rung fired, what was dropped and
+why. Two fields matter most:
+
+- `lossy_trials` — the trials where clipping fired. Empty is the good case.
+- `reduction_vs_source_dir_pct` — against the **whole** trial directory with
+  `.gz` members counted decompressed. Content against content: measuring a
+  gzipped input against plain-JSON output makes decompressing a trajectory look
+  like a 300% regression.
+
+## Ordering constraint
+
+If you also blind a job (stripping verdicts for an unbiased analysis), **compress
+first, then blind.** A blinding pass that hard-links trajectories through will
+carry an uncompressed trace into the blind job.

--- a/skills/harbor-job-upload/references/ingest-contract.md
+++ b/skills/harbor-job-upload/references/ingest-contract.md
@@ -1,0 +1,77 @@
+# What the platform actually stores, and what it reads
+
+Two different questions with two different answers, and conflating them is how
+job directories end up 50x larger than they need to be.
+
+1. **Ingest** reads the uploaded archive and stores a fixed set of per-trial
+   files. Anything outside that set is uploaded, unpacked, and discarded.
+2. **The analyzer never reads your archive at all.** It rebuilds a tree from the
+   database and the trace store. So a file that ingest does not store cannot
+   reach analysis no matter how it is named.
+
+Verify both against the server's own source before trusting this page:
+`lib/evaluations/job-upload.ts` (the ingest, and its deviation ledger in the
+module header) and `lib/evaluations/worker/analysis-inputs.ts` (the analyzer's
+input tree).
+
+## Per-trial: what ingest stores
+
+| Path | Notes |
+|---|---|
+| `result.json` | **Required.** A record file, capped at 8 MiB. Carries the verdict, `agent_info`, and `config.agent.{name,model_name}`. |
+| `config.json` | **Required.** Record file, same 8 MiB cap. |
+| `agent/trajectory.json` | The trace. The one file worth compressing. |
+| `agent/stdout.log` | Skipped if empty. |
+| `agent/stderr.log` | Skipped if empty. |
+| `verifier/test-stdout.txt` | Skipped if empty. |
+| `verifier/reward.txt` | Two bytes. Free. |
+| `agent/sessions/**` | Ingested **complete**, under a 128 MiB per-trial cap. Served as the native session home by the trace viewer. The **analyzer never reads it** — dead weight for a rubric run, which is why it is opt-in behind `--keep-sessions`. |
+| `agent/<harness>.txt` | The stdout slot's **fallback**, used only when `agent/stdout.log` is absent. Hub archives carry these (`claude-code.txt`, `codex.txt`). |
+
+The job directory also needs `result.json` **and** `config.json` at its **root**.
+A job dir is not merely a directory of trial dirs; the client refuses before
+packing if either is missing, with the same sentence Harbor's CLI uses.
+
+The root `result.json`'s `id` is the server's **dedup key**. Content-address it
+over the trial set — keying it on a label alone lets a smoke test collide with
+the real job, and lets a re-run create a twin instead of being refused.
+
+## Per-trial: what is never ingested
+
+`artifacts/**` · `steps/**` · `lock.json` · `trial.log` ·
+`verifier/reward.json` · `verifier/ctrf.json` · `evolve.json` ·
+any prior `analysis.json` / `analysis.md` · any other file under `agent/`
+mapping to no native slot.
+
+Two of these are worth calling out:
+
+- **`artifacts/`** is agent *output* — model weights, database dumps, tarballs.
+  On a raw Harbor corpus it is routinely the majority of the bytes and it
+  carries no reasoning signal. Dropping it is free.
+- **A prior analysis is never imported.** This is deliberate: the analyzer must
+  not read its own previous verdict.
+
+## What the analyzer reads
+
+Rebuilt server-side from the database, not from your archive:
+
+`result.json` (synthesized lean, from DB rows) · `exception.txt` (only when the
+trial recorded an exception) · `agent/trajectory.json` · `agent/stdout.log` ·
+`agent/stderr.log` · `verifier/test-stdout.txt` · plus the task's byte-sacred
+content from the retained dataset package.
+
+**Every one of those is head-truncated at 24 MiB** with an in-band marker. It is
+not a refusal, so nothing tells you it happened except the marker inside the
+file. This is the number to compress against.
+
+If the task content cannot be resolved from a dataset package, analysis still
+runs — it takes the "task definition is not available" branch, which is Harbor's
+own fallback. Passing `-d <dataset>@<version>` at upload is what avoids that.
+
+## The label leak
+
+`verifier/test-stdout.txt` is ingested and handed to the analyzer whole, and
+`result.json` carries `verifier_result` and the score. If you are inducing or
+validating a rubric, the analyzer is **not blind** — its length alone is a strong
+predictor of the verdict. Strip the verdict fields and drop `verifier/` for a
+blind run, and do that **after** compression, not before.

--- a/skills/harbor-job-upload/references/limits.md
+++ b/skills/harbor-job-upload/references/limits.md
@@ -1,0 +1,101 @@
+# Every cap on the job-upload path
+
+## Read them live, do not trust this page
+
+The caps move. The dataset door's source default is 512 MiB and production
+serves **8 GiB** — raised by an environment variable with no client change. Any
+document that hardcodes these numbers will eventually lie.
+
+```bash
+curl -s -H "Authorization: Bearer $EVOLVE_API_KEY" \
+  https://dashboard.evolvingmachines.ai/api/meta | jq .limits.uploads
+```
+
+`check_job.py` does this for you and says which source it used; `--offline`
+falls back to frozen defaults and labels them as such.
+
+## Published caps (`limits.uploads`)
+
+Values observed 2026-09-02. Treat as a snapshot.
+
+| Field | Value | Refusal |
+|---|---|---|
+| `job_archive_bytes` | 512 MiB | `413 upload_too_large` |
+| `job_trials` | 2000 | `400 job_too_large` |
+| `job_trial_file_bytes` | 32 MiB | `422 invalid_trial` |
+| `job_trial_session_bytes` | 128 MiB | `422 invalid_trial` |
+| `dataset_archive_bytes` | 8 GiB | `413 import_too_large` |
+
+## Unpublished server caps
+
+Not in `/api/meta`; found by reading the ingest.
+
+| Cap | Value | Refusal | Raisable |
+|---|---|---|---|
+| Decompressed footprint | 2 GiB | `413 upload_too_large` | No — hardcoded |
+| Tar entries | 200,000 | `400 invalid_archive` | No |
+| Record file (`result.json`/`config.json`) | 8 MiB | `400 not_a_job_dir` | No |
+
+**The 2 GiB decompressed cap is the real ceiling.** At the ~1.8x ratio JSON
+corpora compress at, a 512 MiB archive expands to roughly 920 MB — comfortably
+under. But raising the compressed cap past about **1.1 GiB** buys nothing,
+because the decompressed cap bites first. The two have to move together.
+
+## Analyzer ceilings — truncate, never refuse
+
+| Cap | Value | Behaviour |
+|---|---|---|
+| Per input file | 24 MiB | head-truncated with an in-band marker |
+| Whole input tree | 96 MiB | typed inputs failure |
+
+**This is the gap that catches people.** The per-file upload cap (32 MiB) sits
+*above* the analyzer's ceiling (24 MiB) deliberately, so nothing accepted is
+outright unusable — but a trajectory in between is stored whole and then cut at
+analysis time. Compress to 24 MiB, not 32.
+
+## Raising the job archive cap
+
+Ranked by cost:
+
+1. **Set `EVAL_MAX_JOB_UPLOAD_BYTES` on the web task.** An environment variable,
+   no code deploy. This is exactly what was already done for the dataset door,
+   which is why it serves 8 GiB against the same 512 MiB source default — so the
+   mechanism is proven in production, not theoretical. Ceiling: ~1.1 GiB before
+   the decompressed cap.
+2. **Move `MAX_EXTRACTED_BYTES` (2 GiB) with it** for anything beyond that. A
+   code change, and it needs care: ingest runs **synchronously inside one
+   request** on a small web task under a 900 s load-balancer idle timeout. The
+   trial-count cap exists for the same reason. Raising the byte caps without
+   addressing that trades a clean 413 for a timeout partway through ingest.
+3. **Just chunk the job.** Several jobs of N trials each upload fine and analyze
+   independently. This needs nothing from the platform and is usually the right
+   answer.
+
+## Client-side: not the bottleneck
+
+Worth knowing, because it used to be and the folklore persists.
+
+The SDK **streams**. The archive is tarred and gzipped to a temp file, then sent
+over raw `node:http` with per-chunk backpressure — a few MB resident regardless
+of archive size. The older collect-everything-into-one-Buffer path is gone; it
+is what the streaming rewrite was written to fix. If you read a note anywhere
+saying job uploads are buffered in memory as one request body, it is stale.
+
+Two client-side details that still matter:
+
+- **A 600 s inactivity timeout**, re-armed on every flushed chunk. It measures
+  stalls, not total duration.
+- **Job upload is one POST.** The resumable chunked door exists in the SDK but
+  only the dataset publish surface passes the threshold that switches to it, so
+  a job upload that drops at 90% restarts from zero. Wiring it into job upload
+  would not raise any cap; it would remove that failure mode.
+
+## Reading a refusal
+
+Ingest decides in this order, so the first thing that is wrong is what you hear
+about: `invalid_archive` → `upload_too_large` (decompressed) → `not_a_job_dir` →
+`job_already_uploaded` → dataset resolution → `job_too_large` →
+`invalid_trial`.
+
+A `413` on `Content-Length` arrives before any bytes are read, so a too-large
+archive fails fast rather than after a long transfer.

--- a/skills/harbor-job-upload/scripts/check_job.py
+++ b/skills/harbor-job-upload/scripts/check_job.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check a job directory against every cap `evolve upload` will apply.
+
+Answers the question the CLI cannot answer until after a long transfer: will
+this be accepted, and once accepted will the analyzer actually read it?
+
+The archive size is MEASURED, not estimated — the directory is tarred and
+gzipped to a temp file exactly as the SDK does, so the number reported is the
+number the server will see. Compression ratio varies from ~1.0x on blobs to
+~1.8x on JSON, so an estimate is not good enough to trust near a cap.
+
+Beyond the caps it looks for the three failures that produce a SUCCESSFUL
+upload carrying an unreadable trial:
+
+  * a symlink              -> skipped by the packer, never followed
+  * agent/trajectory.json.gz -> maps to no ingest slot; empty trace
+  * a trajectory over the analyzer ceiling -> stored whole, then head-truncated
+                                              at analysis time
+
+Exit codes: 0 clean, 1 violations found, 2 not a job directory.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import pathlib
+import sys
+import tarfile
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import jobspec  # noqa: E402
+
+
+def measure_archive(job: pathlib.Path) -> tuple[int, int, int]:
+    """(compressed, decompressed, entries), by actually packing it."""
+    with tempfile.TemporaryDirectory(prefix="harbor-job-check-") as tmp:
+        path = pathlib.Path(tmp) / "job.tar.gz"
+        entries = raw = 0
+        with tarfile.open(path, "w:gz") as tar:
+            for cur, dirs, files in os.walk(job):
+                dirs[:] = [d for d in dirs if d not in (".git", ".venv")]
+                for f in sorted(files):
+                    if f == ".DS_Store":
+                        continue
+                    p = pathlib.Path(cur) / f
+                    if p.is_symlink() or not p.is_file():
+                        continue
+                    tar.add(p, arcname=str(p.relative_to(job)))
+                    entries += 1
+                    raw += p.stat().st_size
+        return path.stat().st_size, raw, entries
+
+
+def check(job: pathlib.Path, caps: dict, live: bool, target: int) -> list[dict]:
+    findings: list[dict] = []
+
+    def bad(level, what, detail):
+        findings.append({"level": level, "what": what, "detail": detail})
+
+    for rel in jobspec.RECORD_FILES:
+        if not (job / rel).is_file():
+            bad("error", "not_a_job_dir",
+                f"{job}/{rel} is missing — the client refuses before packing")
+
+    trials = sorted(d for d in job.iterdir() if d.is_dir())
+    if len(trials) > caps["job_trials"]:
+        bad("error", "job_too_large",
+            f"{len(trials)} trials, cap is {caps['job_trials']}")
+
+    for t in trials:
+        for cur, _dirs, files in os.walk(t):
+            for f in files:
+                p = pathlib.Path(cur) / f
+                rel = p.relative_to(job)
+                if p.is_symlink():
+                    bad("error", "symlink",
+                        f"{rel} is a symlink — the packer skips it silently")
+                    continue
+                if not p.is_file():
+                    continue
+                size = p.stat().st_size
+                trial_rel = str(p.relative_to(t))
+                if trial_rel in jobspec.RECORD_FILES and size > jobspec.MAX_RECORD_FILE_BYTES:
+                    bad("error", "not_a_job_dir",
+                        f"{rel} is {jobspec.human(size)}, record cap is 8.0 MiB")
+                elif size > caps["job_trial_file_bytes"]:
+                    bad("error", "invalid_trial",
+                        f"{rel} is {jobspec.human(size)}, per-file cap is "
+                        f"{jobspec.human(caps['job_trial_file_bytes'])}")
+                elif size > target:
+                    bad("warn", "analyzer_truncation",
+                        f"{rel} is {jobspec.human(size)}, over the "
+                        f"{jobspec.human(target)} analyzer ceiling — it uploads "
+                        f"clean and is then head-truncated at analysis time")
+
+        if (t / "agent" / "trajectory.json.gz").exists():
+            bad("error", "empty_trace",
+                f"{t.name}/agent/trajectory.json.gz maps to no ingest slot — "
+                f"the trial will upload with no trace")
+        traj = t / "agent" / "trajectory.json"
+        if not traj.is_file():
+            bad("warn", "no_trajectory", f"{t.name} has no agent/trajectory.json")
+        else:
+            try:
+                json.loads(traj.read_text(errors="replace"))
+            except json.JSONDecodeError as e:
+                bad("error", "invalid_trajectory",
+                    f"{t.name}/agent/trajectory.json is not valid JSON ({e.msg}) — "
+                    f"an unrepaired [REDACTED] token does this")
+
+        sess = t / "agent" / "sessions"
+        if sess.is_dir():
+            total = sum(p.stat().st_size for p in sess.rglob("*") if p.is_file())
+            if total > caps["job_trial_session_bytes"]:
+                bad("error", "invalid_trial",
+                    f"{t.name} session tree is {jobspec.human(total)}, cap is "
+                    f"{jobspec.human(caps['job_trial_session_bytes'])}")
+
+    compressed, raw, entries = measure_archive(job)
+    if compressed > caps["job_archive_bytes"]:
+        bad("error", "upload_too_large",
+            f"archive is {jobspec.human(compressed)}, cap is "
+            f"{jobspec.human(caps['job_archive_bytes'])}")
+    if raw > jobspec.MAX_DECOMPRESSED_BYTES:
+        bad("error", "upload_too_large",
+            f"decompressed footprint is {jobspec.human(raw)}, cap is "
+            f"{jobspec.human(jobspec.MAX_DECOMPRESSED_BYTES)}")
+    if entries > jobspec.MAX_ARCHIVE_ENTRIES:
+        bad("error", "invalid_archive",
+            f"{entries:,} entries, cap is {jobspec.MAX_ARCHIVE_ENTRIES:,}")
+
+    ratio = raw / compressed if compressed else 0
+    print(f"{job.name}")
+    print(f"  trials       {len(trials)} / {caps['job_trials']}")
+    print(f"  archive      {jobspec.human(compressed)} / "
+          f"{jobspec.human(caps['job_archive_bytes'])}   (measured, {ratio:.2f}x)")
+    print(f"  decompressed {jobspec.human(raw)} / "
+          f"{jobspec.human(jobspec.MAX_DECOMPRESSED_BYTES)}")
+    print(f"  entries      {entries:,} / {jobspec.MAX_ARCHIVE_ENTRIES:,}")
+    print(f"  caps from    {'GET /api/meta (live)' if live else 'frozen defaults — server unreachable'}")
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("job", nargs="+", help="job directory")
+    ap.add_argument("--target-bytes", type=int, default=jobspec.ANALYZER_FILE_BYTES,
+                    help="the analyzer ceiling to warn against (default 24 MiB)")
+    ap.add_argument("--offline", action="store_true",
+                    help="do not query /api/meta; use the frozen defaults")
+    ap.add_argument("--json", action="store_true", help="machine-readable findings")
+    args = ap.parse_args()
+
+    caps, live = jobspec.resolve_caps(offline=args.offline)
+    all_findings = {}
+    rc = 0
+    for j in args.job:
+        job = pathlib.Path(j)
+        if not job.is_dir():
+            print(f"{j}: not a directory", file=sys.stderr)
+            return 2
+        findings = check(job, caps, live, args.target_bytes)
+        all_findings[str(job)] = findings
+        errors = [f for f in findings if f["level"] == "error"]
+        warns = [f for f in findings if f["level"] == "warn"]
+        for f in errors + warns:
+            print(f"  {f['level'].upper():5s} {f['what']}: {f['detail']}")
+        if not findings:
+            print("  OK — every cap satisfied")
+        if errors:
+            rc = 1
+        print()
+
+    if args.json:
+        print(json.dumps(all_findings, indent=1))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/harbor-job-upload/scripts/compress_job.py
+++ b/skills/harbor-job-upload/scripts/compress_job.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Build an uploadable Harbor job directory from a set of trial directories.
+
+Keeps exactly what the platform ingests, drops what it never reads, and
+shrinks `agent/trajectory.json` to fit the ANALYZER's budget rather than the
+upload cap — a file between the two is accepted and then silently truncated
+at analysis time, which looks like a successful upload and reads like a
+mangled trace.
+
+Three failure modes this exists to prevent, each of which is silent:
+
+  * a symlinked file            -> the packer skips symlinks without following
+                                   them, so the trial ships without its trace.
+                                   Everything here is hard-linked or written.
+  * agent/trajectory.json.gz    -> maps to no ingest slot, so the trial lands
+                                   with an empty trace. Decompressed on the way in.
+  * a [REDACTED] token in JSON  -> not valid JSON; a broad except drops the
+                                   trial. Repaired on read.
+
+Usage:
+  compress_job.py --out JOB_DIR --trial DIR [--trial DIR ...]
+  compress_job.py --out JOB_DIR --from-list paths.txt --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import pathlib
+import shutil
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import jobspec  # noqa: E402
+import trajectory as traj_mod  # noqa: E402
+
+LOG_CLIP_MARKER = "\n... [{n:,} characters clipped to fit the upload budget] ...\n"
+
+
+def read_json(path: pathlib.Path):
+    """Repairing read. Returns None when the file is absent or unparseable."""
+    if not path.is_file():
+        return None
+    try:
+        return traj_mod.loads(path.read_text(errors="replace"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def source_of(trial: pathlib.Path, rel: str) -> pathlib.Path | None:
+    """The real file for an ingest slot, accepting a .gz twin.
+
+    Symlinks are resolved here rather than linked through: the packer skips a
+    symlink silently, so one that survives into the job dir is a file that
+    quietly does not upload.
+    """
+    for cand in (trial / rel, trial / (rel + ".gz")):
+        real = cand.resolve() if cand.is_symlink() else cand
+        if real.is_file():
+            return real
+    return None
+
+
+def read_bytes(path: pathlib.Path) -> bytes:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rb") as fh:
+            return fh.read()
+    return path.read_bytes()
+
+
+def uncompressed_size(path: pathlib.Path) -> int:
+    """Size of a file's content — for a .gz, what it expands to.
+
+    gzip records ISIZE (mod 2^32) in its last four bytes; every file here is
+    far under 4 GiB, so the trailer is exact and costs one seek instead of a
+    full decompression.
+    """
+    if path.suffix != ".gz":
+        return path.stat().st_size
+    try:
+        with path.open("rb") as fh:
+            fh.seek(-4, os.SEEK_END)
+            return int.from_bytes(fh.read(4), "little")
+    except OSError:
+        return path.stat().st_size
+
+
+def place(src: pathlib.Path, dst: pathlib.Path) -> None:
+    """Hard-link when possible (free on one volume), copy across devices."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def clip_text(data: bytes, budget: int) -> tuple[bytes, bool]:
+    if len(data) <= budget:
+        return data, False
+    text = data.decode(errors="replace")
+    head = budget * 2 // 3
+    out = text[:head] + LOG_CLIP_MARKER.format(n=len(text) - budget) + text[-(budget - head):]
+    return out.encode(), True
+
+
+def trial_name(trial: pathlib.Path, result: dict | None) -> str:
+    if result:
+        if result.get("trial_name"):
+            return str(result["trial_name"])
+        task = str(result.get("task_name") or "").split("/")[-1]
+        if task:
+            return f"{task}__{trial.name[:8]}"
+    return trial.name
+
+
+def build_trial(trial: pathlib.Path, dest: pathlib.Path, args) -> dict:
+    """Materialise one trial into the job dir. Returns its report."""
+    result = read_json(trial / "result.json")
+    rep = {
+        "source": str(trial),
+        "name": dest.name,
+        "kept": [],
+        "dropped": [],
+        "bytes_in": 0,
+        "bytes_out": 0,
+    }
+
+    # Record files. Required by ingest; both are small by contract, and a
+    # record over the record cap is a refusal, so it is reported not clipped.
+    for rel in jobspec.RECORD_FILES:
+        src = source_of(trial, rel)
+        if src is None:
+            rep["dropped"].append({"path": rel, "why": "missing"})
+            continue
+        data = read_bytes(src)
+        rep["bytes_in"] += len(data)
+        if len(data) > jobspec.MAX_RECORD_FILE_BYTES:
+            rep["dropped"].append(
+                {"path": rel, "why": "over the 8 MiB record cap", "bytes": len(data)})
+            continue
+        if src.suffix == ".gz":
+            (dest / rel).parent.mkdir(parents=True, exist_ok=True)
+            (dest / rel).write_bytes(data)
+        else:
+            place(src, dest / rel)
+        rep["bytes_out"] += len(data)
+        rep["kept"].append(rel)
+
+    have_stdout = source_of(trial, "agent/stdout.log") is not None
+
+    for rel in jobspec.TRIAL_ARTIFACT_FILES:
+        src = source_of(trial, rel)
+        if src is None:
+            continue
+        data = read_bytes(src)
+        rep["bytes_in"] += len(data)
+
+        if rel == "agent/trajectory.json":
+            out, treport = traj_mod.compress(data.decode(errors="replace"),
+                                             args.target_bytes)
+            rep["trajectory"] = treport
+        else:
+            out, clipped = clip_text(data, args.target_bytes)
+            if clipped:
+                rep.setdefault("clipped_logs", []).append(rel)
+
+        (dest / rel).parent.mkdir(parents=True, exist_ok=True)
+        if len(out) == len(data) and src.suffix != ".gz" and rel != "agent/trajectory.json":
+            place(src, dest / rel)      # untouched: link it, do not rewrite
+        else:
+            (dest / rel).write_bytes(out)
+        rep["bytes_out"] += len(out)
+        rep["kept"].append(rel)
+
+    # The stdout slot's fallback, used only when agent/stdout.log is absent.
+    if not have_stdout and not args.no_harness_log:
+        agent_dir = trial / "agent"
+        if agent_dir.is_dir():
+            for cand in sorted(agent_dir.glob(f"*{jobspec.HARNESS_LOG_SUFFIX}")):
+                if not cand.is_file():
+                    continue
+                data = read_bytes(cand)
+                rep["bytes_in"] += len(data)
+                out, clipped = clip_text(data, args.target_bytes)
+                (dest / "agent" / cand.name).write_bytes(out)
+                rep["bytes_out"] += len(out)
+                rep["kept"].append(f"agent/{cand.name}")
+                if clipped:
+                    rep.setdefault("clipped_logs", []).append(f"agent/{cand.name}")
+                break
+
+    if args.keep_sessions:
+        sess = trial / "agent" / "sessions"
+        total = 0
+        for cur, _dirs, files in os.walk(sess):
+            for f in files:
+                s = pathlib.Path(cur) / f
+                real = s.resolve() if s.is_symlink() else s
+                if not real.is_file() or real.stat().st_size > jobspec.MAX_TRIAL_FILE_BYTES:
+                    rep["dropped"].append({"path": str(s.relative_to(trial)),
+                                           "why": "over the per-file cap"})
+                    continue
+                total += real.stat().st_size
+                place(real, dest / s.relative_to(trial))
+        if total:
+            rep["session_bytes"] = total
+            rep["bytes_in"] += total
+            rep["bytes_out"] += total
+
+    if args.keep_artifacts:
+        for cur, _dirs, files in os.walk(trial / "artifacts"):
+            for f in files:
+                s = pathlib.Path(cur) / f
+                real = s.resolve() if s.is_symlink() else s
+                if not real.is_file() or real.stat().st_size > jobspec.MAX_TRIAL_FILE_BYTES:
+                    continue
+                place(real, dest / s.relative_to(trial))
+
+    # The honest denominator: everything the trial dir holds, not just the
+    # slots we ship. Without it a report can claim "1% removed" for a trial
+    # whose artifacts/ tree was the actual 90%.
+    #
+    # A .gz member is counted at its DECOMPRESSED size. The comparison has to
+    # be content against content: our output is plain JSON that the uploader
+    # gzips on the way out, so measuring a gzipped input against it makes
+    # decompressing a trajectory look like a 300% regression.
+    rep["source_dir_bytes"] = sum(
+        uncompressed_size(p) for p in trial.rglob("*")
+        if p.is_file() and not p.is_symlink())
+    rep["result"] = result
+    return rep
+
+
+def write_job_meta(job: pathlib.Path, reports: list[dict], args) -> str:
+    """The job-level result.json + config.json the client and server require.
+
+    The id is content-addressed over the trial set: the server dedupes on it,
+    so keying it on a label alone lets a smoke run collide with the real job
+    and lets a re-run create a twin.
+    """
+    names = sorted(r["name"] for r in reports)
+    results = [r.get("result") or {} for r in reports]
+    seed = args.job_id_seed or (args.name + "/" + ",".join(names))
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
+
+    rewards, tasks, agents = [], set(), {}
+    for res in results:
+        rw = ((res.get("verifier_result") or {}).get("rewards") or {}).get("reward")
+        rewards.append(rw)
+        task = str(res.get("task_name") or "").split("/")[-1]
+        if task:
+            tasks.add(task)
+        ag = (res.get("config") or {}).get("agent") or {}
+        if ag.get("name"):
+            agents[(ag["name"], ag.get("model_name"))] = True
+
+    if args.agent or args.model:
+        agents = {(args.agent or "unknown", args.model): True}
+    if not agents:
+        agents = {("unknown", None): True}
+
+    (job / "result.json").write_text(json.dumps({
+        "id": job_id,
+        "n_total_trials": len(reports),
+        "stats": {
+            "n_trials": len(reports),
+            "n_errors": 0,
+            "n_resolved": sum(1 for r in rewards if r and r > 0),
+            "n_unresolved": sum(1 for r in rewards if not r),
+        },
+        "source": args.source,
+        "provenance": {
+            "note": "Assembled by the harbor-job-upload skill",
+            "job_name": args.name,
+            "trials": len(reports),
+        },
+    }, indent=1))
+
+    (job / "config.json").write_text(json.dumps({
+        "job_name": args.name,
+        "jobs_dir": "jobs",
+        "n_attempts": 1,
+        "timeout_multiplier": 1.0,
+        "debug": False,
+        "agents": [{"name": n, "import_path": None, "model_name": m}
+                   for (n, m) in agents],
+        "datasets": [{"name": args.dataset_name, "version": args.dataset_version,
+                      "task_names": sorted(tasks)}],
+        "tasks": [],
+        "metrics": [],
+    }, indent=1))
+    return job_id
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", required=True, help="job directory to create")
+    ap.add_argument("--trial", action="append", default=[],
+                    help="a trial directory; repeatable")
+    ap.add_argument("--from-list", help="file of trial directory paths, one per line")
+    ap.add_argument("--target-bytes", type=int, default=jobspec.ANALYZER_FILE_BYTES,
+                    help="per-file budget (default: the 24 MiB analyzer ceiling, "
+                         "NOT the 32 MiB upload cap)")
+    ap.add_argument("--keep-sessions", action="store_true",
+                    help="keep agent/sessions/ (ingested and served, but the "
+                         "analyzer never reads it)")
+    ap.add_argument("--keep-artifacts", action="store_true",
+                    help="keep artifacts/ (never ingested; for local parity only)")
+    ap.add_argument("--no-harness-log", action="store_true",
+                    help="drop agent/<harness>.txt, the stdout-slot fallback")
+    ap.add_argument("--name", help="job name (default: the --out basename)")
+    ap.add_argument("--job-id-seed", help="override the content-addressed id seed")
+    ap.add_argument("--agent", help="override the agent name in config.json")
+    ap.add_argument("--model", help="override the model name in config.json")
+    ap.add_argument("--source", default="harbor-job-upload")
+    ap.add_argument("--dataset-name", default="terminal-bench")
+    ap.add_argument("--dataset-version", default="4.0.0")
+    ap.add_argument("--report", help="write the JSON report here")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report only; write nothing")
+    args = ap.parse_args()
+
+    trials = [pathlib.Path(t) for t in args.trial]
+    if args.from_list:
+        trials += [pathlib.Path(l.strip())
+                   for l in pathlib.Path(args.from_list).read_text().splitlines()
+                   if l.strip() and not l.startswith("#")]
+    missing = [t for t in trials if not t.is_dir()]
+    if missing:
+        print("not a directory:\n  " + "\n  ".join(map(str, missing)), file=sys.stderr)
+        return 2
+    if not trials:
+        print("no trials given (--trial / --from-list)", file=sys.stderr)
+        return 2
+
+    job = pathlib.Path(args.out)
+    args.name = args.name or job.name
+    stage = job.with_name(job.name + ".building") if not args.dry_run else None
+
+    if args.dry_run:
+        import tempfile
+        tmp = tempfile.mkdtemp(prefix="harbor-job-dry-")
+        stage = pathlib.Path(tmp) / job.name
+
+    if stage.exists():
+        shutil.rmtree(stage)
+    stage.mkdir(parents=True)
+
+    reports = []
+    for t in trials:
+        res = read_json(t / "result.json")
+        name = trial_name(t, res)
+        reports.append(build_trial(t, stage / name, args))
+        reports[-1]["name"] = name
+
+    job_id = write_job_meta(stage, reports, args)
+
+    bytes_in = sum(r["bytes_in"] for r in reports)
+    bytes_out = sum(r["bytes_out"] for r in reports)
+    src_bytes = sum(r["source_dir_bytes"] for r in reports)
+    report = {
+        "job": args.name,
+        "job_id": job_id,
+        "trials": len(reports),
+        "target_bytes": args.target_bytes,
+        "source_dir_bytes": src_bytes,
+        "bytes_in": bytes_in,
+        "bytes_out": bytes_out,
+        "reduction_pct": round(100 * (1 - bytes_out / bytes_in), 1) if bytes_in else 0.0,
+        "reduction_vs_source_dir_pct": (
+            round(100 * (1 - bytes_out / src_bytes), 1) if src_bytes else 0.0),
+        "lossy_trials": [r["name"] for r in reports
+                         if (r.get("trajectory") or {}).get("lossy")],
+        "per_trial": [{k: v for k, v in r.items() if k != "result"} for r in reports],
+    }
+
+    if args.dry_run:
+        shutil.rmtree(stage.parent)
+    else:
+        if job.exists():
+            shutil.rmtree(job)
+        stage.rename(job)
+
+    print(f"{args.name}: {len(reports)} trials  id={job_id}")
+    print(f"  ingested slots  {jobspec.human(bytes_in)} -> {jobspec.human(bytes_out)}"
+          f"  ({report['reduction_pct']}% removed by compression)")
+    print(f"  whole trial dirs {jobspec.human(src_bytes)} -> {jobspec.human(bytes_out)}"
+          f"  ({report['reduction_vs_source_dir_pct']}% removed overall, "
+          f"content-for-content)")
+    if report["lossy_trials"]:
+        print(f"  lossy (observation clipping fired): {len(report['lossy_trials'])} "
+              f"of {len(reports)}")
+    if args.dry_run:
+        print("  dry run — nothing written")
+
+    if args.report:
+        pathlib.Path(args.report).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(args.report).write_text(json.dumps(report, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/harbor-job-upload/scripts/jobspec.py
+++ b/skills/harbor-job-upload/scripts/jobspec.py
@@ -1,0 +1,120 @@
+"""The platform's job-upload contract, in one place.
+
+Every constant here is a published server limit or a documented ingest rule.
+Sources are cited so a reader can re-verify rather than trust this file:
+
+  - Caps are published live at `GET /api/meta` under `limits.uploads`. Read
+    them with `evolve_limits()` rather than trusting the frozen defaults; the
+    defaults exist only so the tools still run offline.
+  - The per-trial ingest whitelist is the server's own `TRIAL_ARTIFACT_FILES`
+    plus the two record files.
+  - The analyzer's input ceiling is NOT an upload cap. A file between the
+    analyzer ceiling and the upload cap is accepted, stored, and then
+    head-truncated at analysis time with only an in-band marker. That is why
+    the compressor targets the analyzer ceiling, not the upload cap.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+MiB = 1024 * 1024
+GiB = 1024 * MiB
+
+# --- Published upload caps (defaults; prefer evolve_limits() at runtime) -----
+MAX_JOB_ARCHIVE_BYTES = 512 * MiB       # limits.uploads.job_archive_bytes
+MAX_JOB_TRIALS = 2000                   # limits.uploads.job_trials
+MAX_TRIAL_FILE_BYTES = 32 * MiB         # limits.uploads.job_trial_file_bytes
+MAX_TRIAL_SESSION_BYTES = 128 * MiB     # limits.uploads.job_trial_session_bytes
+
+# --- Server-side caps that are NOT published, and are not raisable by env ----
+MAX_DECOMPRESSED_BYTES = 2 * GiB        # the real wall behind the 512 MiB one
+MAX_ARCHIVE_ENTRIES = 200_000
+MAX_RECORD_FILE_BYTES = 8 * MiB         # result.json / config.json per trial
+
+# --- The analyzer's own ceilings (truncate silently; never refuse) -----------
+ANALYZER_FILE_BYTES = 24 * MiB
+ANALYZER_TREE_BYTES = 96 * MiB
+
+# --- What ingest stores, per trial ------------------------------------------
+# The server's TRIAL_ARTIFACT_FILES, verbatim.
+TRIAL_ARTIFACT_FILES = (
+    "agent/trajectory.json",
+    "agent/stdout.log",
+    "agent/stderr.log",
+    "verifier/test-stdout.txt",
+    "verifier/reward.txt",
+)
+# Required at the root of a trial dir, and at the root of the job dir. The
+# client refuses before packing if either is missing from the JOB root.
+RECORD_FILES = ("result.json", "config.json")
+
+# Ingested as a tree, under its own cap. Dead weight for rubric analysis (the
+# analyzer never reads it), but it is what the trace viewer serves as the
+# native session home — hence a flag, not an unconditional drop.
+SESSION_PREFIX = "agent/sessions/"
+
+# The stdout slot's fallback: a harness CLI log directly under agent/, used
+# only when agent/stdout.log is absent. Hub archives carry these.
+HARNESS_LOG_SUFFIX = ".txt"
+
+# Never ingested. Listed so tools can explain a drop rather than just do it.
+NEVER_INGESTED = (
+    "artifacts/**", "steps/**", "lock.json", "trial.log",
+    "analysis.json", "analysis.md", "verifier/reward.json",
+    "verifier/ctrf.json", "evolve.json",
+)
+
+DEFAULT_DASHBOARD_URL = "https://dashboard.evolvingmachines.ai"
+
+
+def evolve_limits(base_url: str | None = None, api_key: str | None = None,
+                  timeout: float = 20.0) -> dict | None:
+    """Live `limits.uploads` from GET /api/meta, or None if unreachable.
+
+    The caps move — the dataset door was raised 16x above its source default
+    without any client change — so a tool that hardcodes them will eventually
+    lie. Falling back to the frozen defaults is fine; silently reporting a
+    stale cap as if it were live is not, so the caller is told which it got.
+    """
+    base = (base_url or os.environ.get("EVOLVE_DASHBOARD_URL")
+            or DEFAULT_DASHBOARD_URL).rstrip("/")
+    key = api_key or os.environ.get("EVOLVE_API_KEY")
+    req = urllib.request.Request(f"{base}/api/meta")
+    if key:
+        req.add_header("Authorization", f"Bearer {key}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return (json.load(r).get("limits") or {}).get("uploads")
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def resolve_caps(base_url: str | None = None, api_key: str | None = None,
+                 offline: bool = False) -> tuple[dict, bool]:
+    """(caps, live) — published caps, preferring the server's own numbers."""
+    caps = {
+        "job_archive_bytes": MAX_JOB_ARCHIVE_BYTES,
+        "job_trials": MAX_JOB_TRIALS,
+        "job_trial_file_bytes": MAX_TRIAL_FILE_BYTES,
+        "job_trial_session_bytes": MAX_TRIAL_SESSION_BYTES,
+    }
+    if offline:
+        return caps, False
+    live = evolve_limits(base_url, api_key)
+    if not live:
+        return caps, False
+    for k in caps:
+        if isinstance(live.get(k), int):
+            caps[k] = live[k]
+    return caps, True
+
+
+def human(n: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if abs(n) < 1024 or unit == "GiB":
+            return f"{n:.1f} {unit}" if unit != "B" else f"{int(n)} B"
+        n /= 1024
+    return f"{n:.1f} GiB"

--- a/skills/harbor-job-upload/scripts/trajectory.py
+++ b/skills/harbor-job-upload/scripts/trajectory.py
@@ -1,0 +1,179 @@
+"""Read, repair, and shrink an ATIF trajectory without lying about the trace.
+
+Four transforms, applied in increasing order of cost to the reader:
+
+  1. repair    - the hub sanitises some numeric fields to a bare [REDACTED]
+                 token, which is not valid JSON. A plain json.load raises and,
+                 in every pipeline that catches broadly, silently drops the
+                 trial. Repair first, always.
+  2. dedup     - `observation.results[].extra` re-states the observation's own
+                 `content` (often twice), and `tool_calls[].extra.raw_arguments`
+                 re-states `arguments`. Removing a string that is provably
+                 recoverable from a sibling field costs the reader nothing.
+  3. base64    - inline image payloads. Bytes, not reasoning.
+  4. clip      - the only lossy step: per-observation head+tail truncation,
+                 walked down a ladder until the file fits. Never touches a
+                 step's `message` (the agent's reasoning) and never drops a
+                 step, so the action sequence stays intact end to end.
+
+Steps 1-3 are lossless for anything that reads the trace, so they run
+unconditionally. Step 4 runs only if the file is still over budget.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterator
+
+# Ladder and tail protection are inherited from the corpus normaliser, so a
+# clipped upload and a locally rendered trace agree on what got elided.
+BUDGET_LADDER = (20_000, 8_000, 4_000, 2_000, 1_000, 400)
+TAIL_PROTECT_OBS = 8
+TAIL_BUDGET_MULTIPLIER = 4
+
+BASE64_KEYS = ("base64", "data")
+BASE64_MIN_CHARS = 100_000
+# Below this, a duplicated string is not worth a marker that says so.
+DUP_MIN_CHARS = 200
+
+_REDACTED = re.compile(r":\s*\[REDACTED\]")
+
+
+def loads(text: str) -> Any:
+    """json.loads with the [REDACTED] repair. Raises if it is still not JSON."""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return json.loads(_REDACTED.sub(": null", text))
+
+
+def observations(traj: Any) -> Iterator[dict]:
+    """Each observation result dict, in trace order."""
+    for step in traj.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        for r in (step.get("observation") or {}).get("results") or []:
+            if isinstance(r, dict):
+                yield r
+
+
+def strip_duplicate_extra(traj: Any) -> dict:
+    """Remove restatements of a sibling field. Provably lossless.
+
+    A string under `extra` is removed only when it is a SUBSTRING of the
+    content it sits beside — that is the proof it carries nothing new. A
+    payload that merely looks redundant is left alone, so an unfamiliar
+    harness cannot lose data here.
+    """
+    n_obs = n_args = 0
+    freed = 0
+
+    def prune(node: Any, content: str) -> Any:
+        nonlocal n_obs, freed
+        if isinstance(node, dict):
+            return {k: prune(v, content) for k, v in node.items()}
+        if isinstance(node, list):
+            return [prune(v, content) for v in node]
+        if isinstance(node, str) and len(node) >= DUP_MIN_CHARS and node in content:
+            n_obs += 1
+            freed += len(node)
+            return f"[{len(node):,} chars identical to observation content, removed for upload]"
+        return node
+
+    for step in traj.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        for tc in step.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            extra = tc.get("extra")
+            if (isinstance(extra, dict) and "raw_arguments" in extra
+                    and extra["raw_arguments"] == tc.get("arguments")):
+                freed += len(json.dumps(extra.pop("raw_arguments")))
+                n_args += 1
+
+    for r in observations(traj):
+        content, extra = r.get("content"), r.get("extra")
+        if isinstance(content, str) and content and extra is not None:
+            r["extra"] = prune(extra, content)
+
+    return {"observation_strings": n_obs, "raw_arguments": n_args,
+            "chars_freed": freed}
+
+
+def strip_base64(traj: Any) -> dict:
+    """Replace inline base64 payloads with a byte count."""
+    n = 0
+    freed = 0
+
+    def walk(o: Any) -> None:
+        nonlocal n, freed
+        if isinstance(o, dict):
+            for k, v in list(o.items()):
+                if k in BASE64_KEYS and isinstance(v, str) and len(v) > BASE64_MIN_CHARS:
+                    o[k] = f"[{len(v):,} bytes of base64 stripped for upload]"
+                    n += 1
+                    freed += len(v)
+                else:
+                    walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+
+    walk(traj)
+    return {"fields": n, "chars_freed": freed}
+
+
+def _clip(text: str, budget: int, marker: str) -> str:
+    if len(text) <= budget:
+        return text
+    head = budget * 2 // 3
+    return text[:head] + marker.format(n=len(text) - budget) + text[-(budget - head):]
+
+
+def clip_observations(traj: Any, target_bytes: int) -> int | None:
+    """Walk the ladder until the encoded trajectory fits. Returns the rung used.
+
+    Truncation is per observation and always head+tail, so the command that
+    produced an observation and the verdict at its end both survive. The last
+    TAIL_PROTECT_OBS observations get a larger budget because a failure's
+    evidence is concentrated in the final verification and its output.
+    """
+    if len(json.dumps(traj).encode()) <= target_bytes:
+        return None
+    marker = ("\n... [{n:,} characters clipped to fit the "
+              f"{target_bytes // (1024 * 1024)} MiB analysis budget] ...\n")
+    obs = list(observations(traj))
+    originals = [r.get("content") if isinstance(r.get("content"), str) else None
+                 for r in obs]
+    tail_from = max(0, len(obs) - TAIL_PROTECT_OBS)
+    used = None
+    for budget in BUDGET_LADDER:
+        for i, (r, orig) in enumerate(zip(obs, originals)):
+            if orig is None:
+                continue
+            b = budget * TAIL_BUDGET_MULTIPLIER if i >= tail_from else budget
+            r["content"] = _clip(orig, b, marker)
+        used = budget
+        if len(json.dumps(traj).encode()) <= target_bytes:
+            break
+    return used
+
+
+def compress(text: str, target_bytes: int) -> tuple[bytes, dict]:
+    """Full pipeline. Returns (encoded trajectory, report)."""
+    traj = loads(text)
+    report = {"original_bytes": len(text.encode())}
+
+    report["dedup"] = strip_duplicate_extra(traj)
+    report["after_dedup_bytes"] = len(json.dumps(traj).encode())
+
+    report["base64"] = strip_base64(traj)
+    report["after_base64_bytes"] = len(json.dumps(traj).encode())
+
+    report["obs_budget_chars"] = clip_observations(traj, target_bytes)
+
+    out = json.dumps(traj).encode()
+    report["final_bytes"] = len(out)
+    report["lossy"] = report["obs_budget_chars"] is not None
+    return out, report


### PR DESCRIPTION
Porting the Terminal-Bench 4 corpus (3,300 trials) surfaced several ways an `evolve upload` can report success and still leave a trial unreadable. **None of them errors** — the upload returns a job id, the job lists its trials, and the damage only surfaces when an analysis reads a trace that is empty or truncated.

This adds a `harbor-job-upload` skill that prevents each one, plus [`ISSUES.md`](https://github.com/evolving-machines-lab/evolve/blob/feat/harbor-job-upload-skill/skills/harbor-job-upload/ISSUES.md) recording every problem, how it was diagnosed, and what was measured.

## The silent failures

| Symptom | Cause |
|---|---|
| Trial uploads, trace is empty | `agent/trajectory.json.gz` maps to no ingest slot. **12 such files had already shipped** before this was caught |
| Files never arrive, nothing says so | the packer skips symlinks and never follows them, so a tree built by symlinking its large files uploads as a shell |
| A whole trial vanishes | a `[REDACTED]` token where a number belongs is not valid JSON; a broad `except` drops the trial. ~11% of trials carry one |
| Trace mangled part-way through analysis | **the upload cap and the analysis cap are different numbers** — ingest refuses at 32 MiB, the analyzer head-truncates at 24 MiB with only an in-band marker |

That last one is the expensive one: a 30 MiB trajectory uploads clean, stores clean, and is quietly cut when analyzed. The artifact looks healthy right up until the verdict is wrong.

## What's added

- **`scripts/compress_job.py`** — builds a job dir carrying exactly the server's own `TRIAL_ARTIFACT_FILES` plus the two record files, decompressing `.gz` on the way in, targeting the **24 MiB analyzer ceiling** rather than the upload cap.
- **`scripts/check_job.py`** — validates any job dir against every cap before a byte moves. Archive size is **measured** (tar+gzip to a temp file, exactly as the SDK does) because the ratio ranges 1.0x–5.0x and an estimate is worthless near a cap. Caps are read live from `GET /api/meta`, and the output states whether they came from the server or from frozen defaults — the dataset door's source default is 512 MiB and production serves 8 GiB, so any hardcoded number eventually lies.
- **`references/ingest-contract.md`** — the exact keep/drop map, and the distinction that matters: ingest stores a fixed set from your archive; the analyzer never reads your archive at all, it rebuilds a tree from the DB.
- **`references/limits.md`** — every cap, which are published, which are hardcoded, and which can be raised.

## The largest win, and why it must be proven

`observation.results[].extra` restates the observation's own `content`. The previous approach clipped only `results[].content` — so it **shrank the copy a reader needs and left the byte-identical duplicate at full size**.

Deduplication now removes a string only when it is a **substring of the content beside it** — the proof it carries nothing new. Measured on real rows, 5 trials each:

| Row | Harness | Removed |
|---|---|---|
| `09-claude-code__sonnet-5` | claude-code | **48.0%** |
| `09-grok-build__grok-4-5` | grok-build | 2.5% |
| `07-grok-build__grok-4-6` | grok-build | 2.3% |
| `08-codex__gpt-5-6-luna` | codex | 0.9% |

The duplication is harness-shaped. **A codex row that suddenly shrinks a lot means the deduplicator is deleting something real** — that asymmetry is the check, not a disappointment.

Truncation is the last resort and never flat: per-observation head+tail down a ladder, last 8 observations at 4x budget, a step's `message` never touched and no step ever dropped. 703 of 738 failures in this corpus are `agent_declared_done`, so the evidence a rubric needs is concentrated in the final observations.

## Verification

End to end on the bottom four TB4 leaderboard rows — 4 jobs, 20 trials, uploaded for real:

- All 20 landed with **non-empty traces** (68–630 events, scaling consistently with local step counts per harness).
- All four job dirs passed every cap check against live caps.
- **Compression is byte-lossless across all 20** on every step `message`, every tool call, and every observation `content` — while the claude-code row still lost 48%.
- Ladder and tail protection verified at a deliberately harsh 1 MiB budget: settled at the 8,000-char rung, no head observation over budget, all 8 tail observations untouched, final observation ended byte-identically.
- Three analyses completed with substantive trajectory-grounded verdicts (13 rubric checks each, `no_harness_error=pass`), citing detail from deep inside compressed traces.

**Not confirmed:** 7 of 10 analysis runs failed as `phase: stopped — the analyzer box was killed`. This is infrastructure, not input — the failures land in a 6-second window spanning an unrelated job, and across 200 recent platform-wide analyses (118 failed) **not one failure of any kind was an inputs failure**. The compressed trees were never rejected, but a full 5-of-5 analysis pass has not been observed.

## Notes for review

- **A stale belief is corrected in `ISSUES.md`:** the SDK no longer buffers an archive in memory. `hosted/tar.ts` streams to disk and `hosted/upload.ts` posts over raw `node:http` with backpressure. The 512 MiB wall is server-side, not client heap — chunking is still needed, but for the published cap.
- **`CLAUDE.md` rule narrowed.** It said `skills/` and `.claude/skills/` are regenerated on push. `sync-docs-to-skill.yml` copies **only** into `skills/evolve/` and `.claude/skills/evolve/`, so the rule is narrowed to match — otherwise a hand-written skill reads as something CI will overwrite.
- **No SDK or server behaviour changes.** Additive: a skill directory, its mirror, and three lines of `CLAUDE.md`.
- Two follow-ups are deliberately left out and recorded in `ISSUES.md`: raising `EVAL_MAX_JOB_UPLOAD_BYTES` (needs the hardcoded 2 GiB decompressed cap to move with it), and giving `jobs().upload()` the resumable door `datasets().publish()` already has (needs a server door that does not exist for jobs yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
