### PR TITLE
fix: the spec gates go green on a clean tree — SSE fixture double-close, and a skipped Python gate

### DIFF
--- a/packages/sdk-ts/tests/unit/hosted-client.test.ts
+++ b/packages/sdk-ts/tests/unit/hosted-client.test.ts
@@ -157,14 +157,40 @@ function setMockResponse(urlPattern: string, response: MockResponse) {
 
 function buildMockResponse(resp: MockResponse): Response {
   let body: ReadableStream | null = null;
-  const streamSource = resp.streamChunks != null
-    ? resp.streamChunks.map((chunk) => Buffer.from(chunk, "utf-8"))
-    : resp.streamBody != null
-      ? Buffer.from(resp.streamBody, "utf-8")
-      : resp.bodyBytes;
-  if (streamSource != null) {
-    const nodeStream = Readable.from(streamSource);
-    body = Readable.toWeb(nodeStream) as ReadableStream;
+  const chunks: Buffer[] | null =
+    resp.streamChunks != null
+      ? resp.streamChunks.map((chunk) => Buffer.from(chunk, "utf-8"))
+      : resp.streamBody != null
+        ? [Buffer.from(resp.streamBody, "utf-8")]
+        : resp.bodyBytes != null
+          ? [resp.bodyBytes]
+          : null;
+  if (chunks != null) {
+    // A NATIVE web stream, deliberately not Readable.toWeb(): a real fetch()
+    // body is an undici ReadableStream, and only that shape survives the
+    // cancel() every consumer here performs. Readable.toWeb wraps the Node
+    // stream in an adapter that calls controller.close() again when the
+    // wrapped Readable emits 'close' after an explicit reader.cancel() —
+    // watch() cancels in its finally the instant a terminal event arrives,
+    // mid-stream, which is exactly that case. The second close throws
+    // ERR_INVALID_STATE from an emitCloseNT tick, so it is uncaught: the
+    // process dies with zero failed assertions, one or two tests PAST the one
+    // that built the stream, and the suite exits 1 with nothing to point at.
+    // Node fixed the adapter in 20.20.x; on 20.15.1 and 18.x it still bites,
+    // which is why CI (setup-node '20' -> latest 20.x) never saw this.
+    let next = 0;
+    body = new ReadableStream<Uint8Array>({
+      // One chunk per read(), so streamChunks keeps testing what it was
+      // written to test: a CRLF pair split across two chunks must reach the
+      // SSE parser as two separate pushes, not one merged buffer.
+      pull(controller) {
+        if (next < chunks.length) {
+          controller.enqueue(new Uint8Array(chunks[next++]));
+        } else {
+          controller.close();
+        }
+      },
+    }) as ReadableStream;
   }
   return {
     ok: resp.status >= 200 && resp.status < 300,
@@ -216,7 +242,6 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { Readable } from "node:stream";
 import { createHash } from "node:crypto";
 import { gunzipSync, gzipSync } from "node:zlib";
 

--- a/scripts/run-spec-gates.sh
+++ b/scripts/run-spec-gates.sh
@@ -47,8 +47,25 @@ npx tsx tests/unit/cli.test.ts
 npx tsx tests/unit/cli-bin.test.ts
 
 cd "${REPO_ROOT}/packages/sdk-py"
+# All three Python gates skip at MODULE level when no spec is present, so
+# pytest collects nothing and exits 5 ("no tests collected") — which turns the
+# documented public-checkout path (see the header: every test prints SKIP and
+# passes) into a red gate on a clean tree, and a gate that is red on a clean
+# tree teaches people to ignore it. CI never sees this: every workflow that
+# runs this script runs it with EVOLVE_OPENAPI_SPEC_PATH set, so the gates
+# always collect there. Tolerate 5 on the no-spec path and nowhere else —
+# with a spec present, 5 means the gates stopped gating and still fails, and
+# a renamed or deleted file is pytest's exit 4 either way, so no gate can go
+# missing unnoticed.
+py_status=0
 python -m pytest \
     tests/unit/test_hosted_spec_gate.py \
     tests/unit/test_hosted_stats_typing.py \
     tests/unit/test_hosted_retry_typing.py \
-    -v
+    -v || py_status=$?
+
+if [ "${py_status}" -eq 5 ] && [ -z "${EVOLVE_OPENAPI_SPEC_PATH:-}" ]; then
+    echo "[spec-gates] python: no contract present, so every gate skipped and pytest collected nothing — passing"
+elif [ "${py_status}" -ne 0 ]; then
+    exit "${py_status}"
+fi


### PR DESCRIPTION
## What was broken

`packages/sdk-ts/tests/unit/hosted-client.test.ts` killed the Node process — no
failing assertion, just `ERR_INVALID_STATE: Controller is already closed` from a
`process.nextTick` — so the suite exited 1 with nothing to point at. Because
`scripts/run-spec-gates.sh` runs that file, the spec gates were red on a clean
tree, which is the state that teaches people to ignore a red gate.

Pre-existing, not a regression: it reproduces on untouched `project-sable`.

## Root cause

Two independent defects, both of which only show up outside CI.

**1. The SSE fixture built its `Response.body` with `Readable.toWeb()`.**

`Readable.toWeb`'s adapter closes the web stream's controller from an
end-of-stream callback when the wrapped Node `Readable` emits `'close'`. An
explicit `reader.cancel()` has *already* closed that controller, so the
adapter's close is a second close, and `ReadableStreamDefaultController.close()`
throws for it. The throw happens inside `emitCloseNT`, so nothing can catch it.

`jobs().watch()` cancels in its `finally` the instant a terminal event arrives —
mid-stream, before `done` — which is exactly that case. Reduced:

```js
const web = Readable.toWeb(Readable.from([chunkA, chunkB, chunkC]));
const reader = web.getReader();
await reader.read();
await reader.read();      // more chunks remain, so we never see done
await reader.cancel();    // -> uncaught ERR_INVALID_STATE, one tick later
```

The stream that crashed belonged to `watch() parses CR and CRLF line
terminators` (four `streamChunks`), but the throw surfaced a tick later, after
the *next* test had already printed its header. That is why the failure looked
like it lived in `watch() is usable as an async iterator`.

The fixture now builds a native `ReadableStream` directly — which is what
`fetch()` actually hands back — so there is no Node stream to double-close. It
still yields one chunk per `read()`, so `streamChunks` keeps testing chunk
boundaries (a CRLF pair split across two chunks must arrive as two pushes).

`Readable.toWeb` appears nowhere in `src/` — this was only ever a test-fixture
defect, and `watch()`'s `cancel()` is correct as written.

**2. `run-spec-gates.sh` treated a fully-skipped Python gate as a failure.**

With the second defect fixed, the script still exited 5. All three Python gates
skip at module level when no spec is present, so pytest collects nothing and
exits 5 — contradicting this script's own header, which documents that a public
checkout without the contract should SKIP and pass. Exit 5 is now tolerated on
that path and nowhere else: with `EVOLVE_OPENAPI_SPEC_PATH` set, 5 still fails
(the gates stopped gating), and a renamed or deleted file is pytest's exit 4
either way, so no gate can go missing unnoticed.

## Why CI never caught either

Not a Node 22-vs-20 gap — `tests.yml` and `spec-gate.yml` both pin
`node-version: '20'`. But `setup-node` resolves that to the *latest* 20.x, and
Node fixed the `toWeb` adapter during the 20.x line:

| Node | reduced repro |
|---|---|
| v18.20.8 | crashes |
| v20.15.1 | crashes |
| v20.20.2 (what `'20'` resolves to today) | clean |
| v22.14.0 | clean |

So CI ran a patched Node while a developer pinned to 20.15.1 did not. The second
defect is the same shape: every workflow that runs the gate script sets
`EVOLVE_OPENAPI_SPEC_PATH`, so CI never walks the no-spec path.

## Verification

On Node **v20.15.1**, the version that reproduced the crash:

- `npx tsx tests/unit/hosted-client.test.ts` → exit **0**, 874 passed / 0 failed
  (same assertion count the file already produced on a patched Node, so nothing
  was lost).
- `./scripts/run-spec-gates.sh` → exit **0**.
- `npm run test:ts:unit` → exit **0**. `npm run type-check` → exit **0**.
- Guard check: `EVOLVE_OPENAPI_SPEC_PATH=/nonexistent ./scripts/run-spec-gates.sh`
  still exits 5, so the tolerance cannot hide a gate that stopped collecting.
- Gates also re-run green on v20.20.2 and v22.14.0.

## Not fixed here (flagged, out of scope)

`sessions-client.test.ts:72` and `cli.test.ts:90` carry the same copy-pasted
`Readable.toWeb` fixture. Both exit 0 today because nothing in them cancels
mid-stream — latent, not broken. `packages/e2b/src/index.ts` and
`packages/modal/src/index.ts` use `Readable.toWeb` for real upload bodies, where
undici cancelling a failed upload could hit the same adapter bug on Node < 20.20;
that wants its own change and its own testing.
